### PR TITLE
fix(twitch): Fix darkTheme json

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -10,7 +10,7 @@
 @license        MIT
 
 @var select lightTheme "Light Variant" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha"]
-@var select darkTheme "Dark Variant" ["latte:Latte", frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkTheme "Dark Variant" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha"]
 @var select accentColor  "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red*", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 @-moz-document domain("twitch.tv") {


### PR DESCRIPTION
It gave the error "Invalid JSON: frappe is not a valid JSON literal" because of a missing quotation mark.