### PR TITLE
fix(paste.rs): change image extension from .webp to .png

### DIFF
--- a/styles/paste.rs/README.md
+++ b/styles/paste.rs/README.md
@@ -21,26 +21,23 @@
 
 <details>
 <summary>🌻 Latte</summary>
-<img src="assets/latte.webp"/>
+<img src="assets/latte.png"/>
 </details>
 <details>
 <summary>🪴 Frappé</summary>
-<img src="assets/frappe.webp"/>
+<img src="assets/frappe.png"/>
 </details>
 <details>
 <summary>🌺 Macchiato</summary>
-<img src="assets/macchiato.webp"/>
+<img src="assets/macchiato.png"/>
 </details>
 <details>
 <summary>🌿 Mocha</summary>
-<img src="assets/mocha.webp"/>
+<img src="assets/mocha.png"/>
 </details>
 
-
-
-
-
 ## 💝 Current Maintainer(s)
+
 - [Stonks3141](https://github.com/Stonks3141)
 
 &nbsp;


### PR DESCRIPTION
The 4 flavor image were not shown, so I changed image extension from .webp to .png so that it matches images extension in the assets folder

<details><summary>Before:</summary>
<img src="https://github.com/catppuccin/userstyles/assets/64875290/91d4be9f-4888-47b6-a5cc-b882d77251db"/>
</details>

After:
<details><summary>Latte</summary>
<img src="https://github.com/catppuccin/userstyles/assets/64875290/518386be-55ba-4b00-8ba0-ef95cc611f16"/>
</details>
<details><summary>frappe</summary>
<img src="https://github.com/catppuccin/userstyles/assets/64875290/4af88e21-c102-4ab0-be8d-e04112282c09"/>
</details>
<details><summary>macchiato</summary>
<img src="https://github.com/catppuccin/userstyles/assets/64875290/2cef9ad0-982e-4438-8a13-85cc7c9e84e5"/>
</details>
<details><summary>mocha</summary>
<img src="https://github.com/catppuccin/userstyles/assets/64875290/cd324c90-25a6-44be-a032-a252a44eb535"/
>

</details>