### PR TITLE
ci: add crate-ci/typos

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,16 @@
+name: Typos
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  run:
+    name: Spell Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v3
+
+    - uses: crate-ci/typos@master

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -14,3 +14,8 @@ jobs:
       uses: actions/checkout@v3
 
     - uses: crate-ci/typos@master
+
+    # We don't want this check to fail on `main` but continue to fail on PRs
+    - name: Successfully Exit When Branch 'main'
+      if: ${{ github.repository == 'catppuccin/userstyles' && github.ref == 'refs/heads/main' }}
+      run: "exit 0"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,12 @@
+[default]
+locale = "en-us"
+
+# maintainer names
+[default.extend-words]
+Ren = "Ren"
+
+[type.css]
+extend-ignore-re = [
+  # generated classnames from css modules
+  '_[\w\d]+',
+]


### PR DESCRIPTION
This is mainly to enforce `en_US` spelling in this repository, and might also be useful to catch some syntax/className errors (e.g. the YouTube port with the current failure)