### PR TITLE
fix(proton): email item text color on hover

### DIFF
--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -257,7 +257,7 @@
     .item-container:not(.item-is-selected):hover {
       box-shadow: none;
       background-color: var(--navigation-current-item-background-color);
-      color: var(--email-item-selected-text-color);
+      color: var(--email-item-unread-text-color);
     }
   }
 }


### PR DESCRIPTION
Before:
![Screenshot from 2023-07-25 05-52-01](https://github.com/catppuccin/userstyles/assets/18283756/ed3dea19-d079-4b31-b476-6438e512bb40)
After:
![Screenshot from 2023-07-25 05-52-43](https://github.com/catppuccin/userstyles/assets/18283756/b439f054-65a1-47c7-8fa3-44c1c1d082e4)
