### PR TITLE
feat(proton): accent-colored logos

### DIFF
--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -162,6 +162,55 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-Color: @catppuccin[@@lookup][@@accent];
 
+    svg.logo {
+      @accentH: hue(@accent-Color);
+      @protonH: hue(#6d4aff);
+
+      .replaceColor(@org, @property) {
+        &[@{property}="@{org}"] {
+          @hDiff: @protonH - hue(@org);
+          @{property}: hsl(
+            @accentH - @hDiff,
+            saturation(@org) - 30%,
+            lightness(@org)
+          );
+        }
+      }
+
+      > path {
+        .replaceColor(#B8D7FF, fill);
+        .replaceColor(#8f69ff, fill);
+      }
+
+      > defs stop {
+        .replaceColor(#E3D9FF, stop-color);
+        .replaceColor(#7341ff, stop-color);
+        .replaceColor(#6d4aff, stop-color);
+        .replaceColor(#AA8EFF, stop-color);
+        .replaceColor(#06b8ff, stop-color);
+        .replaceColor(#BFE8FF, stop-color);
+        .replaceColor(#BFABFF, stop-color);
+        .replaceColor(#FF50C3, stop-color);
+        .replaceColor(#B487FF, stop-color);
+        .replaceColor(#FFC8FF, stop-color);
+        .replaceColor(#8effee, stop-color);
+        .replaceColor(#C9C7FF, stop-color);
+        .replaceColor(#00f0c3, stop-color);
+        .replaceColor(#FFD580, stop-color);
+        .replaceColor(#F6C592, stop-color);
+        .replaceColor(#EBB6A2, stop-color);
+        .replaceColor(#DFA5AF, stop-color);
+        .replaceColor(#D397BE, stop-color);
+        .replaceColor(#C486CB, stop-color);
+        .replaceColor(#B578D9, stop-color);
+        .replaceColor(#A166E5, stop-color);
+        .replaceColor(#8b57f2, stop-color);
+        .replaceColor(#704cff, stop-color);
+        .replaceColor(#B39FFB, stop-color);
+        .replaceColor(#FFE8DB, stop-color);
+      }
+    }
+
     &,
     .ui-prominent,
     .ui-standard {

--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -177,25 +177,27 @@
         }
       }
 
+      /* prettier-ignore */
       > path {
         .replaceColor(#B8D7FF, fill);
-        .replaceColor(#8f69ff, fill);
+        .replaceColor(#8F69FF, fill);
       }
 
+      /* prettier-ignore */
       > defs stop {
         .replaceColor(#E3D9FF, stop-color);
-        .replaceColor(#7341ff, stop-color);
-        .replaceColor(#6d4aff, stop-color);
+        .replaceColor(#7341FF, stop-color);
+        .replaceColor(#6D4AFF, stop-color);
         .replaceColor(#AA8EFF, stop-color);
-        .replaceColor(#06b8ff, stop-color);
+        .replaceColor(#06B8FF, stop-color);
         .replaceColor(#BFE8FF, stop-color);
         .replaceColor(#BFABFF, stop-color);
         .replaceColor(#FF50C3, stop-color);
         .replaceColor(#B487FF, stop-color);
         .replaceColor(#FFC8FF, stop-color);
-        .replaceColor(#8effee, stop-color);
+        .replaceColor(#8EFFEE, stop-color);
         .replaceColor(#C9C7FF, stop-color);
-        .replaceColor(#00f0c3, stop-color);
+        .replaceColor(#00F0C3, stop-color);
         .replaceColor(#FFD580, stop-color);
         .replaceColor(#F6C592, stop-color);
         .replaceColor(#EBB6A2, stop-color);
@@ -204,8 +206,8 @@
         .replaceColor(#C486CB, stop-color);
         .replaceColor(#B578D9, stop-color);
         .replaceColor(#A166E5, stop-color);
-        .replaceColor(#8b57f2, stop-color);
-        .replaceColor(#704cff, stop-color);
+        .replaceColor(#8B57F2, stop-color);
+        .replaceColor(#704CFF, stop-color);
         .replaceColor(#B39FFB, stop-color);
         .replaceColor(#FFE8DB, stop-color);
       }


### PR DESCRIPTION
Hacky but it works

All color codes are uppercased as they have to match with the attribute values in the HTML, and since Prettier seems to randomly lowercase color codes, I had to add `prettier-ignore` to those lines.

Original:
![Screenshot from 2023-07-29 02-09-51](https://github.com/catppuccin/userstyles/assets/18283756/cf495437-4274-4d7a-ab6c-6a3fc3501a97)
Sapphire:
![Screenshot from 2023-07-29 02-10-05](https://github.com/catppuccin/userstyles/assets/18283756/954ffd19-f40b-418e-bf23-3a94cad30de3)
Red:
![Screenshot from 2023-07-29 02-10-50](https://github.com/catppuccin/userstyles/assets/18283756/6bfaaef3-7f7a-4c94-9522-f82527b72274)