### PR TITLE
fix invalid @updateURLs

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -5,7 +5,7 @@
 @version        1.1.5
 @description    Soothing pastel theme for Mastodon
 @author         Catppuccin
-@updateURL      https://github.com/catppuccin/userstyles/raw/main/mastodon/catppuccin.user.css
+@updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
 @license        MIT
 
 @preprocessor less

--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -5,7 +5,7 @@
 @version        1.1.2
 @description    Soothing pastel theme for Modrinth
 @author         Catppuccin
-@updateURL      https://github.com/catppuccin/userstyles/raw/main/modrinth/catppuccin.user.css
+@updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/modrinth/catppuccin.user.css
 @license 		MIT
 
 @preprocessor less


### PR DESCRIPTION
![](https://cdn.betterttv.net/emote/6355e6e6ed98a03da0cd9775/2x.gif)

The updateURL for mastodon's userstyle links to an invalid resource. It was just missing `styles/` directory. 