### PR TITLE
fix(chatgpt): Add ctp-colors to code blocks

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -247,10 +247,37 @@
       background-color: @surface0 !important;
     }
 
+    /* Code blocks */
     code.hljs,
     code[class*="language-"],
     pre[class*="language-"] {
       color: @text !important;
+    }
+
+    .hljs-keyword {
+      color: @blue !important;
+    }
+
+    .hljs-title {
+      color: @red !important;
+    }
+
+    .hljs-built_in {
+      color: @peach !important;
+    }
+
+    .hljs-string {
+      color: @green !important;
+    }
+
+    .hljs-literal {
+      font-style: italic !important;
+      color: @blue !important;
+    }
+
+    .hljs-number {
+      font-weight: 600 !important;
+      color: @maroon !important;
     }
 
     .btn-neutral {


### PR DESCRIPTION
I am unsure if I got every type they use, but these were the ones I found.

Added italic and weight to better mimic the look of the ctp vscode theme.