### PR TITLE
fix(mastodon): search popout themeing

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Mastodon Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version        1.1.5
+@version        1.1.6
 @description    Soothing pastel theme for Mastodon
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
@@ -483,6 +483,7 @@ domain("piaille.fr") {
       box-shadow: none;
     }
 
+    .search__popout,
     .dropdown-menu__arrow:before,
     .dropdown-menu__item a,
     .dropdown-menu__item button,


### PR DESCRIPTION
As pointed in the [ctp discord](https://discord.com/channels/907385605422448742/1012720591180152893/1139802518168277063) the search popout was not being themed this fixes that issue.