### PR TITLE
edit colors to better fit the catppuccin color scheme guides

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -189,9 +189,18 @@ domain("piaille.fr") {
 
     &,
     .tabs-bar__wrapper,
-    .admin-wrapper .sidebar-wrapper__inner {
+    .admin-wrapper .sidebar-wrapper__inner,
+    .ui__header{
       background: @crust;
       color: @text;
+    }
+    
+    .ui__header {
+        border-bottom: none;
+    }
+    
+    .navigation-panel {
+        background: transparent;
     }
 
     .account__header__bio .account__header__fields dt {
@@ -291,7 +300,6 @@ domain("piaille.fr") {
       color: @accent-color;
     }
 
-    .ui__header,
     .column-header,
     .column-header__button,
     .column-header__back-button,
@@ -313,8 +321,8 @@ domain("piaille.fr") {
     .account__header__fields dd:not(.account__header__bio .account__header__fields dd),
     .focusable:focus,
     .admin-wrapper .sidebar ul .simple-navigation-active-leaf .selected {
-      border-color: @mantle;
-      background: @surface1;
+      border-color: @crust;
+      background: @surface0;
     }
 
     .admin-wrapper .sidebar ul a:hover,
@@ -426,12 +434,17 @@ domain("piaille.fr") {
       background-color: @surface2;
     }
 
+    .button.button-secondary {
+        background-color: transparent;
+        color: @text;
+        border-color: @accent-color;
+    }
     .button.button-secondary:active,
     .button.button-secondary:focus,
     .button.button-secondary:hover {
       border-color: @accent-color;
       color: @base;
-      transition: .4s;
+      transition: .2s;
     }
 
     .button:active,

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Mastodon Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version        1.1.6
+@version        1.1.7
 @description    Soothing pastel theme for Mastodon
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css


### PR DESCRIPTION
the colors of the headerbar did looked off on the mobile view when compared to other apps with catppuccin. this commit aims to fix it
![Before](https://github.com/catppuccin/userstyles/assets/27961224/eaeede48-a8f0-41e3-906e-3c0e8f110318)
![After](https://github.com/catppuccin/userstyles/assets/27961224/8829dfb9-e703-427f-99af-5a05d917aa1e)