### PR TITLE
feat(chatgpt): highlightjs

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @description Soothing pastel theme for ChatGPT
 @author Catppuccin
@@ -287,6 +287,148 @@
 
     [class*="text-green"] {
       color: @green !important;
+    }
+
+    code.hljs {
+      background: @crust; /* only modification, rest are same as upstream */
+    }
+    code .hljs-keyword {
+      color: @mauve;
+    }
+    code .hljs-built_in {
+      color: @red;
+    }
+    code .hljs-type {
+      color: @yellow;
+    }
+    code .hljs-literal {
+      color: @peach;
+    }
+    code .hljs-number {
+      color: @peach;
+    }
+    code .hljs-operator {
+      color: @teal;
+    }
+    code .hljs-punctuation {
+      color: @subtext1;
+    }
+    code .hljs-property {
+      color: @teal;
+    }
+    code .hljs-regexp {
+      color: @pink;
+    }
+    code .hljs-string {
+      color: @green;
+    }
+    code .hljs-char.escape_ {
+      color: @green;
+    }
+    code .hljs-subst {
+      color: @subtext0;
+    }
+    code .hljs-symbol {
+      color: @flamingo;
+    }
+    code .hljs-variable {
+      color: @mauve;
+    }
+    code .hljs-variable.language_ {
+      color: @mauve;
+    }
+    code .hljs-variable.constant_ {
+      color: @peach;
+    }
+    code .hljs-title {
+      color: @blue;
+    }
+    code .hljs-title.class_ {
+      color: @yellow;
+    }
+    code .hljs-title.function_ {
+      color: @blue;
+    }
+    code .hljs-params {
+      color: @text;
+    }
+    code .hljs-comment {
+      color: @surface2;
+    }
+    code .hljs-doctag {
+      color: @red;
+    }
+    code .hljs-meta {
+      color: @peach;
+    }
+    code .hljs-section {
+      color: @blue;
+    }
+    code .hljs-tag {
+      color: @subtext0;
+    }
+    code .hljs-name {
+      color: @mauve;
+    }
+    code .hljs-attr {
+      color: @blue;
+    }
+    code .hljs-attribute {
+      color: @green;
+    }
+    code .hljs-bullet {
+      color: @teal;
+    }
+    code .hljs-code {
+      color: @green;
+    }
+    code .hljs-emphasis {
+      color: @red;
+      font-style: italic
+    }
+    code .hljs-strong {
+      color: @red;
+      font-weight: bold
+    }
+    code .hljs-formula {
+      color: @teal;
+    }
+    code .hljs-link {
+      color: @sapphire;
+      font-style: italic
+    }
+    code .hljs-quote {
+      color: @green;
+      font-style: italic
+    }
+    code .hljs-selector-tag {
+      color: @yellow;
+    }
+    code .hljs-selector-id {
+      color: @blue;
+    }
+    code .hljs-selector-class {
+      color: @teal;
+    }
+    code .hljs-selector-attr {
+      color: @mauve;
+    }
+    code .hljs-selector-pseudo {
+      color: @teal;
+    }
+    code .hljs-template-tag {
+      color: @flamingo;
+    }
+    code .hljs-template-variable {
+      color: @flamingo;
+    }
+    code .hljs-diff-addition {
+      color: @green;
+      background: fade(@green, 15%);
+    }
+    code .hljs-diff-deletion {
+      color: @red;
+      background: fade(@red, 15%);
     }
   }
 }


### PR DESCRIPTION
Use catppuccin/highlightjs for the codeblocks. (With one minor change to match the code background and the container background)