### PR TITLE
bStats

### DIFF
--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -78,6 +78,9 @@ collaborators:
   - &r58Playz
     name: r58Playz
     url: https://github.com/r58Playz
+  - &rockquiet
+    name: rockquiet
+    url: https://github.com/rockquiet
 
 userstyles:
   advent-of-code:
@@ -111,6 +114,14 @@ userstyles:
       app-link: "https://search.brave.com"
       usage: "Set theme to dark or light in Brave Search settings, the automatic setting will not work"
       current-maintainers: [*ndsboy]
+  bstats:
+    name: bStats
+    category: game
+    color: green
+    readme:
+      app-link: "https://bstats.org"
+      usage: "Make sure to use the default **Teal** theme from the built-in color picker (located at the bottom of the page) for the best experience!"
+      current-maintainers: [*rockquiet]
   canvas-lms:
     name: Canvas LMS
     category: productivity

--- a/styles/bstats/assets/catwalk.webp
+++ b/styles/bstats/assets/catwalk.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00d929a2b28e7e48a76e24e4a5c0da7368b064a516ab28480c834c9d9b1680a7
+size 82034

--- a/styles/bstats/assets/frappe.webp
+++ b/styles/bstats/assets/frappe.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80bb819ae9168ab0477f16b437d7d76c54a6fd7ace4cbfa2d2ce4157a3e345e3
+size 40578

--- a/styles/bstats/assets/latte.webp
+++ b/styles/bstats/assets/latte.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30aa36fa43b58b38330cd6d97e8e72fd112bd6177513eaa85a59172814916af5
+size 42688

--- a/styles/bstats/assets/macchiato.webp
+++ b/styles/bstats/assets/macchiato.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c8ddc789e2b0297fc33f6c5c2a515c9caf907f0727db50ab7d4bc36613d6c2a
+size 41436

--- a/styles/bstats/assets/mocha.webp
+++ b/styles/bstats/assets/mocha.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1e3bc5358440019af1f6ebc363ce00e8ef76dfcd24e6b5cd7bf58ce0634e1da
+size 41604

--- a/styles/bstats/catppuccin.user.css
+++ b/styles/bstats/catppuccin.user.css
@@ -1,0 +1,653 @@
+/* ==UserStyle==
+@name bStats Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/bstats
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/bstats
+@version 0.1.0
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bstats/catppuccin.user.css
+@description Soothing pastel theme for bStats
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select flavor "Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green*", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Grey"]
+
+@var checkbox graphUseAccentColor "Graphs Use Accent" 0
+@var select fontMain "Main Font" {
+	"Roboto*":		"Roboto, sans-serif",
+	"Montserrat":	"Montserrat",
+	"Poppins":		"Poppins",
+	"Monocraft":	"Monocraft"
+}
+@var select fontSecondary "Secondary Font" {
+	"Signika*":		"Signika, serif",
+	"Montserrat":	"Montserrat",
+	"Poppins":		"Poppins",
+	"Monocraft":	"Monocraft"
+}
+
+==/UserStyle== */
+@-moz-document domain('bstats.org') {
+	@catppuccin: {
+		@latte: {
+			@rosewater: #dc8a78;
+			@flamingo: #dd7878;
+			@pink: #ea76cb;
+			@mauve: #8839ef;
+			@red: #d20f39;
+			@maroon: #e64553;
+			@peach: #fe640b;
+			@yellow: #df8e1d;
+			@green: #40a02b;
+			@teal: #179299;
+			@sky: #04a5e5;
+			@sapphire: #209fb5;
+			@blue: #1e66f5;
+			@lavender: #7287fd;
+			@text: #4c4f69;
+			@subtext1: #5c5f77;
+			@subtext0: #6c6f85;
+			@overlay2: #7c7f93;
+			@overlay1: #8c8fa1;
+			@overlay0: #9ca0b0;
+			@surface2: #acb0be;
+			@surface1: #bcc0cc;
+			@surface0: #ccd0da;
+			@base: #eff1f5;
+			@mantle: #e6e9ef;
+			@crust: #dce0e8;
+		}
+		@frappe: {
+			@rosewater: #f2d5cf;
+			@flamingo: #eebebe;
+			@pink: #f4b8e4;
+			@mauve: #ca9ee6;
+			@red: #e78284;
+			@maroon: #ea999c;
+			@peach: #ef9f76;
+			@yellow: #e5c890;
+			@green: #a6d189;
+			@teal: #81c8be;
+			@sky: #99d1db;
+			@sapphire: #85c1dc;
+			@blue: #8caaee;
+			@lavender: #babbf1;
+			@text: #c6d0f5;
+			@subtext1: #b5bfe2;
+			@subtext0: #a5adce;
+			@overlay2: #949cbb;
+			@overlay1: #838ba7;
+			@overlay0: #737994;
+			@surface2: #626880;
+			@surface1: #51576d;
+			@surface0: #414559;
+			@base: #303446;
+			@mantle: #292c3c;
+			@crust: #232634;
+		}
+		@macchiato: {
+			@rosewater: #f4dbd6;
+			@flamingo: #f0c6c6;
+			@pink: #f5bde6;
+			@mauve: #c6a0f6;
+			@red: #ed8796;
+			@maroon: #ee99a0;
+			@peach: #f5a97f;
+			@yellow: #eed49f;
+			@green: #a6da95;
+			@teal: #8bd5ca;
+			@sky: #91d7e3;
+			@sapphire: #7dc4e4;
+			@blue: #8aadf4;
+			@lavender: #b7bdf8;
+			@text: #cad3f5;
+			@subtext1: #b8c0e0;
+			@subtext0: #a5adcb;
+			@overlay2: #939ab7;
+			@overlay1: #8087a2;
+			@overlay0: #6e738d;
+			@surface2: #5b6078;
+			@surface1: #494d64;
+			@surface0: #363a4f;
+			@base: #24273a;
+			@mantle: #1e2030;
+			@crust: #181926;
+		}
+		@mocha: {
+			@rosewater: #f5e0dc;
+			@flamingo: #f2cdcd;
+			@pink: #f5c2e7;
+			@mauve: #cba6f7;
+			@red: #f38ba8;
+			@maroon: #eba0ac;
+			@peach: #fab387;
+			@yellow: #f9e2af;
+			@green: #a6e3a1;
+			@teal: #94e2d5;
+			@sky: #89dceb;
+			@sapphire: #74c7ec;
+			@blue: #89b4fa;
+			@lavender: #b4befe;
+			@text: #cdd6f4;
+			@subtext1: #bac2de;
+			@subtext0: #a6adc8;
+			@overlay2: #9399b2;
+			@overlay1: #7f849c;
+			@overlay0: #6c7086;
+			@surface2: #585b70;
+			@surface1: #45475a;
+			@surface0: #313244;
+			@base: #1e1e2e;
+			@mantle: #181825;
+			@crust: #11111b;
+		}
+	}
+
+	:root {
+		#catppuccin(@flavor, @accentColor);
+	}
+
+	#catppuccin(@lookup, @accent) {
+		@rosewater: @catppuccin[@@lookup][@rosewater];
+		@flamingo: @catppuccin[@@lookup][@flamingo];
+		@pink: @catppuccin[@@lookup][@pink];
+		@mauve: @catppuccin[@@lookup][@mauve];
+		@red: @catppuccin[@@lookup][@red];
+		@maroon: @catppuccin[@@lookup][@maroon];
+		@peach: @catppuccin[@@lookup][@peach];
+		@yellow: @catppuccin[@@lookup][@yellow];
+		@green: @catppuccin[@@lookup][@green];
+		@teal: @catppuccin[@@lookup][@teal];
+		@sky: @catppuccin[@@lookup][@sky];
+		@sapphire: @catppuccin[@@lookup][@sapphire];
+		@blue: @catppuccin[@@lookup][@blue];
+		@lavender: @catppuccin[@@lookup][@lavender];
+		@text: @catppuccin[@@lookup][@text];
+		@subtext1: @catppuccin[@@lookup][@subtext1];
+		@subtext0: @catppuccin[@@lookup][@subtext0];
+		@overlay2: @catppuccin[@@lookup][@overlay2];
+		@overlay1: @catppuccin[@@lookup][@overlay1];
+		@overlay0: @catppuccin[@@lookup][@overlay0];
+		@surface2: @catppuccin[@@lookup][@surface2];
+		@surface1: @catppuccin[@@lookup][@surface1];
+		@surface0: @catppuccin[@@lookup][@surface0];
+		@base: @catppuccin[@@lookup][@base];
+		@mantle: @catppuccin[@@lookup][@mantle];
+		@crust: @catppuccin[@@lookup][@crust];
+		@accent-color: @catppuccin[@@lookup][@@accent];
+
+		body,
+		.collection-header,
+		.collection-item,
+		.grey.lighten-4,
+		.page-footer .footer-copyright {
+			background: @base !important;
+		}
+		.teal.darken-3,
+		.teal.darken-2,
+		.dropdown-content,
+		.side-nav {
+			background-color: @mantle !important;
+		}
+		
+		.teal {
+			background-color: @surface0 !important;
+		}
+
+		/*slide out nav text & icons*/
+		.subheader,
+		.left {
+			color: @text !important;
+		}
+
+		.collection {
+			border: 1px solid @surface0;
+		}
+		.collection.with-header .collection-header,
+		.collection .collection-item {
+			border-bottom: 1px solid @surface0;
+		}
+
+		.collapsible {
+			border-top: 1px solid @surface1;
+			border-right: 1px solid @surface1;
+			border-left: 1px solid @surface1;
+		}
+		.collapsible-body {
+			border-bottom: 1px solid @surface1;
+		}
+		.collapsible-header {
+			background-color: @surface0 !important;
+			border-bottom: 1px solid @surface1;
+		}
+
+
+		blockquote {
+			border-left: 5px solid @maroon;
+		}
+		/*code box*/
+		.prettyprint,
+		.withBox,
+		.prettyprinted {
+			background-color: @mantle !important;
+			outline: 1px solid @mantle;
+			color: @overlay2;
+		}
+		.tag,
+		.boolean {
+			color: @blue;
+		}
+		.pln {
+			color: @text;
+		}
+		.com {
+			color: @overlay0;
+		}
+		.key {
+			color: @red
+		}
+		.clo,
+		.opn,
+		.pun {
+			color: @yellow;
+		}
+		.str,
+		.string,
+		.atv {
+			color: @green;
+		}
+		.atn {
+			color: @mauve;
+		}
+		.number {
+			color: @peach;
+		}
+
+		p,
+		h5,
+		b,
+		table,
+		th,
+		td,
+		.white-text,
+		nav .brand-logo,
+		nav a,
+		div.material-table .table-title,
+		div.material-table table th,
+		.card-title,
+		.card-content,
+		.container,
+		.center {
+			color: @text !important;
+		}
+		html,
+		div.material-table table tr td,
+		.grey-text.text-lighten-4,
+		.page-footer .footer-copyright {
+			color: @subtext1 !important;
+		}
+		.grey-text,
+		.grey-text.text-darken-2,
+		.input-field label,
+		div.material-table .table-footer label,
+		div.material-table .table-footer,
+		label {
+			color: @subtext0 !important;
+		}
+		.blue-text {
+			color: @blue !important;
+		}
+		.red-text {
+			color: @red !important;
+		}
+
+		/* discord logo on homepage */
+		img[src="/images/discord.svg"] when (@flavor=latte) {
+			filter: saturate(210%) hue-rotate(-20deg) brightness(82%);
+		}
+		img[src="/images/discord.svg"] when (@flavor=frappe) {
+			filter: saturate(53%) hue-rotate(-10deg) brightness(147%) contrast(90%) sepia(15%) invert(2%);
+		}
+		img[src="/images/discord.svg"] when (@flavor=macchiato) {
+			filter: saturate(52%) hue-rotate(-15deg) brightness(157%) contrast(90%) sepia(10%);
+		}
+		img[src="/images/discord.svg"] when (@flavor=mocha) {
+			filter: saturate(38%) hue-rotate(-25deg) brightness(153%) sepia(6%);
+		}
+
+		/*checkbox*/
+		[type="checkbox"] + label::before,
+		[type="checkbox"]:not(.filled-in) + label::after {
+			border: 2px solid @subtext0;
+		}
+		[type="checkbox"]:checked + label::before {
+			border: 0px solid rgba(0, 0, 0, 0.0);
+			border-right: 2px solid @green;
+			border-bottom: 2px solid @green;
+		}
+
+		/*table hover*/
+		div.material-table table tbody tr:hover {
+			background-color: fade(@surface2, 40%);
+		}
+		/*nav hover*/
+		nav ul a:hover {
+			background-color: fade(@surface2, 40%);
+		}
+		.dropdown-content li:hover,
+		.dropdown-content li.active,
+		.dropdown-content li.selected {
+			background-color: fade(@surface2, 5%);
+		}
+
+		.input-field .active {
+			color: @accent-color !important;
+		}
+		/*search unfocused*/
+		input:not([type]),
+		input[type="text"],
+		input[type="password"],
+		input[type="email"],
+		input[type="url"],
+		input[type="time"],
+		input[type="date"],
+		input[type="datetime"],
+		input[type="datetime-local"],
+		input[type="tel"],
+		input[type="number"],
+		input[type="search"],
+		textarea.materialize-textarea {
+			border-bottom: 1px solid @subtext0;
+			box-shadow: 1 1px 0 0 @subtext0;
+		}
+		/*search focused*/
+		input:not([type]):focus:not([readonly]),
+		input[type="text"]:focus:not([readonly]),
+		input[type="password"]:focus:not([readonly]),
+		input[type="email"]:focus:not([readonly]),
+		input[type="url"]:focus:not([readonly]),
+		input[type="time"]:focus:not([readonly]),
+		input[type="date"]:focus:not([readonly]),
+		input[type="datetime"]:focus:not([readonly]),
+		input[type="datetime-local"]:focus:not([readonly]),
+		input[type="tel"]:focus:not([readonly]),
+		input[type="number"]:focus:not([readonly]),
+		input[type="search"]:focus:not([readonly]),
+		textarea.materialize-textarea:focus:not([readonly]) {
+			border-bottom: 1px solid @accent-color;
+			box-shadow: 0 1px 0 0 @accent-color;
+		}
+
+		.teal-text,
+		.teal-text.text-darken-2,
+		.teal-text.text-lighten-3,
+		a {
+			color: @accent-color !important;
+		}
+		a,
+		b,
+		p,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6,
+		html,
+		.highcharts-button,
+		.card {
+			font-family: @fontMain !important;
+			font-weight: normal !important;
+		}
+		b {
+			font-weight: bold !important;
+		}
+
+		.btn,
+		.btn-large {
+			color: @text !important;
+		}
+		.btn.disabled,
+		.disabled.btn-large,
+		.btn-floating.disabled,
+		.btn-large.disabled,
+		.btn-flat.disabled,
+		.btn:disabled,
+		.btn-large:disabled,
+		.btn-floating:disabled,
+		.btn-large:disabled,
+		.btn-flat:disabled,
+		.btn[disabled],
+		[disabled].btn-large,
+		.btn-floating[disabled],
+		.btn-large[disabled],
+		.btn-flat[disabled] {
+			background-color: @mantle !important;
+			color: @subtext0 !important;
+		}
+		
+		.btn-large.red {
+			background-color: darken(@red, 30%) !important;
+		}
+
+		.card {
+			background-color: @base;
+			border: 1px solid @surface0;
+		}
+
+		thead,
+		div.material-table table tr td,
+		div.material-table .table-header {
+			border-bottom: 1px solid @surface0;
+		}
+
+		/*modals found in custom chart settings*/
+		.modal .modal-content,
+		.modal .modal-footer {
+			background-color: @surface0;
+		}
+
+		/*custom chart dropdown menu*/
+		.select-wrapper input.select-dropdown {
+			border-bottom: 1px solid @subtext0;
+		}
+		.select-dropdown li.optgroup {
+			border-top: 1px solid @surface1;
+		}
+		.select-dropdown li.disabled,
+		.select-dropdown li.disabled > span,
+		.select-dropdown li.optgroup {
+			color: @text;
+		}
+		.select-dropdown li.optgroup > span {
+			color: @subtext1;
+		}
+		.dropdown-content li > a,
+		.dropdown-content li > span {
+			color: @accent-color;
+		}
+
+		.divider {
+			background-color: @overlay2;
+		}
+		.caret {
+			color: @overlay1 !important;
+		}
+
+		/*custom chart lever*/
+		.switch label .lever {
+			background-color: @overlay0;
+			&::after {
+				background-color: @overlay2;
+			}
+		}
+		.switch label input[type="checkbox"]:checked + .lever {
+			background-color: desaturate(darken(@accent-color, 30%), 50%);
+			&::after {
+				background-color: @accent-color;
+			}
+		}
+
+		/* HIGHCHARTS "let's hope this does'nt break"-section */
+		/*all the charts*/
+		.highcharts-graph when (@graphUseAccentColor=1) {
+			stroke: @accent-color;
+		}
+		.highcharts-graph when (@graphUseAccentColor=0) {
+			stroke: @red;
+		}
+
+		/*background*/
+		.highcharts-container {
+			background: @base !important;
+		}
+		/* map blends in with background on latte flavor */
+		.highcharts-point when (@flavor=latte) {
+			stroke: @overlay0 !important;
+		}
+		.highcharts-point {
+			stroke: @base;
+		}
+		/*grid*/
+		.highcharts-grid .highcharts-yaxis-grid,
+		.highcharts-grid-line {
+			stroke: @surface0;
+		}
+		.highcharts-axis .highcharts-xaxis,
+		.highcharts-tick,
+		.highcharts-axis-line {
+			stroke: @surface1;
+		}
+		/*vertical line on graph hover*/
+		.highcharts-crosshair,
+		.highcharts-crosshair-thin {
+			stroke: @overlay2;
+		}
+		/*time navigator on bottom*/
+		.highcharts-navigator,
+		.highcharts-navigator-mask-inside {
+			fill: fade(@surface1, 33%);
+		}
+		.highcharts-navigator,
+		.highcharts-navigator-outline {
+			stroke: @surface1;
+		}
+		.highcharts-navigator,
+		.highcharts-navigator-handle {
+			fill: @surface2;
+			stroke: @overlay1;
+		}
+		/*scrollbar*/
+		.highcharts-scrollbar,
+		.highcharts-scrollbar-track {
+			fill: @surface0;
+			stroke: @surface0;
+		}
+		.highcharts-scrollbar,
+		.highcharts-scrollbar-thumb {
+			fill: @overlay1;
+			stroke: @overlay1;
+		}
+		.highcharts-scrollbar .highcharts-scrollbar-rifles {
+			stroke: @mantle;
+		}
+		.highcharts-scrollbar-button {
+			fill: @overlay1;
+			stroke: @overlay1;
+		}
+		.highcharts-scrollbar-arrow {
+			fill: @mantle;
+		}
+		
+		/* buttons */
+		.highcharts-button text {
+			fill: @subtext1 !important;
+		}
+		.highcharts-button-box {
+			fill: @surface0 !important;
+			stroke: @surface0 !important;
+		}
+		.highcharts-button-symbol {
+			fill: @subtext0 !important;
+			stroke: @subtext0 !important;
+		}
+		/* normal state */
+		.highcharts-button.highcharts-button-normal text {
+			fill: @subtext1 !important;
+		}
+		.highcharts-button.highcharts-button-normal .highcharts-button-box {
+			fill: @surface0 !important;
+			stroke: @surface0 !important;
+		}
+		/* hover state */
+		.highcharts-button.highcharts-button-hover text {
+			fill: @text !important;
+		}
+		.highcharts-button.highcharts-button-hover .highcharts-button-box {
+			fill: @surface2 !important;
+			stroke: @surface2 !important;
+		}
+		/* pressed state */
+		.highcharts-button.highcharts-button-pressed text {
+			fill: @text !important;
+		}
+		.highcharts-button.highcharts-button-pressed .highcharts-button-box {
+			fill: @surface2 !important;
+			stroke: @surface2 !important;
+		}
+		/* disabled state */
+		.highcharts-button.highcharts-button-disabled text {
+			fill: @overlay0 !important;
+		}
+		.highcharts-button.highcharts-button-disabled .highcharts-button-box {
+			fill: @base !important;
+			stroke: @surface0 !important;
+		}
+		
+		/*top right "load full data" menu in graph box*/
+		/* TODO */
+		.highcharts-contextmenu,
+		.highcharts-menu,
+		.highcharts-menu-item {
+			font-family: @fontSecondary;
+		}
+		/*pie text*/
+		.highcharts-text-outline {
+			font-family: @fontSecondary;
+			font-size: 12px;
+			stroke: @mantle;
+			stroke-width: 2px;
+		}
+		.highcharts-label,
+		.highcharts-data-label,
+		tspan {
+			font-family: @fontSecondary;
+			font-size: 12px;
+			fill: @subtext1;
+		}
+		.highcharts-range-selector-group {
+			font-family: @fontSecondary;
+		}
+		.highcharts-label,
+		.highcharts-tooltip span {
+			font-family: @fontSecondary;
+			color: @subtext1 !important;
+		}
+		/*hover text background*/
+		.highcharts-label-box,
+		.highcharts-tooltip-box {
+			fill: @surface0;
+		}
+		/*map legend*/
+		.highcharts-label,
+		.highcharts-legend-title text {
+			font-family: @fontSecondary;
+			fill: @subtext0 !important;
+		}
+		.highcharts-axis-labels,
+		.highcharts-coloraxis-labels text {
+			font-family: @fontSecondary;
+			fill: @subtext0 !important;
+		}
+	}
+}

--- a/styles/bstats/catppuccin.user.css
+++ b/styles/bstats/catppuccin.user.css
@@ -13,18 +13,6 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green*", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Grey"]
 
 @var checkbox graphUseAccentColor "Graphs Use Accent" 0
-@var select fontMain "Main Font" {
-	"Roboto*":		"Roboto, sans-serif",
-	"Montserrat":	"Montserrat",
-	"Poppins":		"Poppins",
-	"Monocraft":	"Monocraft"
-}
-@var select fontSecondary "Secondary Font" {
-	"Signika*":		"Signika, serif",
-	"Montserrat":	"Montserrat",
-	"Poppins":		"Poppins",
-	"Monocraft":	"Monocraft"
-}
 
 ==/UserStyle== */
 @-moz-document domain('bstats.org') {
@@ -384,24 +372,6 @@
 		a {
 			color: @accent-color !important;
 		}
-		a,
-		b,
-		p,
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6,
-		html,
-		.highcharts-button,
-		.card {
-			font-family: @fontMain !important;
-			font-weight: normal !important;
-		}
-		b {
-			font-weight: bold !important;
-		}
 
 		.btn,
 		.btn-large {
@@ -604,33 +574,18 @@
 			stroke: @surface0 !important;
 		}
 		
-		/*top right "load full data" menu in graph box*/
-		/* TODO */
-		.highcharts-contextmenu,
-		.highcharts-menu,
-		.highcharts-menu-item {
-			font-family: @fontSecondary;
-		}
 		/*pie text*/
 		.highcharts-text-outline {
-			font-family: @fontSecondary;
-			font-size: 12px;
 			stroke: @mantle;
 			stroke-width: 2px;
 		}
 		.highcharts-label,
 		.highcharts-data-label,
 		tspan {
-			font-family: @fontSecondary;
-			font-size: 12px;
 			fill: @subtext1;
-		}
-		.highcharts-range-selector-group {
-			font-family: @fontSecondary;
 		}
 		.highcharts-label,
 		.highcharts-tooltip span {
-			font-family: @fontSecondary;
 			color: @subtext1 !important;
 		}
 		/*hover text background*/
@@ -641,12 +596,10 @@
 		/*map legend*/
 		.highcharts-label,
 		.highcharts-legend-title text {
-			font-family: @fontSecondary;
 			fill: @subtext0 !important;
 		}
 		.highcharts-axis-labels,
 		.highcharts-coloraxis-labels text {
-			font-family: @fontSecondary;
 			fill: @subtext0 !important;
 		}
 	}


### PR DESCRIPTION
<!-- DELETE THIS IF YOUR PULL REQUEST DOES NOT ADD AN USERSTYLE" -->

<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [bStats](https://bstats.org) 🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

bStats allows you to collect usage data for your Bukkit, Spigot, Bungeecord or Sponge plugin.

![catwalk](https://raw.githubusercontent.com/rockquiet/ctp-bstats/main/assets/catwalk.webp)

<details>
<summary>🌻 Latte</summary>
<img src="https://raw.githubusercontent.com/rockquiet/ctp-bstats/main/assets/latte.webp"/>
</details>
<details>
<summary>🪴 Frappé</summary>
<img src="https://raw.githubusercontent.com/rockquiet/ctp-bstats/main/assets/frappe.webp"/>
</details>
<details>
<summary>🌺 Macchiato</summary>
<img src="https://raw.githubusercontent.com/rockquiet/ctp-bstats/main/assets/macchiato.webp"/>
</details>
<details>
<summary>🌿 Mocha</summary>
<img src="https://raw.githubusercontent.com/rockquiet/ctp-bstats/main/assets/mocha.webp"/>
</details>

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

Still need to theme some smaller parts and add more comments to better identify everything but the major part of the site is done.
Some parts of the website (all the Highcharts stuff, especially the world map) are pretty hard to theme.

I included two dropdown menus to change the fonts (`@fontMain` & `@fontSecondary`) and a toggle to use the accent color as the graph colors (`@graphUseAccentColor`).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/src/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - `catppuccin.user.css` - all the CSS for the userstyle, based on the
    template.
  - `assets/mocha.webp`, `assets/macchiato.webp`, `assets/frappe.webp` and
    `assets/latte.webp` - individual screenshots of the themed website, in all 4
    Catppuccin flavors.
  - `catwalk.webp` - image of all individual screenshots stitched together,
    generated via [catwalk](https://github.com/catppuccin/toolbox#-catwalk).
