### PR TITLE
ci: call `readme.yml` in `catppuccin/catppuccin`

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -55,4 +55,9 @@ jobs:
           commit_message: "chore: generate health files"
           commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: ${{ github.ref }}
+
+  call-generate-readme-in-catppuccin:
+    needs: "generate-health-files"
+    uses: catppuccin/catppuccin/.github/workflows/readme.yml@main
+
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json


### PR DESCRIPTION
This commit adds a new job to call the readme workflow within the main catppuccin/catppuccin repository. This will make sure that any additions to userstyles will be synced with the README on the main repository.

> [!NOTE]
> This should not be merged until [`readme.yaml`](https://github.com/catppuccin/catppuccin/blob/main/.github/workflows/readme.yml) is turned into a re-usable workflow.