### PR TITLE
feat: add hoppscotch

### DIFF
--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -214,6 +214,13 @@ userstyles:
     readme:
       app-link: "https://github.com/benphelps/homepage"
       current-maintainers: [*gandalf-the-blue]
+  hoppscotch:
+    name: Hoppscotch
+    category: development
+    color: green
+    readme:
+      app-link: "https://hoppscotch.io/"
+      current-maintainers: [*justtobbi]
   ichi.moe:
     name: ichi.moe
     category: productivity

--- a/styles/hoppscotch/assets/catwalk.webp
+++ b/styles/hoppscotch/assets/catwalk.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23308b1b27eb31401d64d14d73a10641bec5d47868a1a13c9ada32476dd23300
+size 184974

--- a/styles/hoppscotch/assets/frappe.webp
+++ b/styles/hoppscotch/assets/frappe.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:112fe8765ea854e009cfe368de797c2e33707bfeece1ec34def0e607a2baa74e
+size 94946

--- a/styles/hoppscotch/assets/latte.webp
+++ b/styles/hoppscotch/assets/latte.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3868cc0f0e37269d6dbc40ede4944ec7be1014a0cfe9b95d70a295f412797e9b
+size 100234

--- a/styles/hoppscotch/assets/macchiato.webp
+++ b/styles/hoppscotch/assets/macchiato.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d323a0742c19df57a0530f916f59f734aa677ef80a7b51647032e6c285266042
+size 98888

--- a/styles/hoppscotch/assets/mocha.webp
+++ b/styles/hoppscotch/assets/mocha.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cab74e63d636b7560d74db8d198611d32581c689eddbb0fc569978d00201a38f
+size 102818

--- a/styles/hoppscotch/catppuccin.user.css
+++ b/styles/hoppscotch/catppuccin.user.css
@@ -1,0 +1,227 @@
+/* ==UserStyle==
+@name           Hoppscotch.io Catppuccin
+@namespace      github.com/catppuccin/userstyles/styles/hoppscotch
+@homepageURL	 https://github.com/catppuccin/userstyles/tree/main/styles/hoppscotch
+@version        1.0.0
+@description    Soothing pastel theme for Hoppscotch
+@author         Catppuccin
+@updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/hoppscotch/catppuccin.user.css
+@license	       MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue*", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+@-moz-document domain("hoppscotch.io") {
+
+  @catppuccin: {
+    @latte: {
+      @rosewater: #dc8a78;
+      @flamingo: #dd7878;
+      @pink: #ea76cb;
+      @mauve: #8839ef;
+      @red: #d20f39;
+      @maroon: #e64553;
+      @peach: #fe640b;
+      @yellow: #df8e1d;
+      @green: #40a02b;
+      @teal: #179299;
+      @sky: #04a5e5;
+      @sapphire: #209fb5;
+      @blue: #1e66f5;
+      @lavender: #7287fd;
+      @text: #4c4f69;
+      @subtext1: #5c5f77;
+      @subtext0: #6c6f85;
+      @overlay2: #7c7f93;
+      @overlay1: #8c8fa1;
+      @overlay0: #9ca0b0;
+      @surface2: #acb0be;
+      @surface1: #bcc0cc;
+      @surface0: #ccd0da;
+      @base: #eff1f5;
+      @mantle: #e6e9ef;
+      @crust: #dce0e8;
+    }
+    @frappe: {
+      @rosewater: #f2d5cf;
+      @flamingo: #eebebe;
+      @pink: #f4b8e4;
+      @mauve: #ca9ee6;
+      @red: #e78284;
+      @maroon: #ea999c;
+      @peach: #ef9f76;
+      @yellow: #e5c890;
+      @green: #a6d189;
+      @teal: #81c8be;
+      @sky: #99d1db;
+      @sapphire: #85c1dc;
+      @blue: #8caaee;
+      @lavender: #babbf1;
+      @text: #c6d0f5;
+      @subtext1: #b5bfe2;
+      @subtext0: #a5adce;
+      @overlay2: #949cbb;
+      @overlay1: #838ba7;
+      @overlay0: #737994;
+      @surface2: #626880;
+      @surface1: #51576d;
+      @surface0: #414559;
+      @base: #303446;
+      @mantle: #292c3c;
+      @crust: #232634;
+    }
+    @macchiato: {
+      @rosewater: #f4dbd6;
+      @flamingo: #f0c6c6;
+      @pink: #f5bde6;
+      @mauve: #c6a0f6;
+      @red: #ed8796;
+      @maroon: #ee99a0;
+      @peach: #f5a97f;
+      @yellow: #eed49f;
+      @green: #a6da95;
+      @teal: #8bd5ca;
+      @sky: #91d7e3;
+      @sapphire: #7dc4e4;
+      @blue: #8aadf4;
+      @lavender: #b7bdf8;
+      @text: #cad3f5;
+      @subtext1: #b8c0e0;
+      @subtext0: #a5adcb;
+      @overlay2: #939ab7;
+      @overlay1: #8087a2;
+      @overlay0: #6e738d;
+      @surface2: #5b6078;
+      @surface1: #494d64;
+      @surface0: #363a4f;
+      @base: #24273a;
+      @mantle: #1e2030;
+      @crust: #181926;
+    }
+    @mocha: {
+      @rosewater: #f5e0dc;
+      @flamingo: #f2cdcd;
+      @pink: #f5c2e7;
+      @mauve: #cba6f7;
+      @red: #f38ba8;
+      @maroon: #eba0ac;
+      @peach: #fab387;
+      @yellow: #f9e2af;
+      @green: #a6e3a1;
+      @teal: #94e2d5;
+      @sky: #89dceb;
+      @sapphire: #74c7ec;
+      @blue: #89b4fa;
+      @lavender: #b4befe;
+      @text: #cdd6f4;
+      @subtext1: #bac2de;
+      @subtext0: #a6adc8;
+      @overlay2: #9399b2;
+      @overlay1: #7f849c;
+      @overlay0: #6c7086;
+      @surface2: #585b70;
+      @surface1: #45475a;
+      @surface0: #313244;
+      @base: #1e1e2e;
+      @mantle: #181825;
+      @crust: #11111b;
+    }
+  }
+
+  :root.dark {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+
+  :root.light {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+
+  #catppuccin(@lookup, @accent-color) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent: @catppuccin[@@lookup][@@accent-color];
+    
+    @accent-light-alpha: 1.1;
+    @accent-dark-alpha: 0.9;
+    @accent-gradient-from-color: 1.05;
+    @accent-gradient-via-color: 1.2;
+    @accent-gradient-to-color: 0.85;
+    
+    & {
+      --primary-color: @base;
+      --primary-light-color: @surface1;
+      --primary-dark-color: @crust;
+      --primary-contrast-color: @mantle;
+      --secondary-color: @subtext0;
+      --secondary-light-color: @subtext0;
+      --secondary-dark-color: @subtext1;
+      --divider-color: @overlay0;
+      --divider-light-color: @overlay1;
+      --divider-dark-color: @surface2;
+      --error-color: @red;
+      --tooltip-color: @text;
+      --popover-color: @crust;
+      --editor-theme: "vscode-esque";
+      --editor-type-color: fade(@mauve, 0.9);
+      --editor-name-color: @blue;
+      --editor-operator-color: @mauve;
+      --editor-invalid-color: @maroon;
+      --editor-separator-color: @overlay0;
+      --editor-meta-color: @overlay0;
+      --editor-variable-color: @green;
+      --editor-link-color: @sapphire;
+      --editor-process-color: fade(@pink, 1.4);
+      --editor-constant-color: fade(@lavender, 1.2);
+      --editor-keyword-color: @red;
+      
+      --accent-color: @accent;
+      --accent-light-color: fade(@accent, @accent-light-alpha);
+      --accent-dark-color: fade(@accent, @accent-dark-alpha);
+      --accent-contrast-color: @crust;
+      --gradient-from-color: fade(@accent, @accent-gradient-from-color);
+      --gradient-via-color: fade(@accent, @accent-gradient-via-color);
+      --gradient-to-color: fade(@accent, @accent-gradient-to-color);
+
+      --editor-process-color: @text;
+    }
+    
+
+    .ͼ1 .cm-placeholder {
+      color: @text;
+    }
+
+    .cm-focused .cm-activeLine {
+      background-color: @surface0;
+    }
+
+    .cm-focused .cm-activeLineGutter {
+      background-color: @surface2;
+    }
+  }
+}


### PR DESCRIPTION
Added hoppscotch to the userstyles :)

<!-- DELETE THIS IF YOUR PULL REQUEST DOES NOT ADD AN USERSTYLE" -->

<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for Hoppscotch🎉

![image](https://github.com/catppuccin/userstyles/assets/47004621/b16d8f8c-f008-4c89-9fdc-f2f02582812c)


## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/src/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - `catppuccin.user.css` - all the CSS for the userstyle, based on the
    template.
  - `assets/mocha.webp`, `assets/macchiato.webp`, `assets/frappe.webp` and
    `assets/latte.webp` - individual screenshots of the themed website, in all 4
    Catppuccin flavors.
  - `catwalk.webp` - image of all individual screenshots stitched together,
    generated via [catwalk](https://github.com/catppuccin/toolbox#-catwalk).
