### PR TITLE
fix(mastodon): overlaying profile header

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -348,8 +348,7 @@ domain("piaille.fr") {
     .conversation--unread,
     .column-header__collapsible-inner,
     .announcements,
-    .status-card__image,
-    .account__header__bar {
+    .status-card__image {
       border-color: @crust;
       background: @surface0;
     }

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Mastodon Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version        1.1.9
+@version        1.1.10
 @description    Soothing pastel theme for Mastodon
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css


### PR DESCRIPTION
Fixing an issue where the profile header was partially hidden due to a styled div on top.

Before: 
<img width="579" alt="Mastodon profile header partially hidden" src="https://github.com/catppuccin/userstyles/assets/35840154/4bb805c8-bff7-490b-9580-1a4e9744b3ad">

After:
<img width="579" alt="Mastodon profile header fully visible" src="https://github.com/catppuccin/userstyles/assets/35840154/4fb444e7-2a42-4693-aad2-4de44fed3f45">
