### PR TITLE
fix(youtube): match colors of topbar menu icons

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.0.9
+@version 3.0.10
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @description Soothing pastel theme for YouTube
 @author Catppuccin
@@ -730,7 +730,7 @@
       color: @crust !important;
     }
     .yt-spec-icon-badge-shape--style-overlay .yt-spec-icon-badge-shape__icon {
-      color: @text !important;
+      color: var(--yt-spec-icon-active-other) !important;
     }
 
     /* creator badges */


### PR DESCRIPTION
<details>
<summary>Screenshot of original github theme for reference</summary>

![image](https://github.com/catppuccin/userstyles/assets/49815452/8956728c-8113-45e9-9976-a77565789ad3)
</details>
<details>
<summary>Screenshot of catppuccin theme before this PR</summary>

![image](https://github.com/catppuccin/userstyles/assets/49815452/07728095-568f-4d67-be6e-6300acc86cd4)
</details>
<details>
<summary>Screenshot of catppuccin theme after this PR</summary>

![image](https://github.com/catppuccin/userstyles/assets/49815452/72430fb4-c38c-4a17-8812-31df8e4b3013)
</details>

Or maybe I ditched the wrong color? Maybe these icons should be more contrast but I made them as on screenshot due to this icon being not contrast enough either:
<details>
<summary>Screeshot of top left corner burger icon</summary>

![image](https://github.com/catppuccin/userstyles/assets/49815452/d6d2c65d-76d6-4ac9-9892-b3c28b9bb11a)
</details>

Please review my PR carefully because I am not really into custom website themes and for me they look like just a huge mess :D
