### PR TITLE
Brave Search – remove searchbar background gradient

### DIFF
--- a/styles/brave-search/catppuccin.user.css
+++ b/styles/brave-search/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Brave Search Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/brave-search
 @homepageURL	https://github.com/catppuccin/userstyles/tree/main/styles/brave-search
-@version        1.0.2
+@version        1.0.3
 @description    Soothing pastel theme for Brave Search
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/brave-search/catppuccin.user.css

--- a/styles/brave-search/catppuccin.user.css
+++ b/styles/brave-search/catppuccin.user.css
@@ -295,7 +295,7 @@
       --secondary-90: @lavender;
     }
 
-    .searchbox-wrapper.svelte-m5b7ni.svelte-m5b7ni::after {
+    #searchform > .searchbox-wrapper::after {
       background-image: none;
     }
 

--- a/styles/brave-search/catppuccin.user.css
+++ b/styles/brave-search/catppuccin.user.css
@@ -294,5 +294,10 @@
       --gray-120: @text;
       --secondary-90: @lavender;
     }
+
+    .searchbox-wrapper.svelte-m5b7ni.svelte-m5b7ni::after {
+      background-image: none;
+    }
+
   }
 }


### PR DESCRIPTION
I'll assume that this isn't intended as it does look a little weird. It seems like an oversight, or something Brave may have added since this was released:

With Style installed as is there is a weird gradient within the search-bar. That is fixed via this PR.

Before / After
<img width="705" alt="brave search with gradient" src="https://github.com/catppuccin/userstyles/assets/35840154/b1978f6f-a2a4-430d-8669-2caa68fe3948">
<img width="705" alt="brave search without gradient" src="https://github.com/catppuccin/userstyles/assets/35840154/42b652fa-2f68-4a15-941d-0fe1b675c0db">
