### PR TITLE
fix(chatgpt): boxes color and highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ See [CONTRIBUTING.md](docs/CONTRIBUTING.md)
 
 - [Hoppscotch](styles/hoppscotch)
 - [paste.rs](styles/paste.rs)
-- [Stylus](styles/stylus)
 - [Vercel](styles/vercel)
 
 </details>

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See [CONTRIBUTING.md](docs/CONTRIBUTING.md)
 
 - [Hoppscotch](styles/hoppscotch)
 - [paste.rs](styles/paste.rs)
+- [Stylus](styles/stylus)
 - [Vercel](styles/vercel)
 
 </details>

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @description Soothing pastel theme for ChatGPT
 @author Catppuccin
@@ -321,6 +321,21 @@
 
     [class*="text-green"] {
       color: @green !important;
+    }
+
+    .dark .dark\:hover\:bg-\[\#2A2B32\]:hover {
+      background-color: @surface0;
+    }
+    
+    .dark .dark\:bg-gray-900 {
+      background-color: @mantle;
+    }
+     
+    .dark .dark\:bg-gray-800 {
+      background-color: @surface0;
+    }
+    .radix-state-active\:bg-gray-800[data-state="active"] {
+      background-color: @surface0;
     }
   }
 }


### PR DESCRIPTION
this fixes the following issue:

**Before:**
![image](https://github.com/catppuccin/userstyles/assets/42213155/42cff7aa-694c-42ca-8c19-1f830d72aedd)
![image](https://github.com/catppuccin/userstyles/assets/42213155/91b1b444-65eb-428e-b7b0-02fb3baa5bfb)
![image](https://github.com/catppuccin/userstyles/assets/42213155/253e398c-5988-4e1c-a881-0ea449d8f4d1)

**After:**
![image](https://github.com/catppuccin/userstyles/assets/42213155/fdf1de63-3220-4098-8117-3849db9f0a44)
![image](https://github.com/catppuccin/userstyles/assets/42213155/303a4ca9-111b-4486-b98e-683b0d562e4c)
![image](https://github.com/catppuccin/userstyles/assets/42213155/e96368f8-1a9a-491f-a138-deb0659ac944)
![image](https://github.com/catppuccin/userstyles/assets/42213155/6b237731-c254-40e4-aa35-3fd11b2078a5)
