### PR TITLE
fix(github): move warning to the left so that users can still access settings and signin

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -155,7 +155,7 @@
   html:not([data-dark-theme="dark"]) body::after {
     position: fixed;
     top: 0;
-    right: 0;
+    left: 0;
     padding: 1rem;
     margin: 1rem;
     font-size: 0.9rem;


### PR DESCRIPTION
closes https://github.com/catppuccin/userstyles/issues/231