### PR TITLE
fix(searxng): improve metadata readability

### DIFF
--- a/styles/searxng/catppuccin.user.css
+++ b/styles/searxng/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           SearXNG Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/searxng
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/searxng
-@version        0.3.0
+@version        0.3.1
 @description    Soothing pastel theme for SearXNG
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/searxng/catppuccin.user.css
@@ -344,7 +344,7 @@ url-prefix("https://xo.wtf/")
       --color-result-search-url-border: @surface2;
       --color-result-search-url-font: @text;
       --color-result-detail-font: @text;
-      --color-result-detail-label-font: @surface1;
+      --color-result-detail-label-font: @subtext0;
       --color-result-detail-background: @base;
       --color-result-detail-hr: @base;
       --color-result-detail-link: @accent;


### PR DESCRIPTION
Before:
![image](https://github.com/catppuccin/userstyles/assets/71222764/cd3983f4-8572-460f-8d47-60031f790232)
After:
![image](https://github.com/catppuccin/userstyles/assets/71222764/864e86d8-c790-4fef-951c-6b249edb230e)
