### PR TITLE
docs(github): mention GitHub appearance settings

### DIFF
--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -203,7 +203,7 @@ userstyles:
     category: productivity
     color: text
     readme:
-      usage: "Switch to a default GitHub light/dark theme for the best experience!"
+      usage: "Switch to a default GitHub light/dark via the GitHub Appearance settings for the Catppuccin GitHub userstyle theme for the best experience!"
       app-link: "https://github.com"
       current-maintainers: [*pocco81, *glowingumbreon]
       past-maintainers: [*andreasgrafen]

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Github Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/github
 @homepageURL 	https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version        1.2.6
+@version        1.2.7
 @description    Soothing pastel theme for GitHub
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
@@ -164,7 +164,7 @@
     max-width: 40ch;
     background-color: var(--color-danger-fg);
     color: var(--color-header-bg);
-    content: "You're using an unsupported GitHub theme! Please switch to the default light/dark theme to get the best experience for the Catppuccin GitHub userstyle.";
+    content: "Unsupported GitHub theme detected! Please switch to the default light/dark theme via the GitHub Appearance settings to get the best experience for the Catppuccin GitHub userstyle.";
     z-index: 9999;
   }
 


### PR DESCRIPTION
This commit aims to clearly highlight that the GitHub default theme should be changed via the Appearance settings.

**Are we able to include links in this content?** It would be nice to maybe link to the GitHub docs as that will be updated regularly updated by GitHub themselves.