### PR TITLE
docs(github): fix readme grammar

### DIFF
--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -203,7 +203,7 @@ userstyles:
     category: productivity
     color: text
     readme:
-      usage: "Switch to a default GitHub light/dark via the GitHub Appearance settings for the Catppuccin GitHub userstyle theme for the best experience!"
+      usage: "Switch to a default GitHub light/dark theme via **Settings** > **Appearance** for the best experience!"
       app-link: "https://github.com"
       current-maintainers: [*pocco81, *glowingumbreon]
       past-maintainers: [*andreasgrafen]


### PR DESCRIPTION
"for the Catppuccin GitHub userstyle theme for the best experience" doesn't really make sense.