### PR TITLE
fix(syncthing): replace leaky port capture with proper url config

### DIFF
--- a/styles/syncthing/catppuccin.user.css
+++ b/styles/syncthing/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Syncthing Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/syncthing
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/syncthing
-@version 0.1.0
+@version 0.1.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/syncthing/catppuccin.user.css
 @description Soothing pastel theme for Syncthing
 @author Catppuccin
@@ -12,11 +12,15 @@
 @var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire*", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
-@var number port "Syncthing Port" 8384
+@var text urls "URL(s) for Syncthing" "127\.0\.0\.1\:8384,localhost\:8384"
 
 ==/UserStyle== */
 
-@-moz-document regexp(%("https?://.*:%d/.*", @port))
+/*
+  `replace(<stuff> ," ", "", "g")` is here to remove extra spaces (if any)
+*/
+
+@-moz-document regexp(replace(replace(%("https?://(%s)/.*", @urls), ",", "|"), " ", "", "g"))
 {
   @catppuccin: {
     @latte: {


### PR DESCRIPTION
As discussed on discord, using the old regex that will capture any url with the specified port can be extremely leaky and will not work if someone has 2 urls with 2 different ports.

This PR attempts to fix that by replacing the port option with a setting to specify urls separated with commas.

Now one has to specify urls like `127\.0\.0\.1\:8384,localhost\:8384`

`127\.0\.0\.1\:8384,localhost\:8384` is the default setting.