### PR TITLE
docs: update browsers.md

### DIFF
--- a/docs/browsers.md
+++ b/docs/browsers.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > If you see a popular browser that hasn't been added, please create a pull request to do so!
 
-Find your browser version by following the instructions below:
+Find your browser version by following the link for your browser.
 
 <table>
   <thead>

--- a/docs/browsers.md
+++ b/docs/browsers.md
@@ -1,30 +1,35 @@
 # Browsers
 
-> **Note** <br>
+> [!NOTE]
 > If you see a popular browser that hasn't been added, please create a pull request to do so!
 
 Find your browser version by following the instructions below:
 
 <table>
 <tr>
- <td> Browser
- <td> Instructions
+ <td>Browser</td>
+ <td>URL</td>
+</tr>
 <tr>
- <td> Chromium
- <td> Type <code>chrome://version/</code>
+ <td>Chromium</td>
+ <td><code>chrome://version/</code></td>
+</tr>
 <tr>
- <td> Firefox
- <td> Type <code>about:support</code>
+ <td>Firefox</td>
+ <td><code>about:support</code></td>
+</tr>
 <tr>
- <td> Opera (GX)
- <td> Type <code>opera://about/</code>
+ <td>Opera (GX)</td>
+ <td><code>opera://about/</code></td>
+</tr>
 <tr>
- <td> Microsoft Edge
- <td> Type <code>edge://version/</code>
+ <td>Microsoft Edge</td>
+ <td><code>edge://version/</code></td>
+</tr>
 </table>
 
 ## Common Issues
 
-> **Note** <br>
+> [!NOTE]
 > If you are running into any compatibility issues with your browser, please consider opening 
 > a pull request and documenting your issue here!

--- a/docs/browsers.md
+++ b/docs/browsers.md
@@ -29,6 +29,10 @@ Find your browser version by following the link for your browser.
       <td>Microsoft Edge</td>
       <td><code>edge://version/</code></td>
     </tr>
+    <tr>
+      <td>Arc</td>
+      <td><code>arc://version/</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/browsers.md
+++ b/docs/browsers.md
@@ -6,26 +6,30 @@
 Find your browser version by following the instructions below:
 
 <table>
-<tr>
- <td>Browser</td>
- <td>URL</td>
-</tr>
-<tr>
- <td>Chromium</td>
- <td><code>chrome://version/</code></td>
-</tr>
-<tr>
- <td>Firefox</td>
- <td><code>about:support</code></td>
-</tr>
-<tr>
- <td>Opera (GX)</td>
- <td><code>opera://about/</code></td>
-</tr>
-<tr>
- <td>Microsoft Edge</td>
- <td><code>edge://version/</code></td>
-</tr>
+  <thead>
+    <tr>
+      <th>Browser</th>
+      <th>URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Chromium</td>
+      <td><code>chrome://version/</code></td>
+    </tr>
+    <tr>
+      <td>Firefox</td>
+      <td><code>about:support</code></td>
+    </tr>
+    <tr>
+      <td>Opera (GX)</td>
+      <td><code>opera://about/</code></td>
+    </tr>
+    <tr>
+      <td>Microsoft Edge</td>
+      <td><code>edge://version/</code></td>
+    </tr>
+  </tbody>
 </table>
 
 ## Common Issues


### PR DESCRIPTION
This PR updates `docs/browsers.md` to use the new GitHub callout syntax, `[!NOTE]` (sorry I missed this file earlier!) and corrects the syntax for the browsers table.