### PR TITLE
ci: bump actions and make titles lowercase

### DIFF
--- a/.github/workflows/file-checker.yml
+++ b/.github/workflows/file-checker.yml
@@ -1,4 +1,4 @@
-name: File Checker
+name: File checker
 
 on:
   workflow_dispatch:
@@ -6,12 +6,12 @@ on:
 
 jobs:
   file-checker:
-    name: Required Files Included
+    name: Required files included
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Check Files
+      - uses: actions/checkout@v4
+      - name: Check files
         run: |
           MISSING_FILES=0
           echo "# Missing Files Found 😢" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/file-checker.yml
+++ b/.github/workflows/file-checker.yml
@@ -1,4 +1,4 @@
-name: File checker
+name: File Checker
 
 on:
   workflow_dispatch:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,3 +22,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "style: format code with prettier"
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,25 +1,24 @@
-name: Prettier
+name: Format
 
 on:
   push:
     branches: [main]
 
 jobs:
-  prettier:
+  format:
     name: Format Code
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.USERSTYLES_TOKEN }}
       - uses: actions/setup-node@v3
 
-      - name: Run Prettier
+      - name: Format files
         run: npx prettier --write styles/**/*.css
 
-      - name: Push Changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "style: format code with prettier"
-          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,4 +1,4 @@
-name: File Generator
+name: File generator
 
 on:
   workflow_dispatch:
@@ -13,27 +13,24 @@ env:
 jobs:
   generate-health-files:
     runs-on: ubuntu-latest
-    name: Generate Health Files
+    name: Generate health files
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.
       contents: write
 
     steps:
-      - name: Check Out Repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: env.HAS_USERSTYLES_TOKEN
         with:
           token: ${{ secrets.USERSTYLES_TOKEN }}
           ref: ${{ github.ref }}
-
-      - name: Check Out Repository (Fork)
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: env.HAS_USERSTYLES_TOKEN == 'false'
         with:
           ref: ${{ github.ref }}
 
-      - name: Set up Deno
+      - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
@@ -44,15 +41,14 @@ jobs:
           key: ${{ hashFiles('src/generate/deno.lock') }}
           path: ${{ env.DENO_DIR }}
 
-      - name: Update Health Files
+      - name: Generate health files
         working-directory: src/generate
         run: ./generate.ts
 
-      - name: Push Changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
         if: ${{ github.repository == 'catppuccin/userstyles' && github.ref == 'refs/heads/main' && env.HAS_USERSTYLES_TOKEN }}
         with:
           commit_message: "chore: generate health files"
-          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: ${{ github.ref }}
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,4 +1,4 @@
-name: File generator
+name: File Generator
 
 on:
   workflow_dispatch:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -50,5 +50,6 @@ jobs:
         if: ${{ github.repository == 'catppuccin/userstyles' && github.ref == 'refs/heads/main' && env.HAS_USERSTYLES_TOKEN }}
         with:
           commit_message: "chore: generate health files"
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: ${{ github.ref }}
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,4 +1,4 @@
-name: Issue labeler
+name: Issue Labeler
 
 on:
   workflow_dispatch:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,4 +1,4 @@
-name: Issue Labeler
+name: Issue labeler
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   triage:
-    name: Add Labels
+    name: Add labels
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/maintainers.yml
+++ b/.github/workflows/maintainers.yml
@@ -1,4 +1,4 @@
-name: Sync Maintainers
+name: Sync maintainers
 
 on:
   workflow_dispatch:
@@ -12,10 +12,10 @@ env:
 jobs:
   sync-maintainers:
     runs-on: ubuntu-latest
-    name: Sync Maintainers
+    name: Sync maintainers
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
@@ -30,7 +30,7 @@ jobs:
           key: ${{ hashFiles('src/generate/deno.lock') }}
           path: ${{ env.DENO_DIR }}
 
-      - name: Sync Maintainers
+      - name: Sync maintainers
         if: ${{ github.repository == 'catppuccin/userstyles' && github.ref == 'refs/heads/main' }}
         working-directory: src/generate
         run: ./syncMaintainers.ts

--- a/.github/workflows/maintainers.yml
+++ b/.github/workflows/maintainers.yml
@@ -1,4 +1,4 @@
-name: Sync maintainers
+name: Sync Maintainers
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,15 +1,15 @@
-name: Pull Request Labeler
+name: Pull request labeler
 
 on:
   pull_request_target:
 
 jobs:
   triage:
-    name: Add Labels
+    name: Add labels
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/labeler@v4.0.3
         with:
           configuration-path: .github/pr-labeler.yml

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,4 +1,4 @@
-name: Pull request labeler
+name: Pull Request Labeler
 
 on:
   pull_request_target:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,4 @@
-name: Sync Labels
+name: Sync labels
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,4 @@
-name: Sync labels
+name: Sync Labels
 
 on:
   workflow_dispatch:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,4 +1,4 @@
-name: Typo checker
+name: Typo Checker
 
 on:
   pull_request:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,4 +1,4 @@
-name: Typo Checker
+name: Typo checker
 
 on:
   pull_request:
@@ -6,23 +6,23 @@ on:
     branches: [main]
 
 jobs:
-  run:
-    name: Spell Check
+  spellcheck:
+    name: Spellcheck
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: crate-ci/typos@master
       id: typos
       continue-on-error: true
 
     # 'continue-on-error' will always succeed, we should exit based on the outcome and not the conclusion
     # ref: https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
-    - name: Fail When Typos Are Found in Pull Request
+    - name: Fail when typos are found in pull request
       if: ${{ github.event_name == 'pull_request' && steps.typos.outcome != 'success' }}
       run: "exit 1"
 
     # We always want this check to pass on branch 'main' but continue to fail on PRs
-    - name: Pass When Branch 'main'
+    - name: Pass on 'main' branch
       if: ${{ github.repository == 'catppuccin/userstyles' && github.ref == 'refs/heads/main' }}
       run: "exit 0"


### PR DESCRIPTION
I'm not sure why each step's name is title case - doesn't really fit with GitHub actions casing (see below), though I do understand title case workflow titles, happy to change that back. Otherwise, this PR bumps all uses of `actions/checkout` to `v4` and `stefanzweifel/git-auto-commit-action` to `v5`. I also removed the `commit_author` field used with `stefanzweifel/git-auto-commit-action` since it is already the default with the action.

![Screenshot 2023-10-09 at 21 40 08 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/917cc2fb-6ad9-4628-918f-fb38d653827f)
