### PR TITLE
fix(stylus): disabled button state

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -250,6 +250,9 @@
       color: @text !important;
       background: @mantle !important;
     }
+    #save-button[disabled] {
+      background: @surface0 !important;
+    }
     #message-box-title {
       color: @base;
     }


### PR DESCRIPTION
This PR adjusts the background color of the save button when disabled (which is when a userstyle hasn't been edited).

**Default Stylus**:
![Screenshot 2023-10-13 at 09 56 55 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/964e394c-80f0-48fa-8d5b-96563020c096)

**Before**:
![Screenshot 2023-10-13 at 09 58 02 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/7c9ee1df-5f30-4cb8-acc6-2ee32fd10c30)

**Now**:
![Screenshot 2023-10-13 at 09 56 43 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/08de1f96-0f0b-4b99-bea7-94a2e0bc1b7e)

I just selected the `#save-button` for now but should this apply to all buttons?