### PR TITLE
fix(deepl): flex-shrink in zen mode

### DIFF
--- a/styles/deepl/catppuccin.user.css
+++ b/styles/deepl/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           DeepL Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/deepl
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/deepl
-@version        0.3.0
+@version        0.3.1
 @description    Soothing pastel theme for DeepL
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/deepl/catppuccin.user.css

--- a/styles/deepl/catppuccin.user.css
+++ b/styles/deepl/catppuccin.user.css
@@ -715,7 +715,7 @@
     [data-testid="translator"] {
       // height: 100%;
       // width: 100vw;
-      display: flex;
+      // display: flex;
       justify-content: center;
       align-content: center;
       align-items: center;


### PR DESCRIPTION
## Description
This pull request addresses an issue where the `flex-shrink` property was incorrectly applied to elements when Zen mode is enabled, leading to unexpected layout shrinkage.

<img width="600" alt="deepl-shrink" src="https://github.com/catppuccin/userstyles/assets/70371393/8f669ae1-cf17-4912-bbf6-9267400ab1c0">

Commenting out the line `display: flex;` in `[data-testid="translator"]` seems to resolve this issue.

<img width="600" alt="deepl-fixed" src="https://github.com/catppuccin/userstyles/assets/70371393/dc0e770a-b347-4612-8765-ae9e18dd4769">
