### PR TITLE
refactor(treewide): `url("data:image/svg+xml,@{svg}")`

### DIFF
--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -316,11 +316,10 @@
 
     /* Replace vote arrow with svg arrow and mask */
     .votearrow {
-      background-image: url("data:image/svg+xml,%3C!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' %5B %3C!ENTITY ns_svg 'http://www.w3.org/2000/svg'%3E%3C!ENTITY ns_xlink 'http://www.w3.org/1999/xlink'%3E%0A%5D%3E%3Csvg xmlns='&ns_svg;' width='10' height='10' viewBox='0 0 10 10' fill-opacity='0' xml:space='preserve'%3E%3Cpolygon points='0,10 5,1 10,10 '/%3E%3C/svg%3E%0A");
-      -webkit-mask-image: url("data:image/svg+xml,%3C!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' %5B %3C!ENTITY ns_svg 'http://www.w3.org/2000/svg'%3E%3C!ENTITY ns_xlink 'http://www.w3.org/1999/xlink'%3E%0A%5D%3E%3Csvg xmlns='&ns_svg;' width='10' height='10' viewBox='0 0 10 10' fill='black' xml:space='preserve'%3E%3Cpolygon points='0,10 5,1 10,10 '/%3E%3C/svg%3E%0A");
-      mask-image: url("data:image/svg+xml,%3C!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' %5B %3C!ENTITY ns_svg 'http://www.w3.org/2000/svg'%3E%3C!ENTITY ns_xlink 'http://www.w3.org/1999/xlink'%3E%0A%5D%3E%3Csvg xmlns='&ns_svg;' width='10' height='10' viewBox='0 0 10 10' fill='black' xml:space='preserve'%3E%3Cpolygon points='0,10 5,1 10,10 '/%3E%3C/svg%3E%0A");
-      background-color: @subtext0;
-      height: 8;
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" height="32" viewBox="0 0 32 16" width="32"><path d="m2 27 14-29 14 29z" fill="@{subtext0}"/></svg>'
+      );
+      background-image: url("data:image/svg+xml,@{svg}");
     }
   }
 }

--- a/styles/invidious/catppuccin.user.css
+++ b/styles/invidious/catppuccin.user.css
@@ -81,19 +81,6 @@
       lighten(@accentColor, 5%)
     );
 
-    & when (@lookup = latte) {
-      input[type="checkbox"]:checked {
-        border: 1px solid @crust;
-        background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTYgMTYiIGZpbGw9ImJsYWNrIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik0xMi4yMDcgNC43OTNhMSAxIDAgMDEwIDEuNDE0bC01IDVhMSAxIDAgMDEtMS40MTQgMGwtMi0yYTEgMSAwIDAxMS40MTQtMS40MTRMNi41IDkuMDg2bDQuMjkzLTQuMjkzYTEgMSAwIDAxMS40MTQgMHoiLz48L3N2Zz4K");
-      }
-    }
-    & when not (@lookup = latte) {
-      input[type="checkbox"]:checked {
-        border: 1px solid @crust;
-        background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTYgMTYiIGZpbGw9IndoaXRlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik0xMi4yMDcgNC43OTNhMSAxIDAgMDEwIDEuNDE0bC01IDVhMSAxIDAgMDEtMS40MTQgMGwtMi0yYTEgMSAwIDAxMS40MTQtMS40MTRMNi41IDkuMDg2bDQuMjkzLTQuMjkzYTEgMSAwIDAxMS40MTQgMHoiLz48L3N2Zz4=");
-      }
-    }
-
     color-scheme: if(@lookup = latte, light, dark);
     background-color: @base !important;
     color: @text !important;
@@ -268,6 +255,12 @@
       appearance: none;
       outline: none;
       cursor: pointer;
+      &:checked {
+        @svg: escape(
+          '<svg viewBox="0 0 16 16" fill="@{accentColor}" xmlns="http://www.w3.org/2000/svg"><path d="M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z"/></svg>'
+        );
+        background-image: url("data:image/svg+xml,@{svg}");
+      }
     }
 
     // video player background

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -617,9 +617,11 @@ domain("wetdry.world") {
     }
 
     .simple_form select {
-      background: @mantle
-        url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='%2342485A'/></svg>")
-        no-repeat right 8px center/auto 16px;
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14.933 18.467" height="19.698" width="15.929"><path d="M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z" fill="@{overlay2}"/></svg>'
+      );
+      background: @mantle url("data:image/svg+xml,@{svg}") no-repeat right 8px
+        center/auto 16px;
       border: 1px solid @crust;
     }
 

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -485,8 +485,10 @@
     /* menu items */
     /* checkbox subitem */
     .ytp-menuitem[aria-checked="true"] .ytp-menuitem-toggle-checkbox {
-      @tmp: escape(@accent-color);
-      background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20viewBox%3D%220%200%2024%2024%22%20version%3D%221.1%22%3E%3Cpath%20d%3D%22M9%2016.2L4.8%2012l-1.4%201.4L9%2019%2021%207l-1.4-1.4L9%2016.2z%22%20fill%3D%22@{tmp}%22/%3E%3C/svg%3E");
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" version="1.1"><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" fill="@{accent-color}"/></svg>'
+      );
+      background: url("data:image/svg+xml,@{svg}");
     }
     .ytp-menuitem:not([aria-disabled="true"]):hover {
       background: @surface1 !important;


### PR DESCRIPTION
Changes how overriding `url("data:image/svg...")` is done across all styles, without base64-encoding it, and using `@{escaped-values}` to manipulate colors instead of `mask-image` etc.