### PR TITLE
ci: add pull request title linter workflow

### DIFF
--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -2,10 +2,7 @@ name: Pull Request Title Linter
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+    types: [opened, edited, synchronize]
 
 jobs:
   lint:

--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -14,12 +14,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Lint pull request title
+        uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - name: Add error comment
+        uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -38,6 +40,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        name: Delete error comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error

--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -1,0 +1,44 @@
+name: Pull Request Title Linter
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    name: Lint pull request title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
Adds a workflow to lint pull request titles against the conventional commit specification as discussed in Discord.

I'm using the example workflow they gave for adding a comment: https://github.com/marketplace/actions/semantic-pull-request#outputs. Thoughts? Should we just the workflow fail or is the comment good?