### PR TITLE
fix(yt): private video warning

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.1.8
+@version 3.1.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @description Soothing pastel theme for YouTube
 @author Catppuccin
@@ -554,6 +554,11 @@
       &:hover {
         color: @teal !important;
       }
+    }
+
+    /* private video warning */
+    .WARNING.yt-alert-renderer {
+      background-color: @yellow;
     }
 
     /* search results */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

private video warning

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
