### PR TITLE
ci(pr-titles): allow all scopes

### DIFF
--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Lint pull request title
         uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title
+        with:
+          scopes: |
+            [A-Za-z]+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
As per discussion in Discord, we shouldn't restrict PR scopes since we have scopes for different userstyle names and such.