### PR TITLE
fix(github): update regex to exclude `.patch` and `.diff` urls

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Github Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/github
 @homepageURL 	https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version        1.2.10
+@version        1.2.11
 @description    Soothing pastel theme for GitHub
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
@@ -131,7 +131,7 @@
   };
 };
 
-@-moz-document regexp("https:\/\/(gist\.)*github\.com(?!\/(home|marketplace|organizations\/plan)).*") {
+@-moz-document regexp("https:\/\/(gist\.)*github\.com(?!\/(home|marketplace|organizations\/plan))(?!\/.+?\/.+?\/commit\/[A-Fa-f0-9]+\.).*") {
   [data-color-mode="light"],
   [data-color-mode="auto"] > .theme-light {
     #catppuccin(@lightFlavor, @accentColor);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fix urls

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
