### PR TITLE
ci(lint): set media-feature-range-notation to "prefix"

### DIFF
--- a/scripts/lint/stylelint.ts
+++ b/scripts/lint/stylelint.ts
@@ -160,6 +160,8 @@ const config: stylelint.Config = {
     ],
     "function-name-case": null,
     "no-descending-specificity": null,
+
+    "media-feature-range-notation": "prefix",
   },
 };
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Stylus v1.5.35, which is the latest version on the Firefox add-on store, is unable to process e.g. `@media (width >= 35rem) {}` (context notation) when using less. `@media (min-width: 35rem) {}` (prefix notation) works fine.

This has been fixed in Stylus v1.5.37, which is not yet on the Firefox add-on store. However on the latest version (v1.5.38) other media queries still result in errors: e.g. `@media (not (display-mode: fullscreen)) {}` (the outer braces are needed when nesting in less, but are valid CSS), which might need further handling.

With the current set of rules the linter throws errors, when not using context notation.
For compatibility reasons we should prefer prefix notation.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] ~~I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.~~
