### PR TITLE
ci(typos): also exclude id selectors

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -16,5 +16,5 @@ flavours = "flavours"
 [type.css]
 extend-ignore-re = [
   # css classnames
-  '\.[\w\d\-_]+(\[[\w\d\-_]+\])?',
+  '[\.#][\w\d\-_]+(\[[\w\d\-_]+\])?',
 ]


### PR DESCRIPTION
For the `#analyse-cm` typo false positive in #346 