### PR TITLE
fix: avoid extra url-prefix when possible

### DIFF
--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -12,8 +12,7 @@
 @var select flavor "Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater*", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
-@-moz-document url-prefix("https://mail.google.com")
-{
+@-moz-document domain("mail.google.com") {
   :root {
     #catppuccin(@flavor, @accentColor);
   }
@@ -204,11 +203,8 @@
     .yO {
       background: @mantle !important;
       &:hover {
-        box-shadow:
-          inset 1px 0 0 @surface0,
-          inset -1px 0 0 @surface0,
-          0 0 4px 0 @base,
-          0 0 6px 2px @base !important;
+        box-shadow: inset 1px 0 0 @surface0, inset -1px 0 0 @surface0,
+          0 0 4px 0 @base, 0 0 6px 2px @base !important;
       }
     }
     /* quick text */

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -12,8 +12,7 @@
 @var select flavor "Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
 ==/UserStyle== */
 
-@-moz-document url-prefix("https://news.ycombinator.com")
-{
+@-moz-document domain("news.ycombinator.com") {
   /* prettier-ignore */
   @catppuccin: {
     @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };

--- a/styles/skiff/catppuccin.user.css
+++ b/styles/skiff/catppuccin.user.css
@@ -12,8 +12,7 @@
 @var select flavor "Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater*", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
-@-moz-document url-prefix("https://app.skiff.com")
-{
+@-moz-document domain("app.skiff.com") {
   :root {
     #catppuccin(@flavor, @accentColor);
   }


### PR DESCRIPTION
As title says, no need to use `url-prefix("https://` if there isn't a path at the end - we should just use `domain()`.