### PR TITLE
fix(chatgpt): css variable typo

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -94,7 +94,7 @@
     --ctp-surface0: #rgbify(@surface0) [];
     --ctp-base: #rgbify(@crust) [];
     --ctp-mantle: #rgbify(@mantle) [];
-    --ctp-curst: #rgbify(@crust) [];
+    --ctp-crust: #rgbify(@crust) [];
 
     --text-primary: @text;
     --text-secondary: @subtext0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Corrects a typo in a CSS variable. Kinda irrelevant since it (crust) isn't actually used in catppuccin/highlightjs but good to have correct I would think.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.

^ I don't think a version bump is necessary here lol.