### PR TITLE
fix: youtube error page background

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -574,7 +574,7 @@
         border-color: fadeout(@accent-color, 80) !important;
       }
     }
-
+	  
     /* text color */
     .gsfs {
       color: @text !important;
@@ -776,7 +776,7 @@
       border-color: @accent-color !important;
     }
 
-    /* New Feature inline banner */
+    /* New Feature inline banner */ 
     .ytd-brand-video-singleton-renderer {
       background: @surface0 !important;
       color: @text !important;
@@ -798,6 +798,10 @@
     #error-page {
       background-color: @base !important;
     }
+	   .search_plugin_added {
+		  background-color: @base
+	  }
+	  
 
     #error-page-content {
       color: @text !important;

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.2.1
+@version 3.2.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @description Soothing pastel theme for YouTube
 @author Catppuccin


### PR DESCRIPTION
annoying, the page does not have a dark version, so whatever theme the users set as light mode will be the colors used, blame youtube.

## 🔧 What does this fix? 🔧
Youtube Error Page's Background
<!--
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
