### PR TITLE
fix(stylus): some color when opening the extension from tab or smth

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Stylus Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/stylus
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version        1.1.1
+@version        1.1.2
 @updateURL 	    https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @description    Soothing pastel theme for Stylus
 @author         Catppuccin
@@ -65,9 +65,12 @@
       --c75: @overlay1;
       --c80: @surface1;
       --c85: @surface0;
+      --c90: @base;
       --c95: @mantle;
       --c97: @mantle;
       --c98: @base;
+      --c99: @base;
+      --c100: @base;
       --accent-1: @color;
       --accent-2: @color;
       --accent-3: @color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
