### PR TITLE
fix(google): color logo in images tab

### DIFF
--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Google Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/google
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/google
-@version        0.1.0
+@version        0.1.1
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/google/catppuccin.user.css
 @description    Soothing pastel theme for Google
 @author         Catppuccin
@@ -493,16 +493,16 @@
       color: @text;
     }
     .fSnalc {
-      stroke: @text;
+      stroke: @blue;
     }
     .oOg6Ne {
-      stroke: @text;
+      stroke: @yellow;
     }
     .ZqPjbb {
-      stroke: @text;
+      stroke: @red;
     }
     .aPiskd {
-      stroke: @text;
+      stroke: @green;
     }
     .s8GCU {
       background-color: @base;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The google logo ain't colored in the "Images" tab unlike other tabs

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
