### PR TITLE
fix(reddit): some 'orange' colors are not themed in the new beta theme

### DIFF
--- a/styles/reddit/catppuccin.user.css
+++ b/styles/reddit/catppuccin.user.css
@@ -143,6 +143,7 @@
     --color-brand-background: @accent-color;
     --color-brand-background-hover: @accent-color;
     --color-global-orangered: @accent-color;
+    --color-action-upvote: @accent-color;
 
     #reddit-logo {
       circle[fill="#FF4500"] {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

reddit's new beta theme became the main theme now (apparently), I noticed some orange colors aren't themed.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
