### PR TITLE
fix(reddit): color the recap logo

### DIFF
--- a/styles/reddit/catppuccin.user.css
+++ b/styles/reddit/catppuccin.user.css
@@ -1,12 +1,12 @@
 /* ==UserStyle==
 @name           Reddit Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/reddit
-@homepageURL	https://github.com/catppuccin/userstyles/tree/main/styles/reddit
-@version        2.0.1
+@homepageURL	  https://github.com/catppuccin/userstyles/tree/main/styles/reddit
+@version        2.0.2
 @description    Soothing pastel theme for Reddit
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/reddit/catppuccin.user.css
-@license		MIT
+@license		    MIT
 
 @preprocessor   less
 @var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
@@ -1086,6 +1086,55 @@
 
     div.HQ2VJViRjokXpRbJzPvvc::after {
       border-top-color: @mantle !important;
+    }
+    
+    /* Recap Reddit Logo */
+    .snoo-cls-1 {
+      fill: @base;
+    }
+
+    .snoo-cls-2 {
+      fill: @base;
+    }
+    
+    .snoo-cls-3 {
+      fill: @base;
+    }
+    
+    .snoo-cls-4 {
+      fill: @accent-color;
+    }
+    
+    .snoo-cls-5 {
+      fill: @accent-color;
+    }
+    
+    .snoo-cls-6 {
+      fill: @base;
+    }
+    
+    .snoo-cls-7 {
+      fill: @accent-color;
+    }
+    
+    .snoo-cls-8 {
+      fill: @base;
+    }
+    
+    .snoo-cls-9 {
+      fill: @base;
+    }
+    
+    .snoo-cls-10 {
+      fill: @accent-color;
+    }
+    
+    .snoo-cls-11 {
+      fill: @sky;
+    }
+    
+    .snoo-cls-11 {
+      fill: @sky;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Old:
![image](https://github.com/catppuccin/userstyles/assets/42213155/1ea936a8-4cc4-4230-8311-2a98f45ba09b)

New:
![image](https://github.com/catppuccin/userstyles/assets/42213155/d241d9c2-124a-4cc5-a3f3-dae37c8cce43)
![image](https://github.com/catppuccin/userstyles/assets/42213155/5f94fab4-3252-42fe-8b69-8a23afe59caa)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
