### PR TITLE
feat(whatsapp): split flavor variable into light and dark

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.css
+++ b/styles/whatsapp-web/catppuccin.user.css
@@ -2,14 +2,15 @@
 @name WhatsApp Web  Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/whatsapp-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/whatsapp-web
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/whatsapp-web/catppuccin.user.css
 @description Soothing pastel theme for WhatsApp Web
 @author Catppuccin
 @license MIT
 
 @preprocessor less
-@var select flavor "Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire*", "sky:Sky", "lavender:Lavender", "subtext0:Grey"]
 @var checkbox lighterMessages "Lighter incoming messages" 0
 ==/UserStyle== */
@@ -22,8 +23,12 @@
     @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
   }
 
-  :root {
-    #catppuccin(@flavor, @accentColor);
+  body {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+
+  body.dark {
+    #catppuccin(@darkFlavor, @accentColor);
   }
 
   @color: red;
@@ -60,559 +65,557 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
-    .dark {
-      .landing-wrapper-before {
-        background-color: @accent-color !important;
-      }
-
-      /* STATUS PAGE */
-      --status-background: @base !important;
-      .bfsx6evv {
-        background-color: @mantle !important;
-      }
-
-      --modal-backdrop-solid: @base !important;
-
-      /* join group pop up */
-      --modal-background: @base !important;
-
-      /* startup progress */
-      --progress-primary: @accent-color !important;
-      --progress-background: @surface1 !important;
-      --startup-background: @base !important;
-      --startup-background-rgb: #rgbify(@base) [];
-      /* home page, no chat selected */
-      --intro-background: @base !important;
-      --intro-border: @accent-color !important;
-      /* general background */
-      --app-background: @base !important;
-
-      /* CHAT LIST */
-      /* chat list background */
-      --background-default: @base !important;
-      /* chat list header */
-      --panel-header-background: @mantle !important;
-      /* icons */
-      --panel-header-icon: @text !important;
-      /* other warnings (notifications) */
-      --butterbar-default-background: @mantle !important;
-      --butterbar-notification-icon: @sky !important;
-      /* loading messages warning */
-      --butterbar-green-nux-background: @mantle !important;
-      /* update available warning */
-      --butterbar-update-background: @mantle !important;
-      --butterbar-update-icon: @accent-color !important;
-      /* chat list search bar */
-      --search-container-background: @base !important;
-      --search-input-container-background: @base !important;
-      --search-input-background: @surface0 !important;
-      --search-input-container-background-active: @mantle !important;
-      --icon-search-back: @accent-color !important;
-      /* archive icon */
-      --icon-bright-highlight: @accent-color !important;
-      /* archived unread marker */
-      --unread-marker-background: @accent-color !important;
-      --unread-timestamp: @accent-color !important;
-      /* archived chats header */
-      --archived-chat-persistent-header-background: @crust !important;
-      /* unread voice message */
-      --ptt-green: @green !important;
-      /* read voice message */
-      --ptt-blue: @blue !important;
-      /* pinned chat icon */
-      --icon-pinned: @accent-color !important;
-      /* last message in selected chat */
-      --secondary-stronger: @subtext1 !important;
-      /* background for active and hover chats in chat list */
-      --background-default-active: @surface1 !important;
-      --background-default-hover: @surface0 !important;
-      /* unread chats filter */
-      --icon-high-emphasis: @green !important;
-      .p7idzaix {
-        color: @crust !important;
-      }
-      /* voice message playing */
-      --ptt-ooc-background: @mantle !important;
-
-      /* CONVERSATION */
-      /* chat background */
-      --conversation-panel-background: @mantle !important;
-      /* MESSAGES */
-      /* background for incoming and outgoing messages */
-      & when (@lighterMessages=1) {
-        --incoming-background: @surface1 !important;
-        --incoming-background-deeper: @surface2 !important;
-        /* arrow icon in messages */
-        --incoming-background-rgb: #rgbify(@surface1) [];
-      }
-      & when (@lighterMessages=0) {
-        --incoming-background: @base !important;
-        --incoming-background-deeper: @surface0 !important;
-        /* arrow icon in messages */
-        --incoming-background-rgb: #rgbify(@base) [];
-      }
-      --outgoing-background: @surface0 !important;
-      /* read double tick */
-      --icon-ack: @blue !important;
-      /* received double tick */
-      --bubble-meta-icon: @subtext0 !important;
-      /* message timestamp */
-      --bubble-meta: @text !important;
-      --message-primary: @text !important;
-      /* POLL */
-      /* creation */
-      --poll-modal-background-color: @base !important;
-      --poll-modal-footer-background-color: @surface0 !important;
-      /* votes */
-      --poll-bar-fill-receiver: @green !important;
-      --poll-bar-fill-sender: @green !important;
-      --checkbox-mark: @crust !important;
-
-      /* audio duration */
-      --audio-progress-metadata: @subtext0 !important;
-      /* system messages (unread or day messages in chats) */
-      --system-message-text: @text !important;
-      --system-message-background: @crust !important;
-      /* unread system message background */
-      --unread-background: @crust !important;
-      --unread-bar-background: @surface1 !important;
-      /* meta data for documents */
-      --document-meta: @subtext1 !important;
-      /* mentions, links and link previews */
-      --mention-at-symbol: @sapphire !important;
-      --link: @sapphire !important;
-      --link-preview: @text !important;
-      --link-preview-lighter: @subtext1 !important;
-      --link-preview-light: @subtext0 !important;
-      --outgoing-background-rgb: #rgbify(@surface0) [];
-      /* QUOTED MESSAGES */
-      /* quoted messages */
-      --quoted-message-text: @text !important;
-      /* background for quoted incoming and outgoing messages */
-      --outgoing-background-deeper: @surface1 !important;
-
-      /* SEARCH IN CHAT HIGHLIGHT */
-      --highlight: @teal !important;
-
-      /* quote colors */
-      .bg-color-1 {
-        background-color: @green !important;
-      }
-      .color-1 {
-        color: @green !important;
-      }
-      .bg-color-2 {
-        background-color: @blue !important;
-      }
-      .color-2 {
-        color: @blue !important;
-      }
-      .bg-color-3 {
-        background-color: @pink !important;
-      }
-      .color-3 {
-        color: @pink !important;
-      }
-      .bg-color-4 {
-        background-color: @sapphire !important;
-      }
-      .color-4 {
-        color: @sapphire !important;
-      }
-      .bg-color-5 {
-        background-color: @peach !important;
-      }
-      .color-5 {
-        color: @peach !important;
-      }
-      .bg-color-6 {
-        background-color: @sky !important;
-      }
-      .color-6 {
-        color: @sky !important;
-      }
-      .bg-color-7 {
-        background-color: @yellow !important;
-      }
-      .color-7 {
-        color: @yellow !important;
-      }
-      .bg-color-8 {
-        background-color: @teal !important;
-      }
-      .color-8 {
-        color: @teal !important;
-      }
-      .bg-color-9 {
-        background-color: @lavender !important;
-      }
-      .color-9 {
-        color: @lavender !important;
-      }
-      .bg-color-10 {
-        background-color: @red!important;
-      }
-      .color-10 {
-        color: @red!important;
-      }
-      .bg-color-11 {
-        background-color: @mauve !important;
-      }
-      .color-11 {
-        color: @mauve !important;
-      }
-      .bg-color-12 {
-        background-color: @flamingo !important;
-      }
-      .color-12 {
-        color: @flamingo !important;
-      }
-      .bg-color-13 {
-        background-color: @rosewater !important;
-      }
-      .color-13 {
-        color: @rosewater !important;
-      }
-      .bg-color-14 {
-        background-color: @pink !important;
-      }
-      .color-14 {
-        color: @pink !important;
-      }
-      .bg-color-15 {
-        background-color: @maroon !important;
-      }
-      .color-15 {
-        color: @maroon !important;
-      }
-      .bg-color-16 {
-        background-color: @teal !important;
-      }
-      .color-16 {
-        color: @teal !important;
-      }
-      /* general text */
-      --primary: @text !important;
-      --primary-strong: @text !important;
-      --primary-stronger: @text !important;
-      --primary-strongest: @text !important;
-      --secondary: @subtext0 !important;
-      --secondary-strongest-rgb: #rgbify(@text) [];
-      /* chat list typing message */
-      --typing: @green !important;
-      /* background for video player and image viewer */
-      --media-viewer-background: @mantle !important;
-      /* not loaded media */
-      --media-gallery-thumb-background: @crust !important;
-
-      /* Group info/Contact info */
-      --photopicker-overlay-background: fadeout(@mantle, 0.8) !important;
-      --photopicker-overlay-background-rgb: #rgbify(@base) [];
-      --media-viewer-background-rgb: #rgbify(@base) [];
-      --drawer-background-deep: @crust !important;
-      /* group info read more */
-      --input-button-more: @sapphire !important;
-      /* Group info thumbnails border */
-      --chat-info-drawer-thumb-background: @surface2 !important;
-      /* Group admin badge background */
-      --chat-marker-background: @mantle !important;
-      --chat-marker-border: @mantle !important;
-      /* Group admin badge foreground */
-      --chat-marker: @subtext0 !important;
-      /* Media gallery */
-      --drawer-gallery-background: @crust !important;
-      /* mute toggle */
-      --switch-button-checked-color: @accent-color !important;
-      --switch-track-checked-color: @surface2 !important;
-      --switch-track-color: @surface2 !important;
-      --switch-button-color: @overlay1 !important;
-
-      /* danger, block, exit and report buttons */
-      --danger: @red!important;
-
-      /* group added by someone not in contacts */
-      --button-plain-background: @surface0 !important;
-      --button-plain-background-hover: @surface1 !important;
-
-      /* EMOJI AND STICKERS */
-      --panel-input-background: @surface0 !important;
-      --sticker-button-background: @surface1 !important;
-      --active-tab-marker: @accent-color !important;
-
-      /* REACTIONS */
-      --reactions-panel-background-color: @surface0 !important;
-      --reactions-tray-background: @surface0 !important;
-      --reactions-details-background: @surface0 !important;
-      --svg-gray-button: @surface0 !important;
-
-      /* Forward message popup */
-      --panel-background-colored-deeper: @crust !important;
-      --modal-backdrop: fadeout(@mantle, 0.8) !important;
-
-      /* MEDIA EDITOR */
-      /* background for media editor */
-      --panel-background-deeper: @mantle !important;
-      /* message box for media editor */
-      --media-editor-image-caption-input-background: @surface0 !important;
-      /* selected picture in media editor */
-      --media-editor-thumb-border-active: @accent-color !important;
-      /* send button in media editor */
-      --button-round-background: @accent-color !important;
-
-      /* COMPOSE BAR */
-      /* type a message bar and background */
-      --compose-input-background: @surface0 !important;
-      --compose-input-border: @surface1 !important;
-      --compose-panel-background: @mantle !important;
-      --rich-text-panel-background: @mantle !important;
-      /* select messages fixes */
-      --panel-background: @mantle !important;
-      --panel-background-rgb: #rgbify(@mantle) [];
-      --checkbox-background: @accent-color !important;
-      /* quoted message in compose */
-      --popup-panel-background: @surface0 !important;
-      /* use Surface 0 for contrast, other colors don't pass AAA */
-      /* mention list item background */
-      --compose-panel-background-hover: @surface1 !important;
-      /* compose bar icons */
-      --icon: @accent-color !important;
-      /* ATTACH ICONS */
-      /* poll icon */
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(6)
-        > button
-        > span
-        > svg
-        > circle {
-        fill: @green !important;
-      }
-      /* image icon */
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(1)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > path:nth-child(2) {
-        fill: @pink !important;
-      }
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(1)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > path:nth-child(1) {
-        fill: @pink !important;
-        filter: brightness(85%) !important;
-      }
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(1)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > rect {
-        fill: @pink !important;
-        filter: brightness(70%) !important;
-      }
-      /* sticker icon */
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(2)
-        > button
-        > span
-        > svg
-        > g
-        > circle {
-        fill: @blue !important;
-        filter: brightness(85%) !important;
-      }
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(2)
-        > button
-        > span
-        > svg
-        > g
-        > path:nth-child(2) {
-        fill: @blue !important;
-      }
-      /* camera icon */
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(3)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > path:nth-child(1) {
-        fill: @red!important;
-        filter: brightness(85%) !important;
-      }
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(3)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > path:nth-child(2) {
-        fill: @red!important;
-      }
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(3)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > rect {
-        fill: @red!important;
-        filter: brightness(85%) !important;
-      }
-      /* document icon */
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(4)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > path:nth-child(1) {
-        fill: @mauve !important;
-        filter: brightness(85%) !important;
-      }
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(4)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > path:nth-child(2) {
-        fill: @mauve !important;
-      }
-      /* contact icon */
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(5)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > g
-        > path:nth-child(1) {
-        fill: @sky !important;
-        filter: brightness(85%) !important;
-      }
-      div._1OT67
-        > div
-        > span
-        > div
-        > div
-        > ul
-        > li:nth-child(5)
-        > button
-        > span
-        > svg
-        > g:nth-child(1)
-        > g
-        > g
-        > path:nth-child(2) {
-        fill: @sky !important;
-      }
-      /* VOICE MESSAGE SENDING */
-      --ptt-draft-button-send: @accent-color !important;
-      --ptt-draft-waveform-background: @base !important;
-      --ptt-draft-button-stop: @red !important;
-      --ptt-draft-button-stop-hover: @maroon !important;
-
-      /* GENERAL OPTIONS */
-      /* dropdown menus */
-      --dropdown-background: @surface0 !important;
-      --dropdown-background-hover: @surface1 !important;
-
-      /* OTHER SECTIONS */
-      /* profile background */
-      --drawer-background: @base !important;
-      /* communities, new chat, other panes */
-      --panel-background-colored: @mantle !important;
-      --drawer-section-background: @base !important;
-      /* new chat icons */
-      --round-icon-background: @green !important;
-      --inverse: @text !important;
-      /* title and icon for drawers */
-      --drawer-header-title: @text !important;
-      /* buttons such as create community */
-      --button-primary-background: @accent-color !important;
-      --button-primary-background-hover: fadeout(@accent-color, 0.8) !important;
-      /* keyboard shortcuts background */
-      --panel-background-lighter: @mantle !important;
-      /* active input in modals and drawers */
-      --input-border-active: @accent-color !important;
+    .landing-wrapper-before {
+      background-color: @accent-color !important;
     }
+
+    /* STATUS PAGE */
+    --status-background: @base !important;
+    .bfsx6evv {
+      background-color: @mantle !important;
+    }
+
+    --modal-backdrop-solid: @base !important;
+
+    /* join group pop up */
+    --modal-background: @base !important;
+
+    /* startup progress */
+    --progress-primary: @accent-color !important;
+    --progress-background: @surface1 !important;
+    --startup-background: @base !important;
+    --startup-background-rgb: #rgbify(@base) [];
+    /* home page, no chat selected */
+    --intro-background: @base !important;
+    --intro-border: @accent-color !important;
+    /* general background */
+    --app-background: @base !important;
+
+    /* CHAT LIST */
+    /* chat list background */
+    --background-default: @base !important;
+    /* chat list header */
+    --panel-header-background: @mantle !important;
+    /* icons */
+    --panel-header-icon: @text !important;
+    /* other warnings (notifications) */
+    --butterbar-default-background: @mantle !important;
+    --butterbar-notification-icon: @sky !important;
+    /* loading messages warning */
+    --butterbar-green-nux-background: @mantle !important;
+    /* update available warning */
+    --butterbar-update-background: @mantle !important;
+    --butterbar-update-icon: @accent-color !important;
+    /* chat list search bar */
+    --search-container-background: @base !important;
+    --search-input-container-background: @base !important;
+    --search-input-background: @surface0 !important;
+    --search-input-container-background-active: @mantle !important;
+    --icon-search-back: @accent-color !important;
+    /* archive icon */
+    --icon-bright-highlight: @accent-color !important;
+    /* archived unread marker */
+    --unread-marker-background: @accent-color !important;
+    --unread-timestamp: @accent-color !important;
+    /* archived chats header */
+    --archived-chat-persistent-header-background: @crust !important;
+    /* unread voice message */
+    --ptt-green: @green !important;
+    /* read voice message */
+    --ptt-blue: @blue !important;
+    /* pinned chat icon */
+    --icon-pinned: @accent-color !important;
+    /* last message in selected chat */
+    --secondary-stronger: @subtext1 !important;
+    /* background for active and hover chats in chat list */
+    --background-default-active: @surface1 !important;
+    --background-default-hover: @surface0 !important;
+    /* unread chats filter */
+    --icon-high-emphasis: @green !important;
+    .p7idzaix {
+      color: @crust !important;
+    }
+    /* voice message playing */
+    --ptt-ooc-background: @mantle !important;
+
+    /* CONVERSATION */
+    /* chat background */
+    --conversation-panel-background: @mantle !important;
+    /* MESSAGES */
+    /* background for incoming and outgoing messages */
+    & when (@lighterMessages=1) {
+      --incoming-background: @surface1 !important;
+      --incoming-background-deeper: @surface2 !important;
+      /* arrow icon in messages */
+      --incoming-background-rgb: #rgbify(@surface1) [];
+    }
+    & when (@lighterMessages=0) {
+      --incoming-background: @base !important;
+      --incoming-background-deeper: @surface0 !important;
+      /* arrow icon in messages */
+      --incoming-background-rgb: #rgbify(@base) [];
+    }
+    --outgoing-background: @surface0 !important;
+    /* read double tick */
+    --icon-ack: @blue !important;
+    /* received double tick */
+    --bubble-meta-icon: @subtext0 !important;
+    /* message timestamp */
+    --bubble-meta: @text !important;
+    --message-primary: @text !important;
+    /* POLL */
+    /* creation */
+    --poll-modal-background-color: @base !important;
+    --poll-modal-footer-background-color: @surface0 !important;
+    /* votes */
+    --poll-bar-fill-receiver: @green !important;
+    --poll-bar-fill-sender: @green !important;
+    --checkbox-mark: @crust !important;
+
+    /* audio duration */
+    --audio-progress-metadata: @subtext0 !important;
+    /* system messages (unread or day messages in chats) */
+    --system-message-text: @text !important;
+    --system-message-background: @crust !important;
+    /* unread system message background */
+    --unread-background: @crust !important;
+    --unread-bar-background: @surface1 !important;
+    /* meta data for documents */
+    --document-meta: @subtext1 !important;
+    /* mentions, links and link previews */
+    --mention-at-symbol: @sapphire !important;
+    --link: @sapphire !important;
+    --link-preview: @text !important;
+    --link-preview-lighter: @subtext1 !important;
+    --link-preview-light: @subtext0 !important;
+    --outgoing-background-rgb: #rgbify(@surface0) [];
+    /* QUOTED MESSAGES */
+    /* quoted messages */
+    --quoted-message-text: @text !important;
+    /* background for quoted incoming and outgoing messages */
+    --outgoing-background-deeper: @surface1 !important;
+
+    /* SEARCH IN CHAT HIGHLIGHT */
+    --highlight: @teal !important;
+
+    /* quote colors */
+    .bg-color-1 {
+      background-color: @green !important;
+    }
+    .color-1 {
+      color: @green !important;
+    }
+    .bg-color-2 {
+      background-color: @blue !important;
+    }
+    .color-2 {
+      color: @blue !important;
+    }
+    .bg-color-3 {
+      background-color: @pink !important;
+    }
+    .color-3 {
+      color: @pink !important;
+    }
+    .bg-color-4 {
+      background-color: @sapphire !important;
+    }
+    .color-4 {
+      color: @sapphire !important;
+    }
+    .bg-color-5 {
+      background-color: @peach !important;
+    }
+    .color-5 {
+      color: @peach !important;
+    }
+    .bg-color-6 {
+      background-color: @sky !important;
+    }
+    .color-6 {
+      color: @sky !important;
+    }
+    .bg-color-7 {
+      background-color: @yellow !important;
+    }
+    .color-7 {
+      color: @yellow !important;
+    }
+    .bg-color-8 {
+      background-color: @teal !important;
+    }
+    .color-8 {
+      color: @teal !important;
+    }
+    .bg-color-9 {
+      background-color: @lavender !important;
+    }
+    .color-9 {
+      color: @lavender !important;
+    }
+    .bg-color-10 {
+      background-color: @red!important;
+    }
+    .color-10 {
+      color: @red!important;
+    }
+    .bg-color-11 {
+      background-color: @mauve !important;
+    }
+    .color-11 {
+      color: @mauve !important;
+    }
+    .bg-color-12 {
+      background-color: @flamingo !important;
+    }
+    .color-12 {
+      color: @flamingo !important;
+    }
+    .bg-color-13 {
+      background-color: @rosewater !important;
+    }
+    .color-13 {
+      color: @rosewater !important;
+    }
+    .bg-color-14 {
+      background-color: @pink !important;
+    }
+    .color-14 {
+      color: @pink !important;
+    }
+    .bg-color-15 {
+      background-color: @maroon !important;
+    }
+    .color-15 {
+      color: @maroon !important;
+    }
+    .bg-color-16 {
+      background-color: @teal !important;
+    }
+    .color-16 {
+      color: @teal !important;
+    }
+    /* general text */
+    --primary: @text !important;
+    --primary-strong: @text !important;
+    --primary-stronger: @text !important;
+    --primary-strongest: @text !important;
+    --secondary: @subtext0 !important;
+    --secondary-strongest-rgb: #rgbify(@text) [];
+    /* chat list typing message */
+    --typing: @green !important;
+    /* background for video player and image viewer */
+    --media-viewer-background: @mantle !important;
+    /* not loaded media */
+    --media-gallery-thumb-background: @crust !important;
+
+    /* Group info/Contact info */
+    --photopicker-overlay-background: fadeout(@mantle, 0.8) !important;
+    --photopicker-overlay-background-rgb: #rgbify(@base) [];
+    --media-viewer-background-rgb: #rgbify(@base) [];
+    --drawer-background-deep: @crust !important;
+    /* group info read more */
+    --input-button-more: @sapphire !important;
+    /* Group info thumbnails border */
+    --chat-info-drawer-thumb-background: @surface2 !important;
+    /* Group admin badge background */
+    --chat-marker-background: @mantle !important;
+    --chat-marker-border: @mantle !important;
+    /* Group admin badge foreground */
+    --chat-marker: @subtext0 !important;
+    /* Media gallery */
+    --drawer-gallery-background: @crust !important;
+    /* mute toggle */
+    --switch-button-checked-color: @accent-color !important;
+    --switch-track-checked-color: @surface2 !important;
+    --switch-track-color: @surface2 !important;
+    --switch-button-color: @overlay1 !important;
+
+    /* danger, block, exit and report buttons */
+    --danger: @red!important;
+
+    /* group added by someone not in contacts */
+    --button-plain-background: @surface0 !important;
+    --button-plain-background-hover: @surface1 !important;
+
+    /* EMOJI AND STICKERS */
+    --panel-input-background: @surface0 !important;
+    --sticker-button-background: @surface1 !important;
+    --active-tab-marker: @accent-color !important;
+
+    /* REACTIONS */
+    --reactions-panel-background-color: @surface0 !important;
+    --reactions-tray-background: @surface0 !important;
+    --reactions-details-background: @surface0 !important;
+    --svg-gray-button: @surface0 !important;
+
+    /* Forward message popup */
+    --panel-background-colored-deeper: @crust !important;
+    --modal-backdrop: fadeout(@mantle, 0.8) !important;
+
+    /* MEDIA EDITOR */
+    /* background for media editor */
+    --panel-background-deeper: @mantle !important;
+    /* message box for media editor */
+    --media-editor-image-caption-input-background: @surface0 !important;
+    /* selected picture in media editor */
+    --media-editor-thumb-border-active: @accent-color !important;
+    /* send button in media editor */
+    --button-round-background: @accent-color !important;
+
+    /* COMPOSE BAR */
+    /* type a message bar and background */
+    --compose-input-background: @surface0 !important;
+    --compose-input-border: @surface1 !important;
+    --compose-panel-background: @mantle !important;
+    --rich-text-panel-background: @mantle !important;
+    /* select messages fixes */
+    --panel-background: @mantle !important;
+    --panel-background-rgb: #rgbify(@mantle) [];
+    --checkbox-background: @accent-color !important;
+    /* quoted message in compose */
+    --popup-panel-background: @surface0 !important;
+    /* use Surface 0 for contrast, other colors don't pass AAA */
+    /* mention list item background */
+    --compose-panel-background-hover: @surface1 !important;
+    /* compose bar icons */
+    --icon: @accent-color !important;
+    /* ATTACH ICONS */
+    /* poll icon */
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(6)
+      > button
+      > span
+      > svg
+      > circle {
+      fill: @green !important;
+    }
+    /* image icon */
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(1)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > path:nth-child(2) {
+      fill: @pink !important;
+    }
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(1)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > path:nth-child(1) {
+      fill: @pink !important;
+      filter: brightness(85%) !important;
+    }
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(1)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > rect {
+      fill: @pink !important;
+      filter: brightness(70%) !important;
+    }
+    /* sticker icon */
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(2)
+      > button
+      > span
+      > svg
+      > g
+      > circle {
+      fill: @blue !important;
+      filter: brightness(85%) !important;
+    }
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(2)
+      > button
+      > span
+      > svg
+      > g
+      > path:nth-child(2) {
+      fill: @blue !important;
+    }
+    /* camera icon */
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(3)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > path:nth-child(1) {
+      fill: @red!important;
+      filter: brightness(85%) !important;
+    }
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(3)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > path:nth-child(2) {
+      fill: @red!important;
+    }
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(3)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > rect {
+      fill: @red!important;
+      filter: brightness(85%) !important;
+    }
+    /* document icon */
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(4)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > path:nth-child(1) {
+      fill: @mauve !important;
+      filter: brightness(85%) !important;
+    }
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(4)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > path:nth-child(2) {
+      fill: @mauve !important;
+    }
+    /* contact icon */
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(5)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > g
+      > path:nth-child(1) {
+      fill: @sky !important;
+      filter: brightness(85%) !important;
+    }
+    div._1OT67
+      > div
+      > span
+      > div
+      > div
+      > ul
+      > li:nth-child(5)
+      > button
+      > span
+      > svg
+      > g:nth-child(1)
+      > g
+      > g
+      > path:nth-child(2) {
+      fill: @sky !important;
+    }
+    /* VOICE MESSAGE SENDING */
+    --ptt-draft-button-send: @accent-color !important;
+    --ptt-draft-waveform-background: @base !important;
+    --ptt-draft-button-stop: @red !important;
+    --ptt-draft-button-stop-hover: @maroon !important;
+
+    /* GENERAL OPTIONS */
+    /* dropdown menus */
+    --dropdown-background: @surface0 !important;
+    --dropdown-background-hover: @surface1 !important;
+
+    /* OTHER SECTIONS */
+    /* profile background */
+    --drawer-background: @base !important;
+    /* communities, new chat, other panes */
+    --panel-background-colored: @mantle !important;
+    --drawer-section-background: @base !important;
+    /* new chat icons */
+    --round-icon-background: @green !important;
+    --inverse: @text !important;
+    /* title and icon for drawers */
+    --drawer-header-title: @text !important;
+    /* buttons such as create community */
+    --button-primary-background: @accent-color !important;
+    --button-primary-background-hover: fadeout(@accent-color, 0.8) !important;
+    /* keyboard shortcuts background */
+    --panel-background-lighter: @mantle !important;
+    /* active input in modals and drawers */
+    --input-border-active: @accent-color !important;
 
     /* Start page drawing */
     #app


### PR DESCRIPTION

## 🔧 What does this fix? 🔧

This splits the flavor variable into light and dark flavors that can be selected independently by the user. The rest of the usercss is also adjusted to change depending on the current WhatsApp Web theme.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
