### PR TITLE
feat(proton): split flavor variable into light and dark

### DIFF
--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -2,20 +2,33 @@
 @name           Proton Catppuccin
 @namespace      github.com/catppuccin/userstyles/styles/proton
 @homepageURL    https://github.com/catppuccin/userstyles/tree/main/styles/proton
-@version        0.1.4
+@version        0.1.5
 @description    Soothing pastel theme for Proton services
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/proton/catppuccin.user.css
 @license        MIT
 
 @preprocessor   less
-@var select flavor "Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select lightFlavor "Light Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red*", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 @-moz-document regexp("https://(account|mail|drive|calendar).proton.me/.*$")
 {
   :root {
-    #catppuccin(@flavor, @accentColor);
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   /* prettier-ignore */
@@ -111,7 +124,7 @@
     .ui-standard {
       #lightenOrDarken(@color, @value) {
         @result: if(
-          @flavor=latte,
+          @lookup=latte,
           lighten(@color, @value),
           darken(@color, @value)
         );


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This splits the flavor variable into light and dark flavors for the Proton userstyle that can be selected independently by the user. It still requires that the user select the correct themes, as explained in the current readme.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
