### PR TITLE
refactor: tutanota -> tuta

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -461,15 +461,15 @@ userstyles:
         > [!NOTE]
         > This theme is designed to be used with the default WebGUI and default theme provided by Syncthing. This does not theme syncthing.net.
       current-maintainers: [*BlankParticle]
-  tutanota:
-    name: Tutanota
+  tuta:
+    name: Tuta
     category: productivity
     color: red
     readme:
-      app-link: "https://tutanota.com/"
+      app-link: "https://tuta.com/"
       usage: |+
         > [!NOTE]
-        > Set Tutanota's built-in theme to either **light** if you're using Latte or **dark** if you're using the others.
+        > Set Tuta's built-in theme to either **light** if you're using Latte or **dark** if you're using the others.
       current-maintainers: [*ryanccn]
   twitch:
     name: Twitch


### PR DESCRIPTION
Tutanota has rebranded as Tuta, therefore we should reflect this change in the userstyles schema.
If you want to learn more about the change:  [https://tuta.com](https://tuta.com)