### PR TITLE
fix(nixos.wiki): fix diff highlighting

### DIFF
--- a/styles/nixos.wiki/catppuccin.user.css
+++ b/styles/nixos.wiki/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name NixOS Wiki Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/nixos.wiki
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/nixos.wiki
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/nixos.wiki/catppuccin.user.css
 @description Soothing pastel theme for NixOS Wiki
 @author Catppuccin

--- a/styles/nixos.wiki/catppuccin.user.css
+++ b/styles/nixos.wiki/catppuccin.user.css
@@ -268,6 +268,22 @@
       .go {
         color: @text;
       }
+      // diff added
+      .gi {
+        color: @green;
+      }
+      // diff removed
+      .gd {
+        color: @red;
+      }
+      // diff header
+      .gh {
+        color: @text;
+      }
+      // diff changes
+      .gu {
+        color: @peach;
+      }
     }
 
     .suggestions {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Adds highlighting for diff codeblocks
Closes #388 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
