### PR TITLE
fix: youtube ambient mode + typo

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.2.7
+@version 3.2.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @description Soothing pastel theme for YouTube
 @author Catppuccin
@@ -230,7 +230,7 @@
       ) !important;
       --yt-spec-verified-badge-background: @overlay0 !important;
       --yt-spec-call-to-action-fadeoutd: fadeout(@sapphire, 0.3) !important;
-      --yt-spec-call-to-action-hover: @accent-color !importantr;
+      --yt-spec-call-to-action-hover: @accent-color !important;
       --yt-spec-brand-button-background-hover: @accent-color !important;
       --yt-spec-brand-link-text-fadeoutd: fadeout(
         @accent-color,
@@ -767,9 +767,9 @@
       padding-left: 8px;
     }
 
-    /* disable ambient mode */
-    #cinematics > div > canvas {
-      visibility: hidden;
+    /* ambient mode */
+    #cinematics {
+      mix-blend-mode: lighten;
     }
 
     /* badges e.g. popular */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes YouTube's Ambient Mode which was creating a weird background. As a solution, I've used `mix-blend-mode: lighten`.
Also removed a typo that was causing an error.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
