### PR TITLE
fix(youtube): sidebar icon colors broke after previous commit

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.2.8
+@version 3.2.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @description Soothing pastel theme for YouTube
 @author Catppuccin
@@ -903,7 +903,7 @@
       }
     }
 
-    ytd-guide-section-renderer.style-scope:nth-child(3),
+    ytd-guide-section-renderer.style-scope:nth-child(3) > div:nth-child(2),
     ytd-guide-section-renderer.style-scope:nth-child(4) > div:nth-child(2) {
       > ytd-guide-entry-renderer:nth-child(1)
         > a:nth-child(1)


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

title

## 🗒 Checklist 🗒
- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
