### PR TITLE
fix(chatgpt): use crust on sidebar

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.0.7
+@version 0.0.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @description Soothing pastel theme for ChatGPT
 @author Catppuccin
@@ -208,7 +208,7 @@
         }
         /* Gradient */
         a[href^="/c/"] .bg-gradient-to-l {
-          --tw-gradient-from: @mantle var(--tw-gradient-from-position);
+          --tw-gradient-from: @crust var(--tw-gradient-from-position);
         }
         &:hover a[href^="/c/"] .bg-gradient-to-l {
           --tw-gradient-from: var(--surface-primary)


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

use crust on sidebar, since it was broken idk

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
