### PR TITLE
feat(google): split flavor variable into light and dark

### DIFF
--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -1216,9 +1216,6 @@
     }
     color: @subtext0;
   }
-  body {
-    #catppuccin(@lightFlavor);
-  }
   @media (prefers-color-scheme: light) {
     body {
       #catppuccin(@lightFlavor);
@@ -1357,9 +1354,6 @@
     .nz9sqb.o07G5 .tX9u1b:active:hover .Rq5Gcb {
       background-color: @surface0;
     }
-  }
-  body {
-    #catppuccin(@lightFlavor);
   }
   @media (prefers-color-scheme: light) {
     body {

--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google
-@version 0.1.1
+@version 0.1.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle
 @description Soothing pastel theme for Google
@@ -10,7 +10,8 @@
 @license MIT
 
 @preprocessor less
-@var select flavor "Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
 ==/UserStyle== */
 
 @-moz-document regexp("^https?://(www\\.|images\\.)?google\\..*")
@@ -1216,7 +1217,17 @@
     color: @subtext0;
   }
   body {
-    #catppuccin(@flavor);
+    #catppuccin(@lightFlavor);
+  }
+  @media (prefers-color-scheme: light) {
+    body {
+      #catppuccin(@lightFlavor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    body {
+      #catppuccin(@darkFlavor);
+    }
   }
 }
 
@@ -1348,7 +1359,17 @@
     }
   }
   body {
-    #catppuccin(@flavor);
+    #catppuccin(@lightFlavor);
+  }
+  @media (prefers-color-scheme: light) {
+    body {
+      #catppuccin(@lightFlavor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    body {
+      #catppuccin(@darkFlavor);
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This splits the flavor variable into light and dark flavors that can be selected independently by the user.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
