### PR TITLE
fix(whatsapp): caption when forwarding media

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.css
+++ b/styles/whatsapp-web/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name WhatsApp Web Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/whatsapp-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/whatsapp-web
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/whatsapp-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awhatsapp-web
 @description Soothing pastel theme for WhatsApp Web
@@ -353,6 +353,10 @@
     /* Forward message popup */
     --panel-background-colored-deeper: @crust !important;
     --modal-backdrop: fadeout(@mantle, 0.8) !important;
+
+    /* Forward media caption */
+    --forward-caption-preview-background: @mantle !important;
+    --forward-caption-preview-content: @crust !important;
 
     /* MEDIA EDITOR */
     /* background for media editor */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

When forwarding media, the text box and surrounding area were using the default colors.
They have been changed to match the theme to mantle for the background, and crust for the text box.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
