### PR TITLE
feat(hacker-news): split flavor variable into light and dark

### DIFF
--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hacker News Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hacker-news
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news
-@version 0.1.1
+@version 0.1.2
 @description Soothing pastel theme for HackerNews
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hacker-news/catppuccin.user.css
@@ -10,7 +10,8 @@
 @license MIT
 
 @preprocessor less
-@var select flavor "Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha*"]
 ==/UserStyle== */
 
 @-moz-document domain("news.ycombinator.com") {
@@ -22,7 +23,12 @@
     @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
   }
 
-  #catppuccin(@flavor);
+  @media (prefers-color-scheme: light) {
+    #catppuccin(@lightFlavor);
+  }
+  @media (prefers-color-scheme: dark) {
+    #catppuccin(@darkFlavor);
+  }
 
   #catppuccin(@lookup) {
     @rosewater: @catppuccin[@@lookup][@rosewater];


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This splits the flavor variable into light and dark flavors that can be selected independently by the user.

## 🗒 Checklist 🗒

- [ ] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
