### PR TITLE
fix(github): start actively theming the contribution calendar

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -332,24 +332,25 @@
     --color-notifications-row-bg: var(--color-canvas-subtle);
     --color-icon-directory: @text;
     --color-checks-step-error-icon: var(--color-scale-red-4);
+
+    --color-user-mention-fg: @accent-color;
+    --color-user-mention-bg: @crust;
+    --color-text-white: @text;
+
     --color-calendar-halloween-graph-day-L1-bg: fadeout(@accent-color, 3);
     --color-calendar-halloween-graph-day-L2-bg: fadeout(@accent-color, 2);
     --color-calendar-halloween-graph-day-L3-bg: @accent-color;
     --color-calendar-halloween-graph-day-L4-bg: @mantle;
-    --color-calendar-graph-day-bg: @surface0;
-    --color-calendar-graph-day-border: transparent;
-    /* These could do with a bit of refining */
-    --color-calendar-graph-day-L1-bg: spin(fade(@green, 40%), 15deg);
-    --color-calendar-graph-day-L2-bg: spin(fade(@green, 60%), 10deg);
-    --color-calendar-graph-day-L3-bg: spin(fade(@green, 80%), 5deg);
-    --color-calendar-graph-day-L4-bg: @green;
-    --color-calendar-graph-day-L1-border: transparent;
-    --color-calendar-graph-day-L2-border: transparent;
-    --color-calendar-graph-day-L3-border: transparent;
-    --color-calendar-graph-day-L4-border: transparent;
-    --color-user-mention-fg: @accent-color;
-    --color-user-mention-bg: @crust;
-    --color-text-white: @text;
+    --color-calendar-graph-day-L1-bg: fadeout(@accent-color, 60%) !important;
+    --color-calendar-graph-day-L2-bg: fadeout(@accent-color, 40%) !important;
+    --color-calendar-graph-day-L3-bg: fadeout(@accent-color, 20%) !important;
+    --color-calendar-graph-day-L4-bg: @accent-color !important;
+    --color-calendar-graph-day-L1-border: transparent !important;
+    --color-calendar-graph-day-L2-border: transparent !important;
+    --color-calendar-graph-day-L3-border: transparent !important;
+    --color-calendar-graph-day-L4-border: transparent !important;
+    --color-calendar-graph-day-border: transparent !important;
+    --color-calendar-graph-day-bg: @surface0 !important;
 
     /* New PR, new branch, fork repository, and commit changes buttons */
     .iRoQzU,
@@ -1140,17 +1141,6 @@
     .react-last-commit-history-group:hover {
       background-color: @base;
       color: @text;
-    }
-    .ContributionCalendar-day {
-      --color-calendar-graph-day-L1-bg: spin(fade(@green, 40%), 15deg);
-      --color-calendar-graph-day-L2-bg: spin(fade(@green, 60%), 10deg);
-      --color-calendar-graph-day-L3-bg: spin(fade(@green, 80%), 5deg);
-      --color-calendar-graph-day-L4-bg: @green;
-      --color-calendar-graph-day-L1-border: transparent;
-      --color-calendar-graph-day-L2-border: transparent;
-      --color-calendar-graph-day-L3-border: transparent;
-      --color-calendar-graph-day-L4-border: transparent;
-      --color-calendar-graph-day-bg: @surface0;
     }
 
     .tooltipped.tooltipped-s rect {

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.3.4
+@version      1.3.5
 @description  Soothing pastel theme for GitHub
 @author       Catppuccin
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

start using actively theming the contrib calander graph

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
