### PR TITLE
fix(stylus): save button border color after changes + toggle buttons …

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stylus Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stylus
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version 1.1.2
+@version 1.1.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astylus
 @description Soothing pastel theme for Stylus
@@ -75,9 +75,13 @@
       --accent-1: @color;
       --accent-2: @color;
       --accent-3: @color;
+      .slider {
+        --color-on: fade(@color, 25%);
+        --color-off: @surface2;
+      }
     }
 
-    .active #filters-stats {
+    .active #filters-stats, .dirty #save-button, .dirty #save-button + button {
       background-color: @color;
       border-color: @color;
       color: @base;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Save button when changes are unsaved:
![image](https://github.com/catppuccin/userstyles/assets/42213155/b25425c0-fbe6-4a22-a0bf-c5e0532f2a2e)

![image](https://github.com/catppuccin/userstyles/assets/42213155/971e1d93-fe6e-4687-a862-005e34fddde4)

![image](https://github.com/catppuccin/userstyles/assets/42213155/8e7eb64d-5c5b-47bc-a3a0-c9b368818e44)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
