### PR TITLE
fix(stylus): make header color less deep to match text

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -199,3 +199,4 @@
     #catppuccin(@darkFlavor, @accentColor);
   }
 }
+// vim:ft=less

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stylus Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stylus
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version 1.1.3
+@version 1.1.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astylus
 @description Soothing pastel theme for Stylus
@@ -74,7 +74,7 @@
       --c100: @base;
       --accent-1: @color;
       --accent-2: @color;
-      --accent-3: @color;
+      --accent-3: fade(@color, 25%);
       .slider {
         --color-on: fade(@color, 25%);
         --color-off: @surface2;
@@ -199,4 +199,3 @@
     #catppuccin(@darkFlavor, @accentColor);
   }
 }
-// vim:ft=less


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

# Original Stylus
![image](https://github.com/catppuccin/userstyles/assets/42213155/0357217b-638e-4c56-abfd-5b121c50b506)

# Before
![image](https://github.com/catppuccin/userstyles/assets/42213155/ad9c0efc-d2cd-425d-ac7c-6b2c23129e34)

# After
![image](https://github.com/catppuccin/userstyles/assets/42213155/cb673d49-7893-4280-a8dc-dd146233646c)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
