### PR TITLE
fix(stylus): color gear icon when installing a userstyle

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stylus Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stylus
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version 1.1.4
+@version 1.1.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astylus
 @description Soothing pastel theme for Stylus
@@ -107,6 +107,9 @@
     }
     .cm-s-default .cm-qualifier {
       color: @peach;
+    }
+    .installed .configure-usercss i {
+      color: @color;
     }
     .cm-s-default .cm-variable-2 {
       color: @sapphire;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/9c7e9fd7-4853-4958-a87f-43856329909a)

![image](https://github.com/catppuccin/userstyles/assets/42213155/281a86a1-cf8d-4200-bcb1-52f8cfe0a7e5)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
