### PR TITLE
refactor: remove jn-sena from pinterest

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -393,7 +393,8 @@ userstyles:
     category: social
     readme:
       app-link: "https://www.pinterest.com"
-      current-maintainers: [*jn-sena]
+      current-maintainers: []
+      past-maintainers: [*jn-sena]
   planet-minecraft:
     name: Planet Minecraft
     category: game

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Pinterest Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pinterest
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pinterest
-@version 1.1.0
+@version 1.1.1
 @description Soothing pastel theme for Pinterest
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pinterest/catppuccin.user.css
@@ -146,6 +146,15 @@
       }
     }
 
+    svg circle[fill="white"] ~ path[fill="#e60023"] {
+      fill: @accentColor !important;
+    }
+
+    div#mweb-unauth-container,
+    div#mainContainer {
+      background-color: @base !important;
+    }
+
     /* Header & Search */
 
     div[data-test-id="header-Header"] div.P_h {
@@ -277,8 +286,9 @@
       }
     }
 
-    div[data-test-id="flashlight-button"] {
-      background-color: @base !important;
+    div[data-test-id="flashlight-button"],
+    div[data-test-id="shop-button"] {
+      background-color: fadeout(@base, 20%) !important;
     }
 
     div[data-test-id="flashlight-dot-style"] {
@@ -323,6 +333,7 @@
     /* Profile */
 
     div[data-test-id="profile-board-card"] div,
+    div#profileBoardsFeed div[data-test-id="board-card"] div,
     div[style="border: 1px solid white; border-radius: 16px;"] {
       border-color: @crust !important;
     }
@@ -512,7 +523,7 @@
       }
     }
 
-    /* About */
+    /* Not logged in */
 
     div[style="height: 200px; background: linear-gradient(rgba(255, 255, 255, 0) 0%, rgb(255, 255, 255) 70%);"] {
       background: linear-gradient(
@@ -521,20 +532,47 @@
       ) !important;
     }
 
-    div[data-layout-shift-boundary-id="PageContainer"] {
+    div#mweb-unauth-container div.HFo.Jea.KS5._he.zI7.iyn.Hsu,
+    div[data-test-id="header"]
+      div[style="background-color: rgba(255, 255, 255, 0.95); height: 100%; width: 100%;"] {
       background-color: @base !important;
-      --color-text-inverse: var(--color-text-light);
     }
+
+    span[data-test-id="terms-of-service"] a {
+      color: @accentColor !important;
+    }
+
+    div[data-test-id="breadcrumbs-list"] div.MIw.Rym.zI7.iyn.Hsu,
+    div[data-test-id="vase-carousel"] div[data-test-id="left-scroll-arrow"] {
+      background-image: linear-gradient(
+        to left,
+        fadeout(@base, 100%),
+        @base
+      ) !important;
+    }
+
+    div[data-test-id="breadcrumbs-list"] div.MIw.p6V.zI7.iyn.Hsu,
+    div[data-test-id="vase-carousel"] div[data-test-id="right-scroll-arrow"] {
+      background-image: linear-gradient(
+        to right,
+        fadeout(@base, 100%),
+        @base
+      ) !important;
+    }
+
+    div[data-test-id="standard-save-button"] span {
+      color: @mantle !important;
+    }
+
+    /* Other */
 
     div[data-test-id="public-beta-page"] {
       --color-text-light: @text;
       --color-background-recommendation-weak: @crust;
     }
 
-    /* Mobile-specific */
-
-    div[data-test-id="board-card"] div {
-      border-color: @crust !important;
+    div[data-layout-shift-boundary-id="PageContainer"] {
+      --color-text-inverse: var(--color-text-light);
     }
   }
 


### PR DESCRIPTION
I am not using Pinterest anymore, and I can't stand even seeing it really.
I am so sorry, but I'd like not to keep maintaining it from now on.

I am hoping that my latest rewrite will be more understandable if someone wants to take on.
I've also fixed some minor issues I've seen so far in this pull request.

Thank you <3

## 🔧 What does this fix? 🔧

* Fixes the unthemed pin, profile pages and the flashlight button while not logged in.
* Fixes the white background in some containers like explore page.
* Color the Pinterest icons which have white outline.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
