### PR TITLE
fix(youtube): history tab title

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.3.0
+@version 3.3.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -628,6 +628,11 @@
     /* exmplation box */
     .explanation-box[correct] * {
       color: @crust !important;
+    }
+
+    /* history tab header */
+    .page-header-view-model-wiz__page-header-title {
+      color: @text;
     }
 
     /* custom likes + anims */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/00fcbd4a-0688-42af-ae34-eed51743cdf8)

![image](https://github.com/catppuccin/userstyles/assets/42213155/642c693c-b3e6-460f-8b51-7d9bf5b4cf86)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
