### PR TITLE
fix(reddit): border colors barely visible

### DIFF
--- a/styles/reddit/catppuccin.user.css
+++ b/styles/reddit/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Reddit Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/reddit
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/reddit
-@version 2.0.3
+@version 2.0.4
 @description Soothing pastel theme for Reddit
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/reddit/catppuccin.user.css
@@ -203,16 +203,16 @@
       --newCommunityTheme-checkbox: @text !important;
       --newCommunityTheme-errorText: @red !important;
       --newCommunityTheme-field: @surface0 !important;
-      --newCommunityTheme-fieldFade: fadeout(@surface1, 80) !important;
+      --newCommunityTheme-fieldFade: fadeout(@surface1, 30) !important;
       --newCommunityTheme-flair: @accent-color !important;
       --newCommunityTheme-highlight: @base !important;
       --newCommunityTheme-inactive: @subtext0 !important;
       --newCommunityTheme-lightText: @text !important;
       --newCommunityTheme-lightTextAlpha75: @subtext1 !important;
-      --newCommunityTheme-line: fadeout(@surface1, 80) !important;
-      --newCommunityTheme-lineShaded80: fadeout(@surface1, 80) !important;
-      --newCommunityTheme-lineShaded90: fadeout(@surface1, 80) !important;
-      --newCommunityTheme-lineShadedNinety: fadeout(@surface1, 80) !important;
+      --newCommunityTheme-line: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-lineShaded80: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-lineShaded90: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-lineShadedNinety: fadeout(@surface1, 30) !important;
       --newCommunityTheme-linkText: @accent-color !important;
       --newCommunityTheme-linkTextAlpha80: @accent-color !important;
       --newCommunityTheme-linkTextShaded80: @accent-color !important;
@@ -253,9 +253,9 @@
       --newCommunityTheme-postError: @red !important;
       --newCommunityTheme-postFlairText: @crust !important;
       --newCommunityTheme-postIcon: @accent-color !important;
-      --newCommunityTheme-postLine: fadeout(@surface1, 80) !important;
-      --newCommunityTheme-postLineShaded80: fadeout(@surface1, 80) !important;
-      --newCommunityTheme-postLineShaded90: fadeout(@surface1, 80) !important;
+      --newCommunityTheme-postLine: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-postLineShaded80: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-postLineShaded90: fadeout(@surface1, 30) !important;
       --newCommunityTheme-postTinted20: @base !important;
       --newCommunityTheme-postTransparent20: @base !important;
       --newCommunityTheme-primaryButtonShadedEighty: @overlay1 !important;
@@ -270,7 +270,7 @@
       --newCommunityTheme-upsell-appleIcon: @subtext1 !important;
       --newCommunityTheme-upsell-ssoButtonBorderColor: fadeout(
         @surface1,
-        80
+        30
       ) !important;
       --newCommunityTheme-upsell-ssoButtonTextColor: @text !important;
       --newCommunityTheme-voteText-base: @subtext0 !important;
@@ -283,14 +283,14 @@
       --newCommunityTheme-widgetColors-appleIcon: @overlay0 !important;
       --newCommunityTheme-widgetColors-lineColor: fadeout(
         @surface1,
-        80
+        30
       ) !important;
 
       /* sidebar widgets */
       --newCommunityTheme-widgetColors-sidebarWidgetBackgroundColor: @mantle !important;
       --newCommunityTheme-widgetColors-sidebarWidgetBorderColor: fadeout(
         @surface1,
-        80
+        30
       ) !important;
       --newCommunityTheme-widgetColors-sidebarWidgetHeaderColor: @crust !important;
       --newCommunityTheme-widgetColors-sidebarWidgetHeaderColorAlpha60: @mantle !important;
@@ -350,10 +350,10 @@
       --newRedditTheme-inactive: @surface0 !important;
       --newRedditTheme-lightText: @text !important;
       --newRedditTheme-lightTextAlpha75: @subtext1 !important;
-      --newRedditTheme-line: fadeout(@surface1, 80) !important;
-      --newRedditTheme-lineShaded80: fadeout(@surface1, 80) !important;
-      --newRedditTheme-lineShaded90: fadeout(@surface1, 80) !important;
-      --newRedditTheme-lineShadedNinety: fadeout(@surface1, 80) !important;
+      --newRedditTheme-line: fadeout(@surface1, 30) !important;
+      --newRedditTheme-lineShaded80: fadeout(@surface1, 30) !important;
+      --newRedditTheme-lineShaded90: fadeout(@surface1, 30) !important;
+      --newRedditTheme-lineShadedNinety: fadeout(@surface1, 30) !important;
 
       /* links */
       --newRedditTheme-linkText: @accent-color !important;
@@ -396,9 +396,9 @@
       --newRedditTheme-postError: @red !important;
       --newRedditTheme-postFlairText: @text !important;
       --newRedditTheme-postIcon: @accent-color !important;
-      --newRedditTheme-postLine: fadeout(@surface1, 80) !important;
-      --newRedditTheme-postLineShaded80: fadeout(@surface1, 80) !important;
-      --newRedditTheme-postLineShaded90: fadeout(@surface1, 80) !important;
+      --newRedditTheme-postLine: fadeout(@surface1, 30) !important;
+      --newRedditTheme-postLineShaded80: fadeout(@surface1, 30) !important;
+      --newRedditTheme-postLineShaded90: fadeout(@surface1, 30) !important;
       --newRedditTheme-postTinted20: @base !important;
       --newRedditTheme-postTransparent20: fadeout(@crust, 20) !important;
       --newRedditTheme-primaryButtonShadedEighty: @surface1 !important;
@@ -423,12 +423,12 @@
       --newRedditTheme-widgetColors-appleIcon: @overlay0 !important;
       --newRedditTheme-widgetColors-lineColor: fadeout(
         @surface1,
-        80
+        30
       ) !important;
       --newRedditTheme-widgetColors-sidebarWidgetBackgroundColor: @mantle !important;
       --newRedditTheme-widgetColors-sidebarWidgetBorderColor: fadeout(
         @surface1,
-        80
+        30
       ) !important;
       --newRedditTheme-widgetColors-sidebarWidgetHeaderColor: @crust !important;
       --newRedditTheme-widgetColors-sidebarWidgetHeaderColorAlpha60: fadeout(
@@ -495,7 +495,7 @@
       --addReaction-backgroundColor: @surface0 !important;
       --addReaction-iconFill: @surface1 !important;
       --boxShadow: fadeout(@crust, 20) !important;
-      --bubble-border: fadeout(@surface1, 80) !important;
+      --bubble-border: fadeout(@surface1, 30) !important;
       --bubble-channelsFilter-background: @crust !important;
       --bubble-channelsFilter-selected: @overlay0 !important;
       --bubble-color: @text !important;
@@ -503,9 +503,9 @@
       --bubbleActions-hover: @surface0 !important;
       --editName: @surface1 !important;
       --layout-body: @mantle !important;
-      --layout-colsBorder: fadeout(@surface1, 80) !important;
-      --layout-controlsBorder: fadeout(@surface1, 80) !important;
-      --layout-dropdown-border: fadeout(@surface1, 80) !important;
+      --layout-colsBorder: fadeout(@surface1, 30) !important;
+      --layout-controlsBorder: fadeout(@surface1, 30) !important;
+      --layout-dropdown-border: fadeout(@surface1, 30) !important;
       --layout-header-counterBg: @red !important;
       --layout-header-counterText: @text !important;
       --layout-overlayBackground: fadeout(@crust, 20) !important;
@@ -517,12 +517,12 @@
       --message-list-item-onlineIndicator: @green !important;
       --message-list-item-ownerBg: @surface1 !important;
       --message-list-item-richItem: @overlay0 !important;
-      --message-list-item-richItemBorder: fadeout(@surface1, 80) !important;
+      --message-list-item-richItemBorder: fadeout(@surface1, 30) !important;
       --message-list-item-white: @text !important;
       --modal-buttonsBackground: @text !important;
       --modal-primaryButtonWarning: @red !important;
       --modal-secondaryButton: @text !important;
-      --newChat-inviteLink-borderColor: fadeout(@surface1, 80) !important;
+      --newChat-inviteLink-borderColor: fadeout(@surface1, 30) !important;
       --overlay-backgroundColor: @mantle !important;
       --overlay-headerColor: @text !important;
       --overlay-inputBackground: @crust !important;
@@ -534,7 +534,7 @@
       --settings-panelBackground: @crust !important;
       --settings-panelItemHoverBackground: @surface0 !important;
       --settings-panelItemSelectedBackground: @surface1 !important;
-      --sidebar-background: fadeout(@surface1, 80) !important;
+      --sidebar-background: fadeout(@surface1, 30) !important;
       --sidebar-basic-background-active: @accent-color !important;
       --sidebar-basic-background-hover: @mantle !important;
       --sidebar-footer-background: @crust !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This has been bothering me ever since the userstyle was updated from Stylus to LESS, compare it

# Old Stylus theme
![image](https://github.com/catppuccin/userstyles/assets/42213155/65ff3ae8-2b25-44b1-a852-4e039995dce0)

# Current LESS theme
![image](https://github.com/catppuccin/userstyles/assets/42213155/40ae2fb3-b93a-4a92-9121-9b8cbbc1ce9f)

# My Fix
![image](https://github.com/catppuccin/userstyles/assets/42213155/9b049cf7-225b-4ffc-bf80-a52cc8c36e6a)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
