### PR TITLE
fix(stylus): userstyle settings header

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stylus Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stylus
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version 1.1.5
+@version 1.1.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astylus
 @description Soothing pastel theme for Stylus
@@ -79,6 +79,10 @@
         --color-on: fade(@color, 25%);
         --color-off: @surface2;
       }
+    }
+    
+    #message-box-title {
+      background: @color;
     }
 
     .active #filters-stats,

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -80,10 +80,6 @@
         --color-off: @surface2;
       }
     }
-    
-    #message-box-title {
-      background: @color;
-    }
 
     .active #filters-stats,
     .dirty #save-button,
@@ -166,7 +162,7 @@
       background: @surface0 !important;
     }
     #message-box-title {
-      color: @base;
+      color: @text;
     }
     .svg-icon:hover {
       fill: @overlay1;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/bfc70ed7-fe61-4446-a715-56936a7bcb12)

![image](https://github.com/catppuccin/userstyles/assets/42213155/2fb54055-5890-4feb-a25d-9357b31465b6)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
