### PR TITLE
fix(youtube): button background when hovering is too light

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.3.2
+@version 3.3.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -221,7 +221,7 @@
       --yt-spec-general-background-b: @base !important;
       --yt-spec-general-background-c: @crust !important;
       --yt-spec-error-background: @base !important;
-      --yt-spec-10-percent-layer: @surface2 !important;
+      --yt-spec-10-percent-layer: @surface0 !important;
       --yt-spec-snackbar-background: @mantle !important;
       --yt-spec-snackbar-background-updated: @mantle !important;
       --yt-spec-badge-chip-background: if(


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/de323f70-64c3-4d4c-b01d-4fac8e4973d9)

![image](https://github.com/catppuccin/userstyles/assets/42213155/0993b731-44de-4284-a582-718beca82c17)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
