### PR TITLE
fix(reddit): post title when opened from notification

### DIFF
--- a/styles/reddit/catppuccin.user.css
+++ b/styles/reddit/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Reddit Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/reddit
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/reddit
-@version 2.0.5
+@version 2.0.6
 @description Soothing pastel theme for Reddit
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/reddit/catppuccin.user.css
@@ -667,7 +667,7 @@
       background: @mantle !important;
       color: @text !important;
     }
-
+    
     /* Tag Color */
     .RESUserTagImage::after {
       color: @accent-color;
@@ -749,6 +749,11 @@
 
     a[aria-label="Home"] > svg:nth-child(2) > g > path {
       fill: @text !important;
+    }
+    
+    /* Post title from notification */
+    h1._eYtD2XCVieq6emjKBH3m {
+      color: @text !important;
     }
 
     /* notification icon */

--- a/styles/reddit/catppuccin.user.css
+++ b/styles/reddit/catppuccin.user.css
@@ -750,7 +750,7 @@
     a[aria-label="Home"] > svg:nth-child(2) > g > path {
       fill: @text !important;
     }
-    
+
     /* Post title from notification */
     h1._eYtD2XCVieq6emjKBH3m {
       color: @text !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/adc4a2e1-4f83-454c-8a4c-275ebe40deb2)

![image](https://github.com/catppuccin/userstyles/assets/42213155/89c55398-55c0-4094-bdcd-27eb4fb874af)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
