### PR TITLE
fix: facebook stuff on log in page

### DIFF
--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.1.5
+@version 0.1.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram
@@ -190,8 +190,15 @@
       color: @accent-color !important;
     }
 
+// Log In With Facebook text
+      ._ab37 {
+          color: @blue;
+      }
+
+      
     // Excluded:
     // - _9ys7, _9_1f, _9ys8 (verified icon)
+   
     [style*='background-image: url("https://static.cdninstagram.com/rsrc.php/v3/y4/r/ewSyA8IItw_.png")'],
         ._9zkj,
         ._a3ds,
@@ -226,7 +233,6 @@
         ._a3ec,
         ._a3ed,
         ._a3ee,
-        ._a04s,
         ._9zlu,
         ._9-yp,
         ._a3ef,


### PR DESCRIPTION


## 🔧 What does this fix? 🔧

<!--
the facebook icon was brokenly themed, so that's removed, also themed the log in with facebook text
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
