### PR TITLE
fix(google): color some more elements

### DIFF
--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google
-@version 0.1.4
+@version 0.1.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle
 @description Soothing pastel theme for Google
@@ -390,7 +390,7 @@
       background-color: fade(@blue, 25%);
       color: @blue;
     }
-    .LHJvCe {
+    .LHJvCe, .vqseUe, .dMCttd {
       color: @subtext0;
     }
     .dG2XIf .xpdbox .yc7KLc {
@@ -405,6 +405,34 @@
     }
     .YrbPuc {
       color: @subtext1;
+    }
+    .y6CIle {
+      background-color: @surface0;
+    }
+    .Yt787, .vDF3Oc.vDF3Oc .R8BTeb {
+      color: @text;
+    }
+    .IDFSOe {
+      background-color: @surface2;
+    }
+    .ffmmcd, .u7yw9 .WeviRb {
+      border-color: @surface1;
+    }
+    .wdQNof {
+      border-color: @surface1;
+      background-color: @base;
+    }
+    .eadHV.Ses7yd {
+      color: @text !important;
+    }
+    .f, .j04ED, .j04ED a, .j04ED a:link, .XaIwc {
+      color: @subtext0 !important;
+    }
+    #_Xg6uZYKGBYCDhbIPvK2s2AI_27 > div:nth-child(3) > g-right-button:nth-child(1) > g-fab:nth-child(1), g-right-button.wgbRNb > g-fab:nth-child(1) {
+      background-color: @crust !important;
+    }
+    .kLhEKe {
+      background-color: @base;
     }
     .S8ee5.CwbYXd {
       color: @text;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/f8424bb9-4664-48d0-b91f-90aad811395f)

![image](https://github.com/catppuccin/userstyles/assets/42213155/6fe24ff4-f1bf-4bb4-baf6-1c3efbc5dfec)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
