### PR TITLE
fix(youtube): color shorts logo triangle

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -985,8 +985,8 @@
     [fill="#FF0000"] {
       fill: @accent-color;
     }
-    
-    ytd-rich-section-renderer.style-scope:nth-child(4) > div:nth-child(1) > ytd-rich-shelf-renderer:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > h2:nth-child(1) > yt-icon:nth-child(1) > yt-icon-shape:nth-child(1) > icon-shape:nth-child(1) > div:nth-child(1) > svg:nth-child(1) > g:nth-child(1) > polygon:nth-child(2) {
+
+    svg > g > polygon[fill="#fff"] {
       fill: @base !important;
     }
 

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -990,7 +990,6 @@
       fill: @base !important;
     }
 
-
     .yt-spec-button-shape-next--call-to-action.yt-spec-button-shape-next--text {
       color: @accent-color;
       &:hover {

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.3.3
+@version 3.3.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -985,6 +985,11 @@
     [fill="#FF0000"] {
       fill: @accent-color;
     }
+    
+    ytd-rich-section-renderer.style-scope:nth-child(4) > div:nth-child(1) > ytd-rich-shelf-renderer:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > h2:nth-child(1) > yt-icon:nth-child(1) > yt-icon-shape:nth-child(1) > icon-shape:nth-child(1) > div:nth-child(1) > svg:nth-child(1) > g:nth-child(1) > polygon:nth-child(2) {
+      fill: @base !important;
+    }
+
 
     .yt-spec-button-shape-next--call-to-action.yt-spec-button-shape-next--text {
       color: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/24a7a3a6-8884-44da-9155-569c6fa73ab3)

![image](https://github.com/catppuccin/userstyles/assets/42213155/07593a15-6486-4eb1-8182-a553c9c182e9)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
