### PR TITLE
fix(syncthing): allow more than two URLs to be specified

### DIFF
--- a/styles/syncthing/catppuccin.user.css
+++ b/styles/syncthing/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Syncthing Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/syncthing
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/syncthing
-@version 0.1.1
+@version 0.1.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/syncthing/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Asyncthing
 @description Soothing pastel theme for Syncthing
@@ -20,7 +20,7 @@
   `replace(<stuff> ," ", "", "g")` is here to remove extra spaces (if any)
 */
 
-@-moz-document regexp(replace(replace(%("https?://(%s)/.*", @urls), ",", "|"), " ", "", "g"))
+@-moz-document regexp(replace(replace(%("https?://(%s)/.*", @urls), ",", "|", "g"), " ", "", "g"))
 {
   /* prettier-ignore */
   @catppuccin: {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the issue of being unable to specify more than two URLs because only the first comma got replaced in the document match regexp.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
