### PR TITLE
ci(lint): assert description, error on missing userstyle

### DIFF
--- a/scripts/lint/metadata.ts
+++ b/scripts/lint/metadata.ts
@@ -7,7 +7,7 @@ import { relative } from "std/path/mod.ts";
 
 import { REPO_ROOT } from "@/deps.ts";
 import { log } from "@/lint/logger.ts";
-import { getUserstylesData } from "@/utils.ts";
+import { formatListOfItems, getUserstylesData } from "@/utils.ts";
 
 export const verifyMetadata = async (
   entry: WalkEntry,
@@ -77,6 +77,13 @@ const assertions = async (userstyle: string) => {
     Deno.exit(1);
   });
 
+  if (!userstyles[userstyle]) {
+    log("Metadata section for this userstyle has not been added", {
+      file: "scripts/userstyles.yml",
+    }, "error");
+    Deno.exit(1);
+  }
+
   return {
     name: `${
       Array.isArray(userstyles[userstyle].name)
@@ -85,6 +92,11 @@ const assertions = async (userstyle: string) => {
     } Catppuccin`,
     namespace: `github.com/catppuccin/userstyles/styles/${userstyle}`,
     author: "Catppuccin",
+    description: `Soothing pastel theme for ${
+      Array.isArray(userstyles[userstyle].name)
+        ? formatListOfItems(userstyles[userstyle].name as string[])
+        : userstyles[userstyle].name
+    }`,
     license: "MIT",
     preprocessor: "less",
     homepageURL: `${prefix}/tree/main/styles/${userstyle}`,

--- a/scripts/lint/metadata.ts
+++ b/scripts/lint/metadata.ts
@@ -40,7 +40,7 @@ export const verifyMetadata = async (
         .findIndex((line) => line.includes(key)) + 1;
 
       const message = sprintf(
-        "Metadata %s should be %s but is %s",
+        'Metadata `%s` should be "%s" but is "%s"',
         color.bold(key),
         color.green(value),
         color.red(String(defacto)),

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -46,12 +46,23 @@ export const getUserstylesData = (): Promise<Userstyles> => {
 
 /**
  * Utility function that formats a list of items into the "x, y, ..., and z" format.
+ * @example
+ * formatListOfItems(['x']); // 'x'
+ * @example
+ * formatListOfItems(['x', 'y']); // 'x and y'
+ * @example
+ * formatListOfItems(['x', 'y', 'z']); // 'x, y, and z'
  */
 export const formatListOfItems = (items: unknown[]): string => {
+  // If there are two items, connect them with an "and".
   if (items.length === 2) return items.join(" and ");
+  // Otherwise, there is either just one item or more than two items.
   return items.reduce((prev, curr, idx, arr) => {
+    // If this is the first item of the items we are looping through, set our initial string to it.
     if (idx === 0) return curr;
+    // If this is the last one, add a comma (Oxford commas are amazing) followed by "and" and the item to the string.
     if (curr === arr.at(-1)) return prev + `, and ${curr}`;
+    // Otherwise, it is some item in the middle of the list and we can just add it as a comma followed by the item to the string.
     return prev + `, ${curr}`;
   }) as string;
 };

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -44,4 +44,16 @@ export const getUserstylesData = (): Promise<Userstyles> => {
   });
 };
 
+/**
+ * Utility function that formats a list of items into the "x, y, ..., and z" format.
+ */
+export const formatListOfItems = (items: unknown[]): string => {
+  if (items.length === 2) return items.join(" and ");
+  return items.reduce((prev, curr, idx, arr) => {
+    if (idx === 0) return curr;
+    if (curr === arr.at(-1)) return prev + `, and ${curr}`;
+    return prev + `, ${curr}`;
+  }) as string;
+};
+
 type Userstyles = SetRequired<UserstylesSchema, "userstyles" | "collaborators">;


### PR DESCRIPTION
Adds linting for the `@description` field. Clarifies a confusing unhandled error we got a little while back if a new userstyle `catppuccin.user.css` file is added but no section is added to `scripts/userstyles.yml`.