### PR TITLE
fix: match description field with userstyle branding

### DIFF
--- a/styles/anilist/catppuccin.user.css
+++ b/styles/anilist/catppuccin.user.css
@@ -3,7 +3,7 @@
 @namespace github.com/catppuccin/userstyles/styles/anilist
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/anilist
 @version 2.1.1
-@description Soothing pastel theme for AniList
+@description Soothing pastel theme for AniList and AniChart
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/anilist/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aanilist

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -5,7 +5,7 @@
 @version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bsky/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Absky
-@description Soothing pastel theme for Bluesky
+@description Soothing pastel theme for Bluesky Social
 @author Catppuccin
 @license MIT
 

--- a/styles/graphite/catppuccin.user.css
+++ b/styles/graphite/catppuccin.user.css
@@ -5,7 +5,7 @@
 @version 0.0.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/graphite/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agraphite
-@description Soothing pastel theme for graphite
+@description Soothing pastel theme for Graphite
 @author Catppuccin
 @license MIT
 

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -3,7 +3,7 @@
 @namespace github.com/catppuccin/userstyles/styles/hacker-news
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news
 @version 0.1.2
-@description Soothing pastel theme for HackerNews
+@description Soothing pastel theme for Hacker News
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hacker-news/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahacker-news

--- a/styles/lingva/catppuccin.user.css
+++ b/styles/lingva/catppuccin.user.css
@@ -5,7 +5,7 @@
 @version 0.0.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/lingva/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Alingva
-@description Soothing pastel theme for linvga
+@description Soothing pastel theme for Lingva
 @author Catppuccin
 @license MIT
 

--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -3,7 +3,7 @@
 @namespace github.com/catppuccin/userstyles/styles/proton
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/proton
 @version 0.1.5
-@description Soothing pastel theme for Proton services
+@description Soothing pastel theme for Proton
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/proton/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aproton

--- a/styles/skiff/catppuccin.user.css
+++ b/styles/skiff/catppuccin.user.css
@@ -5,7 +5,7 @@
 @version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/skiff/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Askiff
-@description Soothing pastel theme for skiff
+@description Soothing pastel theme for Skiff
 @author Catppuccin
 @license MIT
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Follow-up from #469, resolves lint issues discovered by the changes.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
