### PR TITLE
fix(gmail): loading animation

### DIFF
--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Gmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/gmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
-@version 0.1.1
+@version 0.1.2
 @description Soothing pastel theme for Gmail
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gmail/catppuccin.user.css

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -462,10 +462,9 @@
 
     #nlpt {
         background-color: @surface0 !important;
-    }
-
-    #nlpt::before {
-        background-color: @overlay0 !important;
+        ::before {
+            background-color: @overlay0 !important;
+        }
     }
 
     .la-b > .la-l, .la-b > .la-r, .la-b > .la-m {

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -462,7 +462,7 @@
 
     #nlpt {
         background-color: @surface0 !important;
-        ::before {
+        &::before {
             background-color: @overlay0 !important;
         }
     }

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -454,6 +454,45 @@
         background: lighten(@accent-color, 10%) !important;
       }
     }
+
+    /* loading */
+    #explosion_clipper_div > .la-i > div {
+      background: @surface0 !important;
+    }
+
+    #nlpt {
+        background-color: @surface0 !important;
+    }
+
+    #nlpt::before {
+        background-color: @overlay0 !important;
+    }
+
+    .la-b > .la-l, .la-b > .la-r, .la-b > .la-m {
+        background: @surface1 !important;
+    }
+
+    .la-k .la-l, .la-k .la-r {
+        border-color: @base !important;
+    }
+
+    .la-k .la-m {
+        background: @base !important;
+        clip-path: polygon(47% 100%, 100% 47%, 100% 100%);
+    }
+
+    .la-i > .la-l, .la-i > .la-r {
+        border-color: @surface0 !important;
+    }
+
+    .la-i > .la-m {
+        background: @surface0 !important;
+    }
+
+    .msgb {
+        color: @text;
+        a { color: @accent-color !important }
+    }
   }
 }
 // vim:ft=less


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The Gmail loading screen didn't have the correct colors, so I fixed it! :D

Before:
<img width="500" src="https://github.com/catppuccin/userstyles/assets/27358071/b68af385-5b14-48f9-9e1e-950b4d029de2">

After:
<img width="500" src="https://github.com/catppuccin/userstyles/assets/27358071/79b3880e-fae3-43a0-8337-c4fdd32514dd">

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
