### PR TITLE
fix(youtube): checkboxes

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -480,12 +480,21 @@
 
     /* menu items */
     /* checkbox subitem */
-    .ytp-menuitem[aria-checked="true"] .ytp-menuitem-toggle-checkbox {
-      @svg: escape(
-        '<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" version="1.1"><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" fill="@{accent-color}"/></svg>'
-      );
-      background: url("data:image/svg+xml,@{svg}");
+    .ytp-menuitem-toggle-checkbox {
+      background-color: @overlay1;
+
+      &::after {
+        background-color: @subtext0;
+      }
     }
+    .ytp-menuitem[aria-checked="true"] .ytp-menuitem-toggle-checkbox {
+      background-color: @accent-color;
+
+      &::after {
+        background-color: @text;
+      }
+    }
+
     .ytp-menuitem:not([aria-disabled="true"]):hover {
       background: @surface1 !important;
     }

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.3.5
+@version 3.3.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes broken checkboxes in the settings menu of a video.

| Before | After |
| --- | --- |
| ![Screenshot 2024-02-02 at 09 43 03 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/8e32a28d-a1f9-4b8d-8ee8-7627864de65e) | ![Screenshot 2024-02-02 at 09 43 34 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/97ca701a-8928-48f1-9ab6-45b9f0d655b2) |


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
