### PR TITLE
feat(snapchat-web): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -102,7 +102,7 @@ collaborators:
   - &rooot
     name: rooot
     url: https://github.com/RoootTheFox
-  - &itzTheMeow_
+  - &itzTheMeow
     name: Meow
     url: https://github.com/itzTheMeow
 

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -102,6 +102,9 @@ collaborators:
   - &rooot
     name: rooot
     url: https://github.com/RoootTheFox
+  - &itzTheMeow_
+    name: Meow
+    url: https://github.com/itzTheMeow
 
 userstyles:
   advent-of-code:
@@ -518,6 +521,14 @@ userstyles:
         If the theme isn't being applied to your instance, go to the userstyle's **Settings > Custom included sites** and add your instance to the list, for instance, `*://searxng.example.com/*`.
       app-link: "https://github.com/searxng/searxng"
       current-maintainers: [*sekki21956, *ryanccn]
+  snapchat-web:
+    name: Snapchat Web
+    category: messaging
+    icon: snapchat
+    color: yellow
+    readme:
+      app-link: "https://web.snapchat.com"
+      current-maintainers: [*itzTheMeow]
   spotify-web:
     name: Spotify Web
     category: leisure

--- a/styles/snapchat-web/assets/catwalk.webp
+++ b/styles/snapchat-web/assets/catwalk.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef02978328a00292f95ecf9933b519d920f940b0c8df9eba9ae3f59a6b03c6c4
+size 115714

--- a/styles/snapchat-web/assets/frappe.webp
+++ b/styles/snapchat-web/assets/frappe.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6af926760d404f54f7f335aa9372670d0def779f9bf9a8d7f4f804eeb945f982
+size 17714

--- a/styles/snapchat-web/assets/latte.webp
+++ b/styles/snapchat-web/assets/latte.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83a45752d7498600f0e76c3e18db821349c4c3acf65a79ec5223dacd749b8893
+size 18632

--- a/styles/snapchat-web/assets/macchiato.webp
+++ b/styles/snapchat-web/assets/macchiato.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b101ee1562999c23ff0d3cf668263c9c4f4d2b46757f2ed4a7ebf0d000b29d63
+size 18948

--- a/styles/snapchat-web/assets/mocha.webp
+++ b/styles/snapchat-web/assets/mocha.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11ed5df2ae8ec3f2c4397402bf2e4c8130857fbe2b2a910153dad328807dabb0
+size 19108

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -65,6 +65,7 @@
       --sigTextField: @crust;
       --sigDivider: @surface0;
       --sigDividerLight: @surface0;
+      --sigColorBackgroundBorder: @surface0;
       --sigBackgroundPrimary: @base;
       --sigBackgroundSecondary: @mantle;
       --sigBackgroundSecondaryHover: darken(@mantle, 5%);
@@ -87,11 +88,16 @@
       --sigButtonOnError: @base;
       --sigButtonOnNegative: @base;
       --sigButtonOnChatSurfaceCalling: @base;
+      --sigTextPlayer: @crust;
+      --sigButtonGreyHover: darken(@surface0, 5%);
+      --sigButtonGreyActive: darken(@surface0, 8%);
 
       --sigButtonPrimary: @accent-color;
       --sigButtonPrimaryHover: darken(@accent-color, 5%);
+      --sigButtonPrimaryActive: darken(@accent-color, 8%);
       --sigButtonSecondary: @surface0;
       --sigButtonSecondaryHover: @surface1;
+      --sigButtonSecondaryActive: @surface2;
       --sigButtonNegative: @red;
       --sigButtonError: @red;
       --sigButtonErrorHover: darken(@red, 5%);
@@ -101,6 +107,7 @@
       --sigIconCallingHover: darken(@green, 5%);
       --sigChatSurfaceCalling: @green;
       --sigChatSurfaceCallingDisabled: darken(@green, 20%);
+      --sigChatSurfaceCallingHover: darken(@green, 5%);
 
       --sigChat: @blue;
       --sigChatIcon: @blue;
@@ -111,10 +118,29 @@
     // new chat button
     button[title="New Chat"],
     // checkbox to choose camera
-    [id*="downshift-"] a {
+    [id*="downshift-"] a,
+    // checkbox in new chat popup
+    [aria-label="Unselect chosen user"] {
       path[fill="#fff"] {
         fill: @crust;
       }
+      // replaces blue fill
+      path[fill="#51B7FF"] {
+        fill: @accent-color;
+      }
+    }
+
+    // new group button
+    form > div > div > div[role="searchbox"] button {
+      color: @crust;
+      path {
+        fill: @crust;
+      }
+    }
+
+    // buttons when in call
+    [data-projection-id] button {
+      --sigColorAlwaysWhite: @surface0;
     }
   }
 

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -70,6 +70,7 @@
       --sigBackgroundSecondaryHover: darken(@mantle, 5%);
       --sigBackgroundTertiary: @crust;
       --sigBackgroundMessageHover: lighten(@crust, 7%);
+      --sigBackgroundMessageSaved: @surface0;
       --sigOverlay: fade(@overlay0, 0.4);
       --sigOverlayHover: fade(@overlay0, 0.35);
 

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -69,8 +69,9 @@
       --sigBackgroundSecondary: @mantle;
       --sigBackgroundSecondaryHover: darken(@mantle, 5%);
       --sigBackgroundTertiary: @crust;
-      --sigBackgroundMessageHover: lighten(@crust, 7%);
+      --sigBackgroundMessageHover: @surface1;
       --sigBackgroundMessageSaved: @surface0;
+      --sigBackgroundMessageSavedHover: @surface2;
       --sigOverlay: fade(@overlay0, 0.4);
       --sigOverlayHover: fade(@overlay0, 0.35);
 
@@ -106,7 +107,7 @@
       --sigSnapWithSound: @mauve;
     }
 
-    path[fill="#fff"] {
+    button[title="New Chat"] path[fill="#fff"] {
       fill: @crust;
     }
   }

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -74,7 +74,7 @@
       --sigOverlayHover: fade(@overlay0, 0.35);
 
       --sigTextPrimary: @text;
-      --sigButtonOnPrimary: @text;
+      --sigButtonOnPrimary: @crust;
       --sigTextSecondary: @subtext0;
       --sigButtonOnSecondary: @subtext0;
       --sigTextTertiary: @subtext1;
@@ -103,6 +103,10 @@
       --sigChatIcon: @blue;
       --sigSnapWithoutSound: @red;
       --sigSnapWithSound: @mauve;
+    }
+
+    path[fill="#fff"] {
+      fill: @crust;
     }
   }
 

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -108,8 +108,13 @@
       --sigSnapWithSound: @mauve;
     }
 
-    button[title="New Chat"] path[fill="#fff"] {
-      fill: @crust;
+    // new chat button
+    button[title="New Chat"],
+    // checkbox to choose camera
+    [id*="downshift-"] a {
+      path[fill="#fff"] {
+        fill: @crust;
+      }
     }
   }
 

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -74,6 +74,7 @@
       --sigBackgroundMessageSavedHover: @surface2;
       --sigOverlay: fade(@overlay0, 0.4);
       --sigOverlayHover: fade(@overlay0, 0.35);
+      --sigBrandSecondary: @accent-color;
 
       --sigTextPrimary: @text;
       --sigButtonOnPrimary: @crust;

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -1,0 +1,116 @@
+/* ==UserStyle==
+@name Snapchat Web Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/snapchat-web
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/snapchat-web
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/snapchat-web/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Asnapchat-web
+@description Soothing pastel theme for Snapchat Web
+@author Meow
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire*", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain('web.snapchat.com') {
+  /* prettier-ignore */
+  @catppuccin: {
+    @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+    @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+    @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+    @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    /* Snapchat applies the variables (overrides?) to specific elements so we need to apply to every element (with high specificity) to override those. */
+    &,
+    body > main#root * {
+      --sigMain: @base;
+      --sigSurface: @mantle;
+      --sigSurfaceRGB: red(@mantle) green(@mantle) blue(@mantle);
+      --sigAboveSurface: @crust;
+      --sigSurfaceDown: @base;
+      --sigSubscreen: @crust;
+      --sigTextField: @crust;
+      --sigDivider: @surface0;
+      --sigDividerLight: @surface0;
+      --sigBackgroundPrimary: @base;
+      --sigBackgroundSecondary: @mantle;
+      --sigBackgroundSecondaryHover: darken(@mantle, 5%);
+      --sigBackgroundTertiary: @crust;
+      --sigBackgroundMessageHover: lighten(@crust, 7%);
+      --sigOverlay: fade(@overlay0, 0.4);
+      --sigOverlayHover: fade(@overlay0, 0.35);
+
+      --sigTextPrimary: @text;
+      --sigButtonOnPrimary: @text;
+      --sigTextSecondary: @subtext0;
+      --sigButtonOnSecondary: @subtext0;
+      --sigTextTertiary: @subtext1;
+      --sigButtonOnTertiary: @subtext1;
+      --sigTextNegative: @red;
+      --sigButtonOnSuccess: @base;
+      --sigButtonOnError: @base;
+      --sigButtonOnNegative: @base;
+      --sigButtonOnChatSurfaceCalling: @base;
+
+      --sigButtonPrimary: @accent-color;
+      --sigButtonPrimaryHover: darken(@accent-color, 5%);
+      --sigButtonSecondary: @surface0;
+      --sigButtonSecondaryHover: @surface1;
+      --sigButtonNegative: @red;
+      --sigButtonError: @red;
+      --sigButtonErrorHover: darken(@red, 5%);
+      --sigButtonSuccess: @green;
+      --sigButtonSuccessHover: darken(@green, 5%);
+      --sigIconCalling: @green;
+      --sigIconCallingHover: darken(@green, 5%);
+      --sigChatSurfaceCalling: @green;
+      --sigChatSurfaceCallingDisabled: darken(@green, 20%);
+
+      --sigChat: @blue;
+      --sigChatIcon: @blue;
+      --sigSnapWithoutSound: @red;
+      --sigSnapWithSound: @mauve;
+    }
+  }
+
+  :root[theme="dark"] {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+  :root[theme="light"] {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+}
+// vim:ft=less

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -6,7 +6,7 @@
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/snapchat-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Asnapchat-web
 @description Soothing pastel theme for Snapchat Web
-@author Meow
+@author Catppuccin
 @license MIT
 
 @preprocessor less


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for Snapchat Web 🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

Theme for snapchat's web client.
![image](https://github.com/catppuccin/userstyles/assets/50887230/86d40510-5a3f-4b2a-b4a0-096afb6af357)
![image](https://github.com/catppuccin/userstyles/assets/50887230/94fba622-7c64-4a1c-9199-169f576a7ed2)
![image](https://github.com/catppuccin/userstyles/assets/50887230/012bca62-c130-45de-8412-87f577d95e6a)


## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

can't really theme this section (or card) since theres no decent selector
the card is just transparent with a blur effect, background image is generated
![image](https://github.com/catppuccin/userstyles/assets/50887230/e327f1dc-f7dc-45e3-a8fe-e00fe1ccb697)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/src/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - `catppuccin.user.css` - all the CSS for the userstyle, based on the
    template.
  - `assets/mocha.webp`, `assets/macchiato.webp`, `assets/frappe.webp` and
    `assets/latte.webp` - individual screenshots of the themed website, in all 4
    Catppuccin flavors.
  - `catwalk.webp` - image of all individual screenshots stitched together,
    generated via [catwalk](https://github.com/catppuccin/toolbox#-catwalk).
