### PR TITLE
feat(twitter): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -587,6 +587,14 @@ userstyles:
         > [!NOTE]
         > Set Twitch's built-in theme to either **light** if you're using Latte or **dark** if you're using the others.
       current-maintainers: [*gitmuslim, *isabelroses]
+  twitter:
+    name: Twitter
+    category: social
+    color: blue
+    icon: twitter
+    readme:
+      app-link: "https://twitter.com"
+      current-maintainers: [*watatomo]
   vercel:
     name: Vercel
     category: development

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -594,6 +594,9 @@ userstyles:
     icon: twitter
     readme:
       app-link: "https://twitter.com"
+      usage: |+
+        > [!NOTE]
+        > Set Twitter's built-in theme to **Lights out** with the blue accent.
       current-maintainers: [*watatomo]
   vercel:
     name: Vercel

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -596,7 +596,7 @@ userstyles:
       app-link: "https://twitter.com"
       usage: |+
         > [!NOTE]
-        > Set Twitter's built-in theme to **Lights out** with the blue accent.
+        > Set Twitter's built-in theme to **Lights out** with the blue accent. Also requires the [:has()](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) selector.
       current-maintainers: [*watatomo]
   vercel:
     name: Vercel

--- a/styles/twitter/assets/catwalk.webp
+++ b/styles/twitter/assets/catwalk.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac820aa5ac9c3a339c58d9f2aa258544e590a508753d0f48ec66a0c3b50d66f0
+size 302926

--- a/styles/twitter/assets/frappe.webp
+++ b/styles/twitter/assets/frappe.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2b6a30405848a254a41a75de14039945c6871678617aa74bb29fe53374aaa22
+size 145428

--- a/styles/twitter/assets/latte.webp
+++ b/styles/twitter/assets/latte.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e94585f95902bff665a5ac7b081d0493d50ee83e8e79429ce8253835de313753
+size 145834

--- a/styles/twitter/assets/macchiato.webp
+++ b/styles/twitter/assets/macchiato.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9750dff7f3506b1e23a5393feb06b5a4215bff5576119e645256e18ab4b855f
+size 145346

--- a/styles/twitter/assets/mocha.webp
+++ b/styles/twitter/assets/mocha.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2e7c21e1c263f27fe8c9637e8f8ca52ea8760f5cb86ce63a6da7157a9f5e419
+size 148418

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -1,0 +1,1140 @@
+/* ==UserStyle==
+@name           Twitter Catppuccin
+@namespace      github.com/catppuccin/userstyles/styles/twitter
+@homepageURL 	  https://github.com/catppuccin/userstyles/tree/main/styles/twitter
+@version        1.0.0
+@description    Soothing pastel theme for Twitter
+@author         Catppuccin
+@updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/twitter/catppuccin.user.css
+@license 		    MIT
+
+@preprocessor   less
+@var select flavor "Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor  "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue*", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Grey"]
+@var checkbox colorizeLogo "Colorize Logo" 0
+@var checkbox darkenShadows "Darken Shadows on Dark Themes" 1
+==/UserStyle== */
+@-moz-document domain("twitter.com") {
+  #catppuccin(@flavor, @accentColor);
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    // no :has() selector alert
+    @supports not selector(:has(div)) {
+      body::before {
+        position: fixed;
+        top: 0;
+        right: 0;
+        padding: 1rem;
+        margin: 1rem;
+        border-radius: 0.5rem;
+        max-width: 40ch;
+        background-color: @maroon;
+        color: if(@lookup=latte, #fff, @crust);
+        content: "This userstyle relies on the :has() selector. Please enable it by going to about:config and setting layout.css.has-selector.enabled to true.";
+      }
+    }
+
+    // unsupported theme alert pulled from github userstyle
+    // body:not(.LightsOut),
+    // body:not(:has(> div > div > div > h2 > a[style^="color: rgb(29, 155, 240)"])):not(:has([role="button"][style*="background-color: rgb(29, 155, 240)"])) {
+    //    &:not(:has(div[role="progressbar"] circle[style^="stroke: rgb(29, 155, 240)"])):not(:has(#placeholder)) { // pre-loading page. can't seem to figure out how to fully target this so...
+    //        &::after {
+    //            position: fixed;
+    //            top: 0;
+    //            left: 0;
+    //            padding: 1rem;
+    //            margin: 1rem;
+    //            border-radius: 0.5rem;
+    //            max-width: 40ch;
+    //            background-color: @maroon;
+    //            color: if(@lookup=latte, #fff, @crust);
+    //            content: "Unsupported Twitter theme detected! Please switch to the \"Lights out\" background with the blue accent color under Settings > Accessibility, display, and languages > Display.";
+    //            z-index: 9999;
+    //        }
+    //    }
+    // }
+
+    body.LightsOut {
+      --border-color: @surface0;
+      --color: @overlay1;
+      --color-emphasis: @text;
+      --hover-bg-color: @surface0;
+
+      // shadows
+      .r-qo02w8 {
+        @default-shadow: fade(@text, 20%) 0px 0px 15px,
+          fade(@text, 15%) 0px 0px 3px 1px;
+        @latte-shadow: @crust 0px 0px 15px, fade(@crust, 95%) 0px 0px 3px 1px;
+        @black-shadow: rgba(0, 0, 0, 0.4) 0px 0px 15px,
+          rgba(0, 0, 0, 0.35) 0px 0px 3px 1px;
+
+        box-shadow: @default-shadow;
+
+        & when (@darkenShadows = 1) {
+          box-shadow: if(@lookup=latte, @latte-shadow, @black-shadow);
+        }
+      }
+
+      .r-1tbvlxk {
+        @default-shadow: drop-shadow(@text 1px -1px 1px);
+        @latte-shadow: drop-shadow(@crust 1px -1px 1px);
+        @black-shadow: drop-shadow(rgb(0, 0, 0) 1px -1px 1px);
+
+        filter: @default-shadow;
+
+        & when (@darkenShadows = 1) {
+          filter: if(@lookup=latte, @latte-shadow, @black-shadow);
+        }
+      }
+    }
+
+    body,
+    .PageContainer,
+    #placeholder {
+      background-color: @base !important;
+      color: @text;
+    }
+
+    #ScriptLoadFailure span {
+      color: @text;
+    }
+
+    [style*="scrollbar-color: rgb(62, 65, 68) rgb(22, 24, 28)"] {
+      scrollbar-color: @accent-color transparent !important;
+      scrollbar-width: thin;
+    }
+
+    // bg color
+    [data-testid="primaryColumn"],
+    .r-kemksi {
+      background-color: @base;
+    }
+
+    // arrow on account switcher
+    .r-cqee49 {
+      color: @base;
+    }
+
+    // top nav bg color
+    .r-5zmot {
+      background-color: fade(@base, 75%);
+    }
+
+    // element hover (when on base)
+    .r-1hdo0pc,
+    .r-pjtv4k {
+      background-color: fade(@text, 10%);
+    }
+
+    // element active (when on base)
+    .r-11gmi9o {
+      background-color: fade(@text, 20%);
+    }
+
+    .r-1cuuowz {
+      background-color: fade(@text, 3%);
+    }
+
+    // text
+    .r-1nao33i {
+      color: @text;
+    }
+
+    // white text, seems to appear on accent colors
+    .r-jwli3a {
+      color: if(@lookup=latte, #fff, @crust);
+    }
+
+    // borders
+    .r-1kqtdi0,
+    .r-1roi411 {
+      border-color: @surface0;
+    }
+
+    .r-1igl3o0 {
+      border-bottom-color: @surface0;
+    }
+
+    .r-2sztyj {
+      border-top-color: @surface0;
+    }
+
+    // is this post relevant to you?
+    .r-1ccsd61 {
+      border-color: @surface2;
+    }
+
+    .r-gu4em3,
+        .r-1bnu78o,
+        .r-z32n2g, // search bar
+        .r-1m3jxhj {
+      background-color: @surface0;
+    }
+
+    // base color border
+    .r-1xc7w19 {
+      border-color: @base;
+    }
+
+    // active border for dms
+    .r-1pbtemp {
+      border-right-color: @accent-color;
+    }
+
+    // accent color borders
+    .r-vhj8yc {
+      border-color: @accent-color;
+    }
+
+    // magnifying glass in search bar
+    .r-1bwzh9t {
+      color: @overlay1;
+    }
+
+    // right side content
+    .r-g2wdr4 {
+      background-color: @mantle;
+    }
+
+    .r-14wv3jr {
+      border-color: @mantle;
+    }
+
+    // bg color accent
+    .r-l5o3uw {
+      background-color: @accent-color;
+
+      .r-jwli3a {
+        color: if(@lookup=latte, #fff, @crust);
+      }
+    }
+
+    // accent element when hovered
+    .r-1vtznih {
+      background-color: darken(@accent-color, 10%);
+
+      .r-jwli3a {
+        color: if(@lookup=latte, #fff, @crust);
+      }
+    }
+
+    .r-1peqgm7 {
+      background-color: fade(@accent-color, 10%);
+    }
+
+    // accent element when active
+    .r-yuvema {
+      background-color: darken(@accent-color, 15%);
+
+      .r-jwli3a {
+        color: if(@lookup=latte, #fff, @crust);
+      }
+    }
+
+    .r-r18ze4 {
+      background-color: fade(@accent-color, 20%);
+    }
+
+    // white elements when hovered
+    .r-jc7xae {
+      background-color: darken(@text, 4%);
+    }
+
+    // white elements when active
+    .r-6wtuen {
+      background-color: darken(@text, 8%);
+    }
+
+    // new notifications
+    .r-1eltapf {
+      background-color: fade(@sapphire, 10%);
+    }
+
+    // polls
+    .r-eok2q2 {
+      background-color: fade(@accent-color, 60%);
+    }
+
+    // box shadow around active poll input box
+    .r-9cip40 {
+      box-shadow: @accent-color 0 0 0 1px;
+    }
+
+    // spaces
+    .r-1blqq69 {
+      border-color: @mauve;
+    }
+
+    @keyframes r-1wvy3k1 {
+      0% {
+        box-shadow: fade(@mauve, 40%) 0px 0px 0px 0px;
+      }
+
+      100% {
+        box-shadow: fade(@mauve, 0%) 0px 0px 0px 0px;
+      }
+    }
+
+    [style="background-image: linear-gradient(61.63deg, rgb(45, 66, 255) -15.05%, rgb(156, 99, 250) 104.96%);"] {
+      background-image: linear-gradient(
+        61.63deg,
+        @blue -15.05%,
+        @mauve 104.96%
+      ) !important;
+    }
+
+    // tweet textbox placeholder
+    .draftjs-styles_0 .public-DraftEditorPlaceholder-root {
+      color: @overlay0;
+    }
+
+    // who can reply? bg
+    .r-rgqbpe {
+      background-color: fade(@blue, 10%);
+    }
+
+    // circles
+    .r-s224ru {
+      background-color: @green;
+    }
+
+    .r-h7o7i8 {
+      background-color: fade(@green, 10%);
+    }
+
+    // live indicator
+    .r-4nw3r4,
+    .r-1dgebii {
+      background-color: @red;
+    }
+
+    // live border
+    .r-b5kvu3 {
+      border-color: @red;
+    }
+
+    // red transparent bg (appears with "unfollow" hover)
+    .r-qqmkd0 {
+      background-color: fade(@red, 10%);
+    }
+
+    // red bg on hover
+    .r-12d83nn {
+      background-color: darken(@red, 10%);
+    }
+
+    // red bg when active
+    .r-oybae9 {
+      background-color: darken(@red, 15%);
+    }
+
+    .r-11mg6pl {
+      border-color: if(@lookup=latte, #fff, @crust); // white border
+    }
+
+    // mask over layer
+    .r-11z020y {
+      background-color: fade(desaturate(darken(@accent-color, 10%), 50%), 12%);
+    }
+
+    // likes
+    [fill="rgb(249,22,127)"],
+    [fill="rgb(222,45,108)"],
+    g[clip-path="url(#__lottie_element_562)"] path,
+    [style="color: rgb(249, 24, 128);"] [viewBox="0 0 24 24"] path {
+      fill: @red !important;
+    }
+
+    // likes when hover
+    .r-1krxqcr {
+      background-color: fade(@red, 10%);
+    }
+
+    // likes when active
+    .r-uuique {
+      background-color: fade(@red, 20%);
+    }
+
+    // heart svg on notifications page
+    .r-vkub15,
+    .r-9l7dzd {
+      color: @red;
+    }
+
+    // bell svg on notifications page
+    .r-1cvl2hr {
+      color: @accent-color;
+    }
+
+    // retweet svg on notifications page
+    .r-o6sn0f {
+      color: @green;
+    }
+
+    // rt when hover
+    .r-15azkrj {
+      background-color: fade(@green, 10%);
+    }
+
+    // rt when active
+    .r-1x669os {
+      background-color: fade(@green, 20%);
+    }
+
+    // image won't load svg
+    [data-testid="card.wrapper"]
+      [d="M21.04 1.54L17.5 5.09c-.04-.02-.08-.03-.13-.04L14.3 3H9.7l-3 2H5C3.62 5 2.5 6.12 2.5 7.5v11c0 .46.12.88.34 1.25l-1.3 1.29 1.42 1.42 19.5-19.5-1.42-1.42zM13.7 5l2.33 1.56-2 1.99C13.44 8.2 12.74 8 12 8c-2.21 0-4 1.79-4 4 0 .74.2 1.44.55 2.03L4.5 18.09V7.5c0-.28.22-.5.5-.5h2.3l3-2h3.4zM12 10c.18 0 .35.02.52.07l-2.45 2.45c-.05-.17-.07-.34-.07-.52 0-1.1.9-2 2-2zm7 11H7.24l2-2H19c.28 0 .5-.22.5-.5V9h2v9.5c0 1.38-1.12 2.5-2.5 2.5z"] {
+      color: @overlay0;
+    }
+
+    // hard-coded shit
+    // ugly-ass twitter blue/premium bg. why.
+    [style*="https://abs.twimg.com/responsive-web/client-web/background-premiumplus-web"]
+    {
+      background-image: none !important;
+      background-color: @surface0;
+    }
+
+    [stroke="#2F3336" i] {
+      stroke: @surface2 !important;
+    }
+
+    [stroke="#1D9BF0" i],
+    [style*="stroke: rgb(29, 155, 240)"] {
+      stroke: @accent-color !important;
+    }
+
+    [stroke="#FFD400" i] {
+      stroke: @yellow !important;
+    }
+
+    [fill="#829AAB" i] {
+      fill: @overlay2 !important;
+    }
+
+    // "we received your report" svg
+    [fill="#1DA1F2" i] {
+      fill: if(@lookup=latte, darken(@sky, 15%), darken(@sky, 30%)) !important;
+    }
+
+    [fill="#78C6EE" i] {
+      fill: @sky !important;
+    }
+
+    [style*="border-color: rgb(83, 100, 113)"] {
+      border-color: @surface1 !important;
+    }
+
+    [style*="border-color: rgb(103, 7, 15)"] {
+      border-color: fadeout(@red, 50%) !important;
+    }
+
+    [style*="border-color: rgb(29, 155, 240)"] {
+      border-color: @accent-color !important;
+    }
+
+    [style*="color: rgb(231, 233, 234)"]:not(
+        [style*="background-color: rgb(231, 233, 234)"]
+      ),
+    [style*="color: rgb(239, 243, 244)"]:not(
+        [style*="background-color: rgb(239, 243, 244)"]
+      ),
+    [style*="color: rgb(255, 255, 255)"]:not(
+        [style*="background-color: rgb(255, 255, 255)"]
+      ) {
+      color: @text !important;
+    }
+
+    // faded text
+    [style*="color: rgb(113, 118, 123)"]:not(
+        [style*="background-color: rgb(113, 118, 123)"]
+      ) {
+      color: @overlay1 !important;
+    }
+
+    // retweets color
+    [style*="color: rgb(0, 186, 124)"]:not(
+        [style*="background-color: rgb(0, 186, 124)"]
+      ) {
+      color: @green !important;
+    }
+
+    // likes/unfollow color
+    [style*="color: rgb(249, 24, 128)"]:not(
+        [style*="background-color: rgb(249, 24, 128)"]
+      ),
+    [style*="color: rgb(244, 33, 46)"]:not(
+        [style*="background-color: rgb(244, 33, 46)"]
+      ) {
+      color: @red !important;
+    }
+
+    [style*="color: rgb(250, 68, 152)"]:not(
+        [style*="background-color: rgb(250, 68, 152)"]
+      ) {
+      color: @pink !important;
+    }
+
+    // accent color (blue)
+    [style*="color: rgb(29, 155, 240)"]:not(
+        [style*="background-color: rgb(29, 155, 240)"]
+      ) {
+      color: @accent-color !important;
+    }
+
+    // background colors
+    [style*="background-color: rgb(142, 205, 248)"] {
+      background-color: lighten(@accent-color, 10%) !important;
+    }
+
+    [style*="background-color: rgb(2, 17, 61)"] {
+      background-color: fade(@accent-color, 15%) !important;
+    }
+
+    [style*="background-color: rgb(29, 155, 240)"] {
+      background-color: @accent-color !important;
+
+      [style*="color: rgb(255, 255, 255)"] {
+        color: if(@lookup=latte, #fff, @crust) !important;
+      }
+    }
+
+    [style*="background-color: rgb(239, 243, 244)"] {
+      background-color: @text !important;
+
+      [style*="color: rgb(15, 20, 25)"] {
+        color: if(@lookup=latte, #fff, @crust) !important;
+      }
+    }
+
+    [style*="background-color: rgb(244, 33, 46)"] {
+      background-color: @red !important;
+
+      [style*="color: rgb(255, 255, 255)"] {
+        color: if(@lookup=latte, #fff, @crust) !important;
+      }
+    }
+
+    [style*="background-color: rgb(0, 0, 0)"],
+    [style*="background-color: #000"] {
+      background-color: @base !important;
+    }
+
+    [style*="background-color: rgba(15, 20, 25, 0.75)"] {
+      background-color: fade(@crust, 75%) !important;
+
+      [style*="color: rgb(255, 255, 255)"] svg {
+        color: @text !important;
+      }
+    }
+
+    // whatever
+    .r-l5o3uw,
+    .r-1vtznih,
+    .r-4nw3r4,
+    .r-12d83nn,
+    .r-oybae9,
+    .r-yuvema,
+    [style="background-image: linear-gradient(61.63deg, rgb(45, 66, 255) -15.05%, rgb(156, 99, 250) 104.96%);"] {
+      [style*="color: rgb(255, 255, 255)"]:not(
+          [style*="background-color: rgb(255, 255, 255)"]
+        ),
+      &[style*="color: rgb(255, 255, 255)"]:not(
+          [style*="background-color: rgb(255, 255, 255)"]
+        ) {
+        color: if(@lookup=latte, #fff, @crust) !important;
+      }
+    }
+
+    [data-testid="videoComponent"],
+    .r-drfeu3:has(
+        [style="background-color: rgba(255, 255, 255, 0.25); border-color: rgba(0, 0, 0, 0); backdrop-filter: blur(4px);"]
+      ) {
+      [style*="color: rgb(255, 255, 255)"]:not(
+          [style*="background-color: rgb(255, 255, 255)"]
+        ),
+      &[style*="color: rgb(255, 255, 255)"]:not(
+          [style*="background-color: rgb(255, 255, 255)"]
+        ),
+      .r-jwli3a {
+        color: #fff !important;
+      }
+    }
+
+    // options
+    & when (@colorizeLogo = 1) {
+      path[d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"] {
+        fill: @accent-color !important;
+      }
+    }
+  }
+}
+
+@-moz-document domain("api.twitter.com") {
+  #catppuccin(@flavor, @accentColor);
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    html {
+      background: @mantle;
+    }
+
+    #header {
+      color: @subtext0;
+      background: @base;
+      border-bottom-color: @surface1;
+
+      .logo a {
+        border-bottom-color: transparent;
+      }
+
+      #session {
+        a {
+          background: transparent;
+          color: @subtext0;
+        }
+
+        h2 img {
+          border-color: @surface1;
+        }
+      }
+    }
+
+    .footer {
+      background: @mantle;
+      border-top-color: @surface1;
+    }
+
+    .auth h2 {
+      color: @subtext1;
+    }
+
+    .oauth #bd {
+      border-color: @surface1;
+    }
+
+    .app-info h3 img {
+      border-color: @base;
+    }
+
+    .permissions.allow strong {
+      color: @green;
+    }
+
+    .button {
+      background: @overlay0;
+      color: @text;
+      border-color: @surface1;
+
+      &:hover {
+        color: @text;
+        border-color: @surface1;
+        background: darken(@surface2, 10%);
+      }
+    }
+
+    .button.selected,
+    .follow-button .unfollow .button {
+      background-color: @accent-color;
+      color: if(@lookup=latte, #fff, @crust);
+      border-color: darken(@accent-color, 10%);
+
+      &:hover {
+        background-color: darken(@accent-color, 10%);
+      }
+
+      .app-info,
+      #bd h3 {
+        color: @subtext0;
+      }
+
+      #ft {
+        color: @overlay0;
+      }
+    }
+  }
+}
+
+@-moz-document domain("twitter.com") {
+  // idk man
+
+  #catppuccin(@flavor, @accentColor);
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    #session a,
+    #session input,
+    #session button {
+      background: @surface0;
+      color: @subtext0;
+    }
+
+    #session .user-menu {
+      & a:focus,
+      & a:hover,
+      & button:focus,
+      & button:hover,
+      & input:focus,
+      & input:hover {
+        color: if(@lookup=latte, #fff, @crust);
+        background-color: @accent-color;
+      }
+    }
+
+    .notice,
+    .notice p,
+    h2 {
+      color: @subtext1;
+    }
+
+    .notice.error {
+      background: fade(@red, 20%);
+      border-color: fade(@red, 25%);
+    }
+
+    // report page? why isn't this themed
+    .ResponsiveLayout--Night .PageContainer {
+      background-color: @base;
+    }
+
+    .list-explanation {
+      color: @subtext0;
+    }
+
+    .ResponsiveLayout--Night .list-btn {
+      &:first-of-type {
+        border-top-color: @mantle;
+      }
+
+      &:hover {
+        background-color: @mantle;
+      }
+    }
+
+    .submit-btn {
+      background-color: @accent-color;
+      color: if(@lookup=latte, #fff, @crust);
+      border-color: darken(@accent-color, 10%);
+    }
+
+    .submit-btn:hover,
+    .redirect-btn:hover {
+      background-color: @overlay2;
+    }
+
+    .block-btn {
+      color: @maroon;
+      border-color: @maroon;
+    }
+
+    .mute-btn,
+    .unfollow-btn,
+    .email-report-btn {
+      color: @accent-color;
+      border-color: @accent-color;
+    }
+
+    .list-btn {
+      border-color: @surface1;
+
+      &:first-of-type {
+        border-top-color: @surface1;
+      }
+
+      &:hover {
+        background-color: @surface0;
+      }
+    }
+
+    .submit-btn:hover,
+    .redirect-btn:hover {
+      background-color: darken(@accent-color, 10%);
+    }
+
+    // authorize page
+    .js #session .user-menu {
+      background-color: @surface0;
+    }
+
+    .dropdown-caret .caret-outer,
+    .dropdown-caret .caret-inner {
+      border-bottom-color: @surface0;
+    }
+  }
+}
+
+@-moz-document domain("twitter.com") {
+  // TWITTER MEDIA DOWNLOADER
+
+  #catppuccin(@flavor, @accentColor);
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    body[data-nightmode="true"] .twMediaDownloader_media_button button.btn,
+    .twMediaDownloader_media_button button.btn {
+      background-color: @surface0;
+      border-color: @surface2;
+      color: @overlay2;
+
+      &:hover {
+        color: @text;
+        background-color: @surface1;
+        border-color: @overlay1;
+      }
+    }
+
+    .twMediaDownloader_download_button_container {
+      bottom: 0 !important;
+    }
+
+    .twMediaDownloader_download_button {
+      color: @accent-color;
+      text-decoration: none;
+      font-family: "TwitterChirp", "Meiryo", -apple-system, BlinkMacSystemFont,
+        "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-weight: 400;
+      font-size: 12px;
+    }
+
+    #twMediaDownloader_container,
+    #twMediaDownloader_container.night_mode {
+      .btn {
+        background-color: @surface0;
+        color: @text;
+        border-color: @surface1;
+
+        &[disabled] {
+          color: @text;
+          background-color: @surface0;
+          background-image: linear-gradient(@overlay1, @surface0);
+          border-color: @surface1;
+        }
+      }
+
+      .twMediaDownloader_dialog {
+        background: @crust;
+
+        .twMediaDownloader_toolbox {
+          background: @base;
+
+          .range_container {
+            h3 {
+              color: @subtext0;
+            }
+
+            table {
+              color: @text;
+            }
+
+            input {
+              padding: 4px;
+              color: @text;
+
+              &.tweet_id,
+              &.tweet_number {
+                color: @overlay1;
+                background: @mantle;
+                border: solid 1px @surface0;
+              }
+            }
+          }
+
+          .twMediaDownloader_button_container {
+            label {
+              color: @text;
+            }
+          }
+        }
+
+        .twMediaDownloader_status {
+          background: @mantle;
+
+          .twMediaDownloader_log {
+            color: @text;
+            background: @base;
+            border: inset @crust 1px;
+
+            .log-item {
+              text-shadow: unset;
+
+              a.tweet-link {
+                color: @red;
+              }
+
+              a.media-link {
+                color: @blue;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@catppuccin: {
+  @latte: {
+    @rosewater: #dc8a78;
+    @flamingo: #dd7878;
+    @pink: #ea76cb;
+    @mauve: #8839ef;
+    @red: #d20f39;
+    @maroon: #e64553;
+    @peach: #fe640b;
+    @yellow: #df8e1d;
+    @green: #40a02b;
+    @teal: #179299;
+    @sky: #04a5e5;
+    @sapphire: #209fb5;
+    @blue: #1e66f5;
+    @lavender: #7287fd;
+    @text: #4c4f69;
+    @subtext1: #5c5f77;
+    @subtext0: #6c6f85;
+    @overlay2: #7c7f93;
+    @overlay1: #8c8fa1;
+    @overlay0: #9ca0b0;
+    @surface2: #acb0be;
+    @surface1: #bcc0cc;
+    @surface0: #ccd0da;
+    @base: #eff1f5;
+    @mantle: #e6e9ef;
+    @crust: #dce0e8;
+  };
+
+  @frappe: {
+    @rosewater: #f2d5cf;
+    @flamingo: #eebebe;
+    @pink: #f4b8e4;
+    @mauve: #ca9ee6;
+    @red: #e78284;
+    @maroon: #ea999c;
+    @peach: #ef9f76;
+    @yellow: #e5c890;
+    @green: #a6d189;
+    @teal: #81c8be;
+    @sky: #99d1db;
+    @sapphire: #85c1dc;
+    @blue: #8caaee;
+    @lavender: #babbf1;
+    @text: #c6d0f5;
+    @subtext1: #b5bfe2;
+    @subtext0: #a5adce;
+    @overlay2: #949cbb;
+    @overlay1: #838ba7;
+    @overlay0: #737994;
+    @surface2: #626880;
+    @surface1: #51576d;
+    @surface0: #414559;
+    @base: #303446;
+    @mantle: #292c3c;
+    @crust: #232634;
+  };
+
+  @macchiato: {
+    @rosewater: #f4dbd6;
+    @flamingo: #f0c6c6;
+    @pink: #f5bde6;
+    @mauve: #c6a0f6;
+    @red: #ed8796;
+    @maroon: #ee99a0;
+    @peach: #f5a97f;
+    @yellow: #eed49f;
+    @green: #a6da95;
+    @teal: #8bd5ca;
+    @sky: #91d7e3;
+    @sapphire: #7dc4e4;
+    @blue: #8aadf4;
+    @lavender: #b7bdf8;
+    @text: #cad3f5;
+    @subtext1: #b8c0e0;
+    @subtext0: #a5adcb;
+    @overlay2: #939ab7;
+    @overlay1: #8087a2;
+    @overlay0: #6e738d;
+    @surface2: #5b6078;
+    @surface1: #494d64;
+    @surface0: #363a4f;
+    @base: #24273a;
+    @mantle: #1e2030;
+    @crust: #181926;
+  };
+
+  @mocha: {
+    @rosewater: #f5e0dc;
+    @flamingo: #f2cdcd;
+    @pink: #f5c2e7;
+    @mauve: #cba6f7;
+    @red: #f38ba8;
+    @maroon: #eba0ac;
+    @peach: #fab387;
+    @yellow: #f9e2af;
+    @green: #a6e3a1;
+    @teal: #94e2d5;
+    @sky: #89dceb;
+    @sapphire: #74c7ec;
+    @blue: #89b4fa;
+    @lavender: #b4befe;
+    @text: #cdd6f4;
+    @subtext1: #bac2de;
+    @subtext0: #a6adc8;
+    @overlay2: #9399b2;
+    @overlay1: #7f849c;
+    @overlay0: #6c7086;
+    @surface2: #585b70;
+    @surface1: #45475a;
+    @surface0: #313244;
+    @base: #1e1e2e;
+    @mantle: #181825;
+    @crust: #11111b;
+  };
+};
+
+/* template
+@-moz-document domain("twitter.com") {
+    // TITLE
+
+    #catppuccin(@flavor, @accentColor);
+
+    #catppuccin(@lookup, @accent) {
+        @rosewater: @catppuccin[@@lookup][@rosewater];
+        @flamingo: @catppuccin[@@lookup][@flamingo];
+        @pink: @catppuccin[@@lookup][@pink];
+        @mauve: @catppuccin[@@lookup][@mauve];
+        @red: @catppuccin[@@lookup][@red];
+        @maroon: @catppuccin[@@lookup][@maroon];
+        @peach: @catppuccin[@@lookup][@peach];
+        @yellow: @catppuccin[@@lookup][@yellow];
+        @green: @catppuccin[@@lookup][@green];
+        @teal: @catppuccin[@@lookup][@teal];
+        @sky: @catppuccin[@@lookup][@sky];
+        @sapphire: @catppuccin[@@lookup][@sapphire];
+        @blue: @catppuccin[@@lookup][@blue];
+        @lavender: @catppuccin[@@lookup][@lavender];
+        @text: @catppuccin[@@lookup][@text];
+        @subtext1: @catppuccin[@@lookup][@subtext1];
+        @subtext0: @catppuccin[@@lookup][@subtext0];
+        @overlay2: @catppuccin[@@lookup][@overlay2];
+        @overlay1: @catppuccin[@@lookup][@overlay1];
+        @overlay0: @catppuccin[@@lookup][@overlay0];
+        @surface2: @catppuccin[@@lookup][@surface2];
+        @surface1: @catppuccin[@@lookup][@surface1];
+        @surface0: @catppuccin[@@lookup][@surface0];
+        @base: @catppuccin[@@lookup][@base];
+        @mantle: @catppuccin[@@lookup][@mantle];
+        @crust: @catppuccin[@@lookup][@crust];
+        @accent-color: @catppuccin[@@lookup][@@accent];
+
+
+    }
+}
+*/

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -64,7 +64,8 @@
       --hover-bg-color: @surface0;
 
       // shadows
-      .r-qo02w8 {
+      .r-qo02w8,
+      .r-15ce4ve {
         @default-shadow: fade(@text, 20%) 0 0 15px, fade(@text, 15%) 0 0 3px 1px;
         @latte-shadow: @crust 0 0 15px, fade(@crust, 95%) 0 0 3px 1px;
         @black-shadow: rgba(0, 0, 0, 0.4) 0 0 15px,
@@ -423,8 +424,28 @@
       fill: @sky !important;
     }
 
+    // yellow verified badge
+    [stop-color="#f4e72a"],
+    [stop-color="#cd8105"],
+    [stop-color="#cb7b00"],
+    [stop-color="#f4ec26"],
+    [stop-color="#f4e72a"],
+    [stop-color="#f9e87f"],
+    [stop-color="#e2b719"],
+    [stop-color="#e2b719"] {
+      stop-color: @yellow !important;
+    }
+
+    [fill="#d18800"] {
+      fill: @yellow !important;
+    }
+
     [style*="border-color: rgb(83, 100, 113)"] {
       border-color: @surface1 !important;
+    }
+
+    [style*="border-color: rgb(51, 54, 57)"] {
+      border-color: @surface0 !important;
     }
 
     [style*="border-color: rgb(103, 7, 15)"] {

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -91,11 +91,10 @@
 
       // shadows
       .r-qo02w8 {
-        @default-shadow: fade(@text, 20%) 0px 0px 15px,
-          fade(@text, 15%) 0px 0px 3px 1px;
-        @latte-shadow: @crust 0px 0px 15px, fade(@crust, 95%) 0px 0px 3px 1px;
-        @black-shadow: rgba(0, 0, 0, 0.4) 0px 0px 15px,
-          rgba(0, 0, 0, 0.35) 0px 0px 3px 1px;
+        @default-shadow: fade(@text, 20%) 0 0 15px, fade(@text, 15%) 0 0 3px 1px;
+        @latte-shadow: @crust 0 0 15px, fade(@crust, 95%) 0 0 3px 1px;
+        @black-shadow: rgba(0, 0, 0, 0.4) 0 0 15px,
+          rgba(0, 0, 0, 0.35) 0 0 3px 1px;
 
         box-shadow: @default-shadow;
 
@@ -296,11 +295,11 @@
 
     @keyframes r-1wvy3k1 {
       0% {
-        box-shadow: fade(@mauve, 40%) 0px 0px 0px 0px;
+        box-shadow: fade(@mauve, 40%) 0;
       }
 
       100% {
-        box-shadow: fade(@mauve, 0%) 0px 0px 0px 0px;
+        box-shadow: fade(@mauve, 0%) 0;
       }
     }
 

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -10,13 +10,23 @@
 @license 		    MIT
 
 @preprocessor   less
-@var select flavor "Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor  "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue*", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Grey"]
 @var checkbox colorizeLogo "Colorize Logo" 0
 @var checkbox darkenShadows "Darken Shadows on Dark Themes" 1
 ==/UserStyle== */
 @-moz-document domain("twitter.com") {
-  #catppuccin(@flavor, @accentColor);
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
 
   #catppuccin(@lookup, @accent) {
     @rosewater: @catppuccin[@@lookup][@rosewater];
@@ -46,42 +56,6 @@
     @mantle: @catppuccin[@@lookup][@mantle];
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
-
-    // no :has() selector alert
-    @supports not selector(:has(div)) {
-      body::before {
-        position: fixed;
-        top: 0;
-        right: 0;
-        padding: 1rem;
-        margin: 1rem;
-        border-radius: 0.5rem;
-        max-width: 40ch;
-        background-color: @maroon;
-        color: if(@lookup=latte, #fff, @crust);
-        content: "This userstyle relies on the :has() selector. Please enable it by going to about:config and setting layout.css.has-selector.enabled to true.";
-      }
-    }
-
-    // unsupported theme alert pulled from github userstyle
-    // body:not(.LightsOut),
-    // body:not(:has(> div > div > div > h2 > a[style^="color: rgb(29, 155, 240)"])):not(:has([role="button"][style*="background-color: rgb(29, 155, 240)"])) {
-    //    &:not(:has(div[role="progressbar"] circle[style^="stroke: rgb(29, 155, 240)"])):not(:has(#placeholder)) { // pre-loading page. can't seem to figure out how to fully target this so...
-    //        &::after {
-    //            position: fixed;
-    //            top: 0;
-    //            left: 0;
-    //            padding: 1rem;
-    //            margin: 1rem;
-    //            border-radius: 0.5rem;
-    //            max-width: 40ch;
-    //            background-color: @maroon;
-    //            color: if(@lookup=latte, #fff, @crust);
-    //            content: "Unsupported Twitter theme detected! Please switch to the \"Lights out\" background with the blue accent color under Settings > Accessibility, display, and languages > Display.";
-    //            z-index: 9999;
-    //        }
-    //    }
-    // }
 
     body.LightsOut {
       --border-color: @surface0;
@@ -599,7 +573,16 @@
 }
 
 @-moz-document domain("api.twitter.com") {
-  #catppuccin(@flavor, @accentColor);
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
 
   #catppuccin(@lookup, @accent) {
     @rosewater: @catppuccin[@@lookup][@rosewater];
@@ -713,7 +696,16 @@
 @-moz-document domain("twitter.com") {
   // idk man
 
-  #catppuccin(@flavor, @accentColor);
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
 
   #catppuccin(@lookup, @accent) {
     @rosewater: @catppuccin[@@lookup][@rosewater];
@@ -840,160 +832,10 @@
   }
 }
 
+/* prettier-ignore */
 @catppuccin: {
-  @latte: {
-    @rosewater: #dc8a78;
-    @flamingo: #dd7878;
-    @pink: #ea76cb;
-    @mauve: #8839ef;
-    @red: #d20f39;
-    @maroon: #e64553;
-    @peach: #fe640b;
-    @yellow: #df8e1d;
-    @green: #40a02b;
-    @teal: #179299;
-    @sky: #04a5e5;
-    @sapphire: #209fb5;
-    @blue: #1e66f5;
-    @lavender: #7287fd;
-    @text: #4c4f69;
-    @subtext1: #5c5f77;
-    @subtext0: #6c6f85;
-    @overlay2: #7c7f93;
-    @overlay1: #8c8fa1;
-    @overlay0: #9ca0b0;
-    @surface2: #acb0be;
-    @surface1: #bcc0cc;
-    @surface0: #ccd0da;
-    @base: #eff1f5;
-    @mantle: #e6e9ef;
-    @crust: #dce0e8;
-  };
-
-  @frappe: {
-    @rosewater: #f2d5cf;
-    @flamingo: #eebebe;
-    @pink: #f4b8e4;
-    @mauve: #ca9ee6;
-    @red: #e78284;
-    @maroon: #ea999c;
-    @peach: #ef9f76;
-    @yellow: #e5c890;
-    @green: #a6d189;
-    @teal: #81c8be;
-    @sky: #99d1db;
-    @sapphire: #85c1dc;
-    @blue: #8caaee;
-    @lavender: #babbf1;
-    @text: #c6d0f5;
-    @subtext1: #b5bfe2;
-    @subtext0: #a5adce;
-    @overlay2: #949cbb;
-    @overlay1: #838ba7;
-    @overlay0: #737994;
-    @surface2: #626880;
-    @surface1: #51576d;
-    @surface0: #414559;
-    @base: #303446;
-    @mantle: #292c3c;
-    @crust: #232634;
-  };
-
-  @macchiato: {
-    @rosewater: #f4dbd6;
-    @flamingo: #f0c6c6;
-    @pink: #f5bde6;
-    @mauve: #c6a0f6;
-    @red: #ed8796;
-    @maroon: #ee99a0;
-    @peach: #f5a97f;
-    @yellow: #eed49f;
-    @green: #a6da95;
-    @teal: #8bd5ca;
-    @sky: #91d7e3;
-    @sapphire: #7dc4e4;
-    @blue: #8aadf4;
-    @lavender: #b7bdf8;
-    @text: #cad3f5;
-    @subtext1: #b8c0e0;
-    @subtext0: #a5adcb;
-    @overlay2: #939ab7;
-    @overlay1: #8087a2;
-    @overlay0: #6e738d;
-    @surface2: #5b6078;
-    @surface1: #494d64;
-    @surface0: #363a4f;
-    @base: #24273a;
-    @mantle: #1e2030;
-    @crust: #181926;
-  };
-
-  @mocha: {
-    @rosewater: #f5e0dc;
-    @flamingo: #f2cdcd;
-    @pink: #f5c2e7;
-    @mauve: #cba6f7;
-    @red: #f38ba8;
-    @maroon: #eba0ac;
-    @peach: #fab387;
-    @yellow: #f9e2af;
-    @green: #a6e3a1;
-    @teal: #94e2d5;
-    @sky: #89dceb;
-    @sapphire: #74c7ec;
-    @blue: #89b4fa;
-    @lavender: #b4befe;
-    @text: #cdd6f4;
-    @subtext1: #bac2de;
-    @subtext0: #a6adc8;
-    @overlay2: #9399b2;
-    @overlay1: #7f849c;
-    @overlay0: #6c7086;
-    @surface2: #585b70;
-    @surface1: #45475a;
-    @surface0: #313244;
-    @base: #1e1e2e;
-    @mantle: #181825;
-    @crust: #11111b;
-  };
-};
-
-/* template
-@-moz-document domain("twitter.com") {
-    // TITLE
-
-    #catppuccin(@flavor, @accentColor);
-
-    #catppuccin(@lookup, @accent) {
-        @rosewater: @catppuccin[@@lookup][@rosewater];
-        @flamingo: @catppuccin[@@lookup][@flamingo];
-        @pink: @catppuccin[@@lookup][@pink];
-        @mauve: @catppuccin[@@lookup][@mauve];
-        @red: @catppuccin[@@lookup][@red];
-        @maroon: @catppuccin[@@lookup][@maroon];
-        @peach: @catppuccin[@@lookup][@peach];
-        @yellow: @catppuccin[@@lookup][@yellow];
-        @green: @catppuccin[@@lookup][@green];
-        @teal: @catppuccin[@@lookup][@teal];
-        @sky: @catppuccin[@@lookup][@sky];
-        @sapphire: @catppuccin[@@lookup][@sapphire];
-        @blue: @catppuccin[@@lookup][@blue];
-        @lavender: @catppuccin[@@lookup][@lavender];
-        @text: @catppuccin[@@lookup][@text];
-        @subtext1: @catppuccin[@@lookup][@subtext1];
-        @subtext0: @catppuccin[@@lookup][@subtext0];
-        @overlay2: @catppuccin[@@lookup][@overlay2];
-        @overlay1: @catppuccin[@@lookup][@overlay1];
-        @overlay0: @catppuccin[@@lookup][@overlay0];
-        @surface2: @catppuccin[@@lookup][@surface2];
-        @surface1: @catppuccin[@@lookup][@surface1];
-        @surface0: @catppuccin[@@lookup][@surface0];
-        @base: @catppuccin[@@lookup][@base];
-        @mantle: @catppuccin[@@lookup][@mantle];
-        @crust: @catppuccin[@@lookup][@crust];
-        @accent-color: @catppuccin[@@lookup][@@accent];
-
-
-    }
-}
-*/
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+  }

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -6,6 +6,7 @@
 @description    Soothing pastel theme for Twitter
 @author         Catppuccin
 @updateURL      https://github.com/catppuccin/userstyles/raw/main/styles/twitter/catppuccin.user.css
+@supportURL     https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitter
 @license 		    MIT
 
 @preprocessor   less
@@ -801,7 +802,7 @@
 
     .submit-btn:hover,
     .redirect-btn:hover {
-      background-color: @overlay2;
+      background-color: darken(@accent-color, 10%);
     }
 
     .block-btn {
@@ -828,11 +829,6 @@
       }
     }
 
-    .submit-btn:hover,
-    .redirect-btn:hover {
-      background-color: darken(@accent-color, 10%);
-    }
-
     // authorize page
     .js #session .user-menu {
       background-color: @surface0;
@@ -841,142 +837,6 @@
     .dropdown-caret .caret-outer,
     .dropdown-caret .caret-inner {
       border-bottom-color: @surface0;
-    }
-  }
-}
-
-@-moz-document domain("twitter.com") {
-  // TWITTER MEDIA DOWNLOADER
-
-  #catppuccin(@flavor, @accentColor);
-
-  #catppuccin(@lookup, @accent) {
-    @rosewater: @catppuccin[@@lookup][@rosewater];
-    @flamingo: @catppuccin[@@lookup][@flamingo];
-    @pink: @catppuccin[@@lookup][@pink];
-    @mauve: @catppuccin[@@lookup][@mauve];
-    @red: @catppuccin[@@lookup][@red];
-    @maroon: @catppuccin[@@lookup][@maroon];
-    @peach: @catppuccin[@@lookup][@peach];
-    @yellow: @catppuccin[@@lookup][@yellow];
-    @green: @catppuccin[@@lookup][@green];
-    @teal: @catppuccin[@@lookup][@teal];
-    @sky: @catppuccin[@@lookup][@sky];
-    @sapphire: @catppuccin[@@lookup][@sapphire];
-    @blue: @catppuccin[@@lookup][@blue];
-    @lavender: @catppuccin[@@lookup][@lavender];
-    @text: @catppuccin[@@lookup][@text];
-    @subtext1: @catppuccin[@@lookup][@subtext1];
-    @subtext0: @catppuccin[@@lookup][@subtext0];
-    @overlay2: @catppuccin[@@lookup][@overlay2];
-    @overlay1: @catppuccin[@@lookup][@overlay1];
-    @overlay0: @catppuccin[@@lookup][@overlay0];
-    @surface2: @catppuccin[@@lookup][@surface2];
-    @surface1: @catppuccin[@@lookup][@surface1];
-    @surface0: @catppuccin[@@lookup][@surface0];
-    @base: @catppuccin[@@lookup][@base];
-    @mantle: @catppuccin[@@lookup][@mantle];
-    @crust: @catppuccin[@@lookup][@crust];
-    @accent-color: @catppuccin[@@lookup][@@accent];
-
-    body[data-nightmode="true"] .twMediaDownloader_media_button button.btn,
-    .twMediaDownloader_media_button button.btn {
-      background-color: @surface0;
-      border-color: @surface2;
-      color: @overlay2;
-
-      &:hover {
-        color: @text;
-        background-color: @surface1;
-        border-color: @overlay1;
-      }
-    }
-
-    .twMediaDownloader_download_button_container {
-      bottom: 0 !important;
-    }
-
-    .twMediaDownloader_download_button {
-      color: @accent-color;
-      text-decoration: none;
-      font-family: "TwitterChirp", "Meiryo", -apple-system, BlinkMacSystemFont,
-        "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      font-weight: 400;
-      font-size: 12px;
-    }
-
-    #twMediaDownloader_container,
-    #twMediaDownloader_container.night_mode {
-      .btn {
-        background-color: @surface0;
-        color: @text;
-        border-color: @surface1;
-
-        &[disabled] {
-          color: @text;
-          background-color: @surface0;
-          background-image: linear-gradient(@overlay1, @surface0);
-          border-color: @surface1;
-        }
-      }
-
-      .twMediaDownloader_dialog {
-        background: @crust;
-
-        .twMediaDownloader_toolbox {
-          background: @base;
-
-          .range_container {
-            h3 {
-              color: @subtext0;
-            }
-
-            table {
-              color: @text;
-            }
-
-            input {
-              padding: 4px;
-              color: @text;
-
-              &.tweet_id,
-              &.tweet_number {
-                color: @overlay1;
-                background: @mantle;
-                border: solid 1px @surface0;
-              }
-            }
-          }
-
-          .twMediaDownloader_button_container {
-            label {
-              color: @text;
-            }
-          }
-        }
-
-        .twMediaDownloader_status {
-          background: @mantle;
-
-          .twMediaDownloader_log {
-            color: @text;
-            background: @base;
-            border: inset @crust 1px;
-
-            .log-item {
-              text-shadow: unset;
-
-              a.tweet-link {
-                color: @red;
-              }
-
-              a.media-link {
-                color: @blue;
-              }
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -429,9 +429,7 @@
     [stop-color="#cd8105"],
     [stop-color="#cb7b00"],
     [stop-color="#f4ec26"],
-    [stop-color="#f4e72a"],
     [stop-color="#f9e87f"],
-    [stop-color="#e2b719"],
     [stop-color="#e2b719"] {
       stop-color: @yellow !important;
     }

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -167,9 +167,9 @@
     }
 
     .r-gu4em3,
-        .r-1bnu78o,
-        .r-z32n2g, // search bar
-        .r-1m3jxhj {
+    .r-1bnu78o,
+    .r-z32n2g, // search bar
+    .r-1m3jxhj {
       background-color: @surface0;
     }
 
@@ -445,6 +445,13 @@
         [style*="background-color: rgb(255, 255, 255)"]
       ) {
       color: @text !important;
+    }
+
+    [style*="color: rgb(231, 233, 234)"]:not(
+        [style*="background-color: rgb(231, 233, 234)"]
+      )
+      input::placeholder {
+      color: @subtext1 !important;
     }
 
     // faded text


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [Twitter](https://twitter.com) 🎉

Soothing pastel theme for Twitter.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/src/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - `catppuccin.user.css` - all the CSS for the userstyle, based on the
    template.
  - `assets/mocha.webp`, `assets/macchiato.webp`, `assets/frappe.webp` and
    `assets/latte.webp` - individual screenshots of the themed website, in all 4
    Catppuccin flavors.
  - `catwalk.webp` - image of all individual screenshots stitched together,
    generated via [catwalk](https://github.com/catppuccin/toolbox#-catwalk).
