### PR TITLE
fix(bsky): various parts

### DIFF
--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Bluesky Social Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/bsky
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/bsky
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bsky/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Absky
 @description Soothing pastel theme for Bluesky Social

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -61,10 +61,8 @@
     /* generic text */
     [style*="color: rgb(255, 255, 255)"] {
       color: @text !important;
-    }
-    & when (@lookup = latte) {
-      /* fix button text in latte */
-      [style*="color: rgb(255, 255, 255)"] {
+      & when (@lookup = latte) {
+        /* fix button text in latte */
         color: @base !important;
       }
     }
@@ -114,12 +112,12 @@
     [style*="background-color: rgb(0, 0, 0)"],
     [style*="background-color: rgb(8, 10, 12)"] {
       background-color: @base !important;
-    }
 
-    & when (@lookup = latte) {
-      /* fix button colors in latte */
-      [style*="background-color: rgb(0, 0, 0)"] {
-        background-color: @text !important;
+      & when (@lookup = latte) {
+        /* fix button colors in latte */
+        [style*="background-color: rgb(0, 0, 0)"] {
+          background-color: @text !important;
+        }
       }
     }
 
@@ -274,11 +272,8 @@
     path[fill="#ffffff"],
     path[fill="hsl(211, 20%, 100%)"] {
       fill: @text;
-    }
-    & when (@lookup = latte) {
-      /* fix small icons in latte */
-      path[fill="#ffffff"],
-      path[fill="hsl(211, 20%, 100%)"] {
+
+      & when (@lookup = latte) {
         fill: @base;
       }
     }

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -62,6 +62,12 @@
     [style*="color: rgb(255, 255, 255)"] {
       color: @text !important;
     }
+    & when (@lookup = latte) {
+      /* fix button text in latte */
+      [style*="color: rgb(255, 255, 255)"] {
+        color: @base !important;
+      }
+    }
 
     /* secondary text */
     [style*="rgb(163, 178, 194)"] {
@@ -103,9 +109,18 @@
     }
 
     /* generic background color */
+    .css-175oi2r.r-13awgt0,
+    [style*="background-color: rgb(255, 255, 255)"],
     [style*="background-color: rgb(0, 0, 0)"],
     [style*="background-color: rgb(8, 10, 12)"] {
       background-color: @base !important;
+    }
+
+    & when (@lookup = latte) {
+      /* fix button colors in latte */
+      [style*="background-color: rgb(0, 0, 0)"] {
+        background-color: @text !important;
+      }
     }
 
     /* secondary background color */
@@ -260,6 +275,13 @@
     path[fill="hsl(211, 20%, 100%)"] {
       fill: @text;
     }
+    & when (@lookup = latte) {
+      /* fix small icons in latte */
+      path[fill="#ffffff"],
+      path[fill="hsl(211, 20%, 100%)"] {
+        fill: @base;
+      }
+    }
 
     /* more gray small icons (seems to only be the trash can/delete icon) */
     path[fill="#8D8E96"] {
@@ -272,6 +294,7 @@
     }
 
     /* x invite codes available icon */
+    div[style*="background-color: rgb(191, 225, 255)"],
     div[style*="background-color: rgb(1, 37, 97)"] {
       background-color: fadeout(@accent-color, 70%) !important;
       & > svg > path[fill="#52acfe"] {

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -103,6 +103,7 @@
     }
 
     /* generic background color */
+    [style*="background-color: rgb(0, 0, 0)"],
     [style*="background-color: rgb(8, 10, 12)"] {
       background-color: @base !important;
     }
@@ -356,10 +357,11 @@
   }
 
   /* manually set colorscheme */
-  html.colorMode--light {
+  html.theme--light {
     #catppuccin(@lightFlavor, @accentColor);
   }
-  html.colorMode--dark {
+  html.theme--dim,
+  html.theme--dark {
     #catppuccin(@darkFlavor, @accentColor);
   }
 } /* /@-moz-document */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Allows the bluesky theme to apply again after changes to the currently used theme selector

also fixes latte (i hope) by adding selectors for latte-specific things

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
