### PR TITLE
fix(gmail): various unthemed elements

### DIFF
--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Gmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/gmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
-@version 0.1.2
+@version 0.1.3
 @description Soothing pastel theme for Gmail
 @author Catppuccin
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gmail/catppuccin.user.css
@@ -101,10 +101,28 @@
     #loading {
       background: @base !important;
     }
+    [style="background:#4285f4"] {
+      background: @blue !important;
+    }
+    [style="background:#34a853"] {
+      background: @green !important;
+    }
+    [style="background:#ea4335"] {
+      background: @red !important;
+    }
+    .la-c.la-l {
+      background: darken(@red, 10%);
+    }
+    .la-c.la-r {
+      background: @yellow;
+    }
 
     header,
     .nH.w-asV,
-    .bkL {
+    .bkL,
+    .bhZ.bym,
+    .bhZ.bjB,
+    .bhZ.bym.baA {
       background: @crust !important;
     }
 
@@ -242,14 +260,6 @@
     .aKx > .aKz {
       color: @subtext0 !important;
     }
-    /* inbox box badge */
-    .at {
-      color: @crust !important;
-      background: @accent-color !important;
-      .au .av {
-        color: @crust !important;
-      }
-    }
     .y6,
     .bA4 {
       color: @text !important;
@@ -368,6 +378,14 @@
       filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
         hue-rotate(337deg) brightness(300%);
     }
+    .J-N-JX,
+    .J-Ph-hFsbo,
+    .OB,
+    .Q1:not(:checked) + .Vo::before,
+    .SV {
+      filter: invert(1);
+    }
+
     /* svgs */
     .gb_Mc svg,
     .gb_Rc.gb_Vc svg,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes the Gmail logo while loading, themes the left sidebar better, removes theming of labels, themes icons in context menus / drop downs.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
