### PR TITLE
fix(github): tooltip colors accidentally affecting other elements

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.3.6
+@version      1.3.7
 @description  Soothing pastel theme for GitHub
 @author       Catppuccin
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
@@ -423,7 +423,7 @@
 
     /* Tooltip */
     [id^="tooltip-"],
-    .tooltipped,
+    .tooltipped:hover::after,
     span[role="tooltip"]::after {
       --color-fg-on-emphasis: @text !important;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

In #496, additional styling to tooltips was added but one selector wasn't specific enough and in some cases causes the wrong color to be used in the wrong place. This fixes that while also ensuring tooltips are still themed correctly :)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
