### PR TITLE
feat(github): syntax highlighting in codemirror web editor

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.3.7
+@version      1.3.8
 @description  Soothing pastel theme for GitHub
 @author       Catppuccin
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -179,6 +179,16 @@
       --color-codemirror-gutters-bg: @base;
       --color-codemirror-guttermarker-text: @base;
       --color-codemirror-lines-bg: @base;
+      --color-codemirror-guttermarker-subtle-text: @overlay0;
+      --color-codemirror-linenumber-text: @subtext1;
+      --color-codemirror-matchingbracket-text: @text;
+      --color-codemirror-syntax-comment: @overlay0;
+      --color-codemirror-syntax-constant: @blue;
+      --color-codemirror-syntax-entity: @blue;
+      --color-codemirror-syntax-keyword: @pink;
+      --color-codemirror-syntax-storage: @peach;
+      --color-codemirror-syntax-string: @green;
+      --color-codemirror-syntax-variable: @peach;
       --color-checks-bg: @mantle;
       --color-checks-text-primary: @text;
       --color-checks-text-secondary: @subtext1;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Adds syntax highlighting to the web editor. It uses CodeMirror but our own port of that doesn't use the same variables so I sorta winged it based on the existing PrettyLights syntax highlighting.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
