### PR TITLE
fix(github): improve selectors

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -24,23 +24,30 @@
 }
 
 @-moz-document regexp("https:\/\/(gist\.)*github\.com(?!((\/.+?\/.+?\/commit\/[A-Fa-f0-9]+\.(patch|diff)$)|\/home$|\/features($|\/.*)|\/marketplace($|\?.*|\/.*)|\/organizations\/plan)).*$") {
-  :root[data-color-mode="light"],
-  :root[data-color-mode="auto"] > .theme-light {
-    #catppuccin(@lightFlavor, @accentColor);
-  }
   @media (prefers-color-scheme: light) {
-    :root[data-color-mode="auto"] {
+    [data-color-mode="auto"][data-dark-theme="light"],
+    [data-color-mode="light"][data-light-theme="light"],
+    [data-color-mode="dark"][data-dark-theme="light"] {
       #catppuccin(@lightFlavor, @accentColor);
     }
   }
-  :root[data-color-mode="dark"],
-  :root[data-color-mode="auto"] > .theme-dark {
-    #catppuccin(@darkFlavor, @accentColor);
-  }
   @media (prefers-color-scheme: dark) {
-    :root[data-color-mode="auto"] {
+    [data-color-mode="auto"][data-dark-theme="dark"],
+    [data-color-mode="light"][data-light-theme="dark"],
+    [data-color-mode="dark"][data-dark-theme="dark"] {
       #catppuccin(@darkFlavor, @accentColor);
     }
+  }
+
+  [data-color-mode="auto"][data-dark-theme="light"],
+  [data-color-mode="light"][data-light-theme="light"],
+  [data-color-mode="dark"][data-dark-theme="light"] {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+  [data-color-mode="auto"][data-dark-theme="dark"],
+  [data-color-mode="light"][data-light-theme="dark"],
+  [data-color-mode="dark"][data-dark-theme="dark"] {
+    #catppuccin(@darkFlavor, @accentColor);
   }
 
   html:not([data-light-theme="light"]) body:not(.logged-out)::after,

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.3.10
+@version      1.3.11
 @description  Soothing pastel theme for GitHub
 @author       Catppuccin
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Improves the selectors used to match GitHub's, I believe this closes #301 too.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
