### PR TITLE
fix(chatgpt): update theme to match website updates

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.2.0
+@version 0.2.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -112,8 +112,8 @@
 
     color: @text;
 
-    @white: if(@lookup=latte, @base, @text);
-    @black: if(@lookup=latte, @text, @base);
+    @white: lighten(if(@lookup=latte, @base, @text), 10%);
+    @black: darken(if(@lookup=latte, @text, @base), 10%);
     --white: @white;
     --black: @black;
 
@@ -127,9 +127,8 @@
       --gray-600: @overlay0;
       --gray-700: @surface2;
       --gray-800: @surface1;
-      --gray-850: @surface0;
-      --gray-900: @base;
-      --gray-950: @mantle;
+      --gray-900: @surface0;
+      --gray-950: @base;
       --brand-purple: @accent-color;
     }
     & when (@lookup = latte) {
@@ -142,9 +141,8 @@
       --gray-600: @overlay1;
       --gray-700: @overlay2;
       --gray-800: @subtext0;
-      --gray-850: @subtext1;
-      --gray-900: @text;
-      --gray-950: darken(mix(@text, @subtext0), 5%);
+      --gray-900: @subtext1;
+      --gray-950: @text;
       --brand-purple: @accent-color;
     }
 
@@ -283,12 +281,6 @@
       --tw-ring-color: lighten(@red, 10%) !important;
     }
 
-    .btn-neutral {
-      background-color: @base;
-      border-color: @surface0;
-      color: @text;
-    }
-
     .btn-neutral.focus-visible {
       --tw-ring-color: @overlay0 !important;
     }
@@ -332,31 +324,31 @@
     }
 
     .border-gray-100 {
-      border-color: @text;
+      border-color: var(--gray-100);
     }
 
     .border-gray-200 {
-      border-color: @subtext1;
+      border-color: var(--gray-200);
     }
 
     .border-gray-300 {
-      border-color: @subtext1;
+      border-color: var(--gray-300);
     }
 
     .border-gray-400 {
-      border-color: @subtext0;
+      border-color: var(--gray-400);
     }
 
     .border-gray-500 {
-      border-color: @overlay2;
+      border-color: var(--gray-500);
     }
 
     .border-gray-700 {
-      border-color: @surface0;
+      border-color: var(--gray-700);
     }
 
     .border-gray-950 {
-      border-color: @crust;
+      border-color: var(--gray-950);
     }
 
     .border-green-500 {
@@ -380,11 +372,11 @@
     }
 
     .border-white {
-      border-color: @base;
+      border-color: @white;
     }
 
     .border-white\/20 {
-      border-color: fade(@base, 20%);
+      border-color: fade(@white, 20%);
     }
 
     .border-t-[\#0077FF] {
@@ -398,7 +390,7 @@
     }
 
     .\!bg-gray-200 {
-      background-color: @subtext1 !important;
+      background-color: var(--gray-200) !important;
     }
 
     .bg-[\#0077FF],
@@ -526,39 +518,39 @@
     }
 
     .bg-gray-100 {
-      background-color: @text;
+      background-color: var(--gray-100);
     }
 
     .bg-gray-200 {
-      background-color: lighten(@subtext1, 10%);
+      background-color: var(--gray-200);
     }
 
     .bg-gray-300 {
-      background-color: @subtext1;
+      background-color: var(--gray-300);
     }
 
     .bg-gray-400 {
-      background-color: @subtext0;
+      background-color: var(--gray-400);
     }
 
     .bg-gray-50 {
-      background-color: @text;
+      background-color: var(--gray-50);
     }
 
     .bg-gray-500 {
-      background-color: @overlay2;
+      background-color: var(--gray-500);
     }
 
     .bg-gray-600 {
-      background-color: @overlay0;
+      background-color: var(--gray-600);
     }
 
     .bg-gray-700 {
-      background-color: @surface0;
+      background-color: var(--gray-700);
     }
 
     .bg-gray-900 {
-      background-color: @base;
+      background-color: var(--gray-900);
     }
 
     .bg-gray-950 {
@@ -720,35 +712,35 @@
     }
 
     .text-gray-100 {
-      color: @text;
+      color: var(--gray-100);
     }
 
     .text-gray-300 {
-      color: @surface2;
+      color: var(--gray-300);
     }
 
     .text-gray-400 {
-      color: @subtext0;
+      color: var(--gray-400);
     }
 
     .text-gray-500 {
-      color: @overlay2;
+      color: var(--gray-500);
     }
 
     .text-gray-600 {
-      color: @overlay0;
+      color: var(--gray-600);
     }
 
     .text-gray-700 {
-      color: @surface1;
+      color: var(--gray-700);
     }
 
     .text-gray-800 {
-      color: @surface0;
+      color: var(--gray-800);
     }
 
     .text-gray-900 {
-      color: @crust;
+      color: var(--gray-900);
     }
 
     .text-green-500 {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The ChatGPT interface was updated today and these changes fix the issues that arose because of that (mostly just meant we can remove some extra classes and use variables more). I've spent a little time testing out various parts and it looks all set to me.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
