### PR TITLE
fix(github): various unthemed elements

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.3.11
+@version      1.3.12
 @description  Soothing pastel theme for GitHub
 @author       Catppuccin
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -363,6 +363,8 @@
     --color-segmented-control-button-hover-bg: @surface0;
     --color-segmented-control-button-active-bg: @mantle;
     --color-segmented-control-button-selected-border: @overlay0;
+    --color-social-reaction-bg-hover: @surface0;
+    --color-social-reaction-bg-reacted-hover: fade(@accent-color, 30%);
 
     /* Other */
     --rgh-heat-color: @red;
@@ -421,6 +423,9 @@
     .notifications-list .Box-header {
       box-shadow: none;
     }
+    .turbo-progress-bar {
+      background: @accent-color;
+    }
 
     /* Currently selected "tab" */
     .gcnonJ::after,
@@ -430,7 +435,7 @@
 
     /* Tooltip */
     [id^="tooltip-"],
-    .tooltipped:hover::after,
+    .tooltipped::after,
     span[role="tooltip"]::after {
       --color-fg-on-emphasis: @text !important;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes upvotes and downvotes in discussions (L366-L367), the progress bar at the top of the screen when loading (L426-L428), more tooltips (L433).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
