### PR TITLE
fix(chatgpt): light flavor on dark theme and v.v

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -112,8 +112,8 @@
 
     color: @text;
 
-    @white: lighten(if(@lookup=latte, @base, @text), 10%);
-    @black: darken(if(@lookup=latte, @text, @base), 10%);
+    @white: lighten(if(@lookup=latte, @base, @text), 5%);
+    @black: darken(if(@lookup=latte, @text, @base), 5%);
     --white: @white;
     --black: @black;
 
@@ -130,6 +130,27 @@
       --gray-900: @surface0;
       --gray-950: @base;
       --brand-purple: @accent-color;
+      --text-primary: var(--gray-100);
+      --text-secondary: var(--gray-300);
+      --text-tertiary: var(--gray-500);
+      --text-quaternary: var(--gray-700);
+      --main-surface-primary: var(--gray-800);
+      --main-surface-secondary: var(--gray-700);
+      --main-surface-tertiary: var(--gray-600);
+      --sidebar-surface-primary: var(--gray-900);
+      --sidebar-surface-secondary: var(--gray-800);
+      --sidebar-surface-tertiary: var(--gray-700);
+      .popover,
+      .dark .popover,
+      .dark.popover,
+      .popover .dark {
+        --main-surface-primary: var(--gray-700) !important;
+        --main-surface-secondary: var(--gray-600) !important;
+        --main-surface-tertiary: var(--gray-500) !important;
+        --text-primary: var(--white) !important;
+        --text-secondary: var(--gray-200) !important;
+        --text-tertiary: var(--gray-300) !important;
+      }
     }
     & when (@lookup = latte) {
       --gray-50: @mantle;
@@ -144,6 +165,27 @@
       --gray-900: @subtext1;
       --gray-950: @text;
       --brand-purple: @accent-color;
+      --text-primary: var(--gray-950);
+      --text-secondary: var(--gray-600);
+      --text-tertiary: var(--gray-500);
+      --text-quaternary: var(--gray-300);
+      --main-surface-primary: var(--white);
+      --main-surface-secondary: var(--gray-50);
+      --main-surface-tertiary: var(--gray-100);
+      --sidebar-surface-primary: var(--gray-50);
+      --sidebar-surface-secondary: var(--gray-100);
+      --sidebar-surface-tertiary: var(--gray-100);
+      .popover,
+      .dark .popover,
+      .dark.popover,
+      .popover .dark {
+        --main-surface-primary: var(--white) !important;
+        --main-surface-secondary: var(--gray-100) !important;
+        --main-surface-tertiary: var(--gray-200) !important;
+        --text-primary: var(--gray-950) !important;
+        --text-secondary: var(--gray-600) !important;
+        --text-tertiary: var(--gray-500) !important;
+      }
     }
 
     --border-light: fade(@text, 10%);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes light flavors not working on ChatGPT's dark mode (and dark flavors not working on ChatGPT's light mode).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
