### PR TITLE
fix(youtube): icon colors, search input placeholder

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -154,7 +154,7 @@
       --yt-spec-call-to-action-inverse: @accent-color !important;
       --yt-spec-suggested-action: fadeout(@accent-color, 80%) !important;
       --yt-spec-suggested-action-inverse: @text !important;
-      --yt-spec-icon-active-other: @overlay0 !important;
+      --yt-spec-icon-active-other: @text !important;
       --yt-spec-button-chip-background-hover: @surface1 !important;
       --yt-spec-touch-response: @surface0 !important;
 
@@ -264,7 +264,7 @@
       --ytd-searchbox-text-color: @text !important;
 
       /* System icons */
-      --yt-spec-icon-inactive: @overlay0 !important;
+      --yt-spec-icon-inactive: @text !important;
       --yt-spec-icon-disabled: @overlay1 !important;
       --yt-spec-brand-icon-inactive: @overlay2 !important;
 
@@ -575,6 +575,11 @@
     /* private video warning */
     .WARNING.yt-alert-renderer {
       background-color: @yellow;
+    }
+      
+    /* search input placeholder */
+    #search-input.ytd-searchbox-spt #search::placeholder {
+      color: @overlay0;
     }
 
     /* search results */

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.3.8
+@version 3.3.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes some icons to be `@text` instead of `@overlay0` since it implies a state difference which is not there (I checked how the same icons appeared without the theme to be sure). I also themed the search bar placeholder text.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
