### PR TITLE
fix(stylus): button default & hover

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stylus Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stylus
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version 1.1.8
+@version 1.1.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astylus
 @description Soothing pastel theme for Stylus
@@ -171,6 +171,10 @@
     button {
       color: @text !important;
       background: @mantle !important;
+      border: 1px solid @surface0;
+      &:hover {
+        border: 1px solid @text;
+      }
     }
     #save-button[disabled] {
       background: @surface0 !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

### Before
![image](https://github.com/catppuccin/userstyles/assets/42213155/668f11db-bcc1-45fa-8eee-a25b98b4130e)

### After
![image](https://github.com/catppuccin/userstyles/assets/42213155/a726db7d-368a-49ce-b2fb-d2fbddb0a2cc)

![image](https://github.com/catppuccin/userstyles/assets/42213155/efb75cdf-71a7-45ae-828a-1d4f3cc055c1)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
