### PR TITLE
fix(youtube): description color (when not exapnded)

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.4.0
+@version 3.4.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -707,6 +707,9 @@
     yt-attributed-string.ytd-text-inline-expander:nth-child(1)
       > span:nth-child(1)
       > span:nth-child(1) {
+      color: @text !important;
+    }
+    #attributed-snippet-text > span:nth-child(1) > span:nth-child(1) {
       color: @text !important;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

previous PR I made fixed the description color when the desc is expanded, this fixes it when it's not.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
