### PR TITLE
fix: added 0.0.0.0 as a valid syncthing domain

### DIFF
--- a/styles/syncthing/catppuccin.user.css
+++ b/styles/syncthing/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Syncthing Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/syncthing
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/syncthing
-@version 0.1.2
+@version 0.1.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/syncthing/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Asyncthing
 @description Soothing pastel theme for Syncthing
@@ -13,7 +13,7 @@
 @var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire*", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
-@var text urls "URL(s) for Syncthing" "127\.0\.0\.1\:8384,localhost\:8384"
+@var text urls "URL(s) for Syncthing" "127\.0\.0\.1\:8384,0\.0\.0\.0\:8384,localhost\:8384"
 ==/UserStyle== */
 
 /*


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Adds 0.0.0.0 as a valid domain for syncthing (only 127.0.0.1 and localhost worked previously)
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
