### PR TITLE
docs(README.md): move all userstyles instructions to release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,7 @@ Install [Stylus](https://github.com/openstyles/stylus) for your chosen browser.
 
 ### All Userstyles
 
-1. Download [the Stylus export](https://github.com/catppuccin/userstyles/releases/download/all-userstyles-export/import.json).
-2. Open the Stylus "manage" page.
-3. Locate backup (on the left bar) and select import.
-   - Select the downloaded file.
-4. Enjoy!
+See the [release page](https://github.com/catppuccin/userstyles/releases/tag/all-userstyles-export).
 
 ### Individual Userstyles
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Install [Stylus](https://github.com/openstyles/stylus) for your chosen browser.
 
 ### All Userstyles
 
-See the [release page](https://github.com/catppuccin/userstyles/releases/tag/all-userstyles-export).
+See instructions on the [GitHub release page](https://github.com/catppuccin/userstyles/releases/tag/all-userstyles-export).
 
 ### Individual Userstyles
 


### PR DESCRIPTION
Once this is merged we should update the release page by adding the following steps instead of the link to the main README:

```md
This is a rolling release that holds builds generated by the GitHub Actions build process. 

### Usage instructions

1. Download the `import.json` file from the "Assets" section below.

> [!TIP]
> If you want more control over what is included in the `import.json` file, e.g. all userstyles with the accent color `mauve`, see "[All Userstyles Import Generator](https://aui.ctp.uncenter.dev/)" by @uncenter.

3. Open the Stylus "manage" page.
4. Locate backup (on the left bar) and select import.
   - Select the downloaded file.
5. Enjoy!
```

<details>
	<summary>Preview</summary>

![Screenshot 2024-02-20 at 16 06 59 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/e528c41e-361c-49e3-a220-e05c28a42079)

</details>