### PR TITLE
fix(perplexity): ai labs chat backgrounds and other things

### DIFF
--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Perplexity Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/perplexity
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/perplexity
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/perplexity/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aperplexity
 @description Soothing pastel theme for Perplexity
@@ -221,6 +221,21 @@
     :is(:where(.dark) .dark\:text-textOffDark) {
       color: @subtext0;
     }
+
+    // PPLX labs chat
+
+		#__next > main > div > div > div.grow {
+			background: @base;
+		}
+		.dark .dark\:divide-borderMainDark\/80>:not([hidden])~:not([hidden]){
+			border-color: @surface1;
+		}
+		.dark .dark\:outline-superDark{
+			outline-color: @accent-color;
+		}
+		.text-super{
+			color: @accent-color;
+		}
 
     // prose
     .prose,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This fixes the borders, container background, and icons for the lab ai chat site.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
