### PR TITLE
fix: bring ruby back as a past maintainer

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -549,7 +549,7 @@ userstyles:
     readme:
       app-link: "https://reddit.com"
       current-maintainers: []
-      past-maintainers: [*jayylmao]
+      past-maintainers: [*jayylmao, *rubyowo]
   searxng:
     name: SearXNG
     category: search_engine


### PR DESCRIPTION
Once upon a time... ruby was wrongfully removed a past maintainer of the reddit userstyle.
This PR aims to fix that mistake.