### PR TITLE
fix(migadu-webmail): compose message modal, buttons

### DIFF
--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -120,17 +120,41 @@
     --btn-clr: @text;
     --btn-border-clr: @overlay0;
 
+    .btn.btn-success {
+      &,
+      [class^="icon-"] {
+        color: @green !important;
+      }
+      background-color: fade(@green, 20%);
+      &:hover,
+      &:active {
+        background-color: fade(@green, 40%);
+      }
+    }
+    .btn.btn-warning {
+      &,
+      [class^="icon-"] {
+        color: @yellow !important;
+      }
+      background-color: fade(@yellow, 20%);
+      &:hover,
+      &:active {
+        background-color: fade(@yellow, 40%);
+      }
+    }
+    .btn.btn-danger {
+      &,
+      [class^="icon-"] {
+        color: @red !important;
+      }
+      background-color: fade(@red, 20%);
+      &:hover,
+      &:active {
+        background-color: fade(@red, 40%);
+      }
+    }
     .btn.disabled {
       color: @surface0;
-    }
-    .btn.btn-success:hover,
-    .btn.btn-success:active {
-      background-color: desaturate(lighten(fade(@green, 40%), 10%), 10%);
-    }
-    .btn.btn-success,
-    .btn.btn-success [class*=" icon-"],
-    .btn.btn-success [class^="icon-"] {
-      color: @green;
     }
     .btn.disabled.fontastic,
     .btn.disabled .fontastic {
@@ -144,6 +168,9 @@
       border-color: @surface0 !important;
       text-shadow: none !important;
       background-color: @base;
+    }
+    .btn:hover {
+      background-color: @mantle;
     }
 
     /* Links */
@@ -236,12 +263,6 @@
     }
     /* stylelint-enable property-disallowed-list */
 
-    #V-PopupsCompose header .close,
-    #V-PopupsCompose header .minimize-custom {
-      color: @surface2;
-      border-color: @surface0;
-    }
-
     /* Nothing selected */
     .messageView .b-message-view-desc,
     #V-PopupsContacts .b-view-content .b-contact-view-desc {
@@ -282,16 +303,6 @@
     .messageListItem.hasFlaggedSubMessage .flagParent::after,
     .messageListItem.msgflag-\\flagged .flagParent::after {
       color: @orange;
-    }
-    .btn.btn-danger,
-    .btn.btn-info,
-    .btn.btn-inverse,
-    .btn.btn-primary,
-    .btn.btn-success,
-    .btn.btn-warning,
-    .btn [class*=" icon-"],
-    .btn [class^="icon-"] {
-      color: @text;
     }
 
     /* Tags */
@@ -404,6 +415,22 @@
       &:hover {
         border-color: @surface0;
       }
+    }
+
+    /* Send mail modal */
+    .squire-toolbar,
+    #V-PopupsCompose .attachmentAreaParent {
+      border-color: @surface0;
+    }
+    #V-PopupsCompose header {
+      color: @text;
+    }
+    /* Minimize and close icons */
+    #V-PopupsCompose header div.pull-right a.minimize-custom,
+    #V-PopupsCompose .close,
+    .close {
+      border-color: @text;
+      color: @text;
     }
   }
 

--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Migadu Webmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/migadu-webmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/migadu-webmail
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/migadu-webmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amigadu-webmail
 @description Soothing pastel theme for Migadu Webmail


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes some parts of the compose modal that I missed earlier (borders, minimize/close icons) and updates the button styling to more accurately reflect default/success/warning/danger states.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
