### PR TITLE
docs(twitch): remove no longer needed note

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -645,9 +645,6 @@ userstyles:
     color: mauve
     readme:
       app-link: "https://twitch.tv"
-      usage: |+
-        > [!NOTE]
-        > Set Twitch's built-in theme to either **light** if you're using Latte or **dark** if you're using the others.
       current-maintainers: [*gitmuslim, *isabelroses]
   twitter:
     name: Twitter


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

the previous commit fixed the shadow problem with latte on dark mode, this note is no longer needed

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
