### PR TITLE
fix(twitch): button text color

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.1.16
+@version 1.1.17
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -590,6 +590,8 @@
       --color-text-label: @text;
       --color-border-input-hover: @surface0;
       --color-opac-b-14: @crust;
+      --color-text-button-overlay-primary: @text !important;
+      --color-text-tooltip: @text !important;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
button text color; closes #575 
![image](https://github.com/catppuccin/userstyles/assets/29279972/cb9eb43f-9427-43c9-90db-9221fe9d0c62)

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
