### PR TITLE
fix(migadu-webmail): disabled button color

### DIFF
--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -153,12 +153,10 @@
         background-color: fade(@red, 40%);
       }
     }
-    .btn.disabled {
-      color: @surface0;
-    }
+    .btn.disabled,
     .btn.disabled.fontastic,
     .btn.disabled .fontastic {
-      color: @surface0;
+      color: @surface0 !important;
     }
     .btn,
     .btn.disabled,

--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Migadu Webmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/migadu-webmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/migadu-webmail
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/migadu-webmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amigadu-webmail
 @description Soothing pastel theme for Migadu Webmail


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the color of icons/text inside success/danger/warning buttons not being overriden by disabled button styling.

| Before | After |
|---|---|
| ![Screenshot 2024-02-28 at 22 10 53 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/9e0ae4a7-6e0a-41ea-8846-7d45022e7f53) | ![Screenshot 2024-02-28 at 22 11 31 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/761157dd-dfd7-448e-91bf-39eb5778137d) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
