### PR TITLE
fix(github): selectors,  header when logged out

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.3.12
+@version      1.3.13
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -24,34 +24,38 @@
 }
 
 @-moz-document regexp("https:\/\/(gist\.)*github\.com(?!((\/.+?\/.+?\/commit\/[A-Fa-f0-9]+\.(patch|diff)$)|\/home$|\/features($|\/.*)|\/marketplace($|\?.*|\/.*)|\/organizations\/plan)).*$") {
-  @media (prefers-color-scheme: light) {
-    [data-color-mode="auto"][data-dark-theme="light"],
-    [data-color-mode="light"][data-light-theme="light"],
-    [data-color-mode="dark"][data-dark-theme="light"] {
-      #catppuccin(@lightFlavor, @accentColor);
+  [data-color-mode="auto"] {
+    @media (prefers-color-scheme: light) {
+      &[data-light-theme="light"] {
+        #catppuccin(@lightFlavor, @accentColor);
+      }
+      &[data-light-theme="dark"] {
+        #catppuccin(@darkFlavor, @accentColor);
+      }
     }
-  }
-  @media (prefers-color-scheme: dark) {
-    [data-color-mode="auto"][data-dark-theme="dark"],
-    [data-color-mode="light"][data-light-theme="dark"],
-    [data-color-mode="dark"][data-dark-theme="dark"] {
-      #catppuccin(@darkFlavor, @accentColor);
-    }
-  }
 
-  [data-color-mode="auto"][data-dark-theme="light"],
-  [data-color-mode="light"][data-light-theme="light"],
-  [data-color-mode="dark"][data-dark-theme="light"] {
-    #catppuccin(@lightFlavor, @accentColor);
+    @media (prefers-color-scheme: dark) {
+      &[data-dark-theme="light"] {
+        #catppuccin(@lightFlavor, @accentColor);
+      }
+      &[data-dark-theme="dark"] {
+        #catppuccin(@darkFlavor, @accentColor);
+      }
+    }
   }
-  [data-color-mode="auto"][data-dark-theme="dark"],
   [data-color-mode="light"][data-light-theme="dark"],
   [data-color-mode="dark"][data-dark-theme="dark"] {
     #catppuccin(@darkFlavor, @accentColor);
   }
+  [data-color-mode="light"][data-light-theme="light"],
+  [data-color-mode="dark"][data-dark-theme="light"] {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
 
-  html:not([data-light-theme="light"]) body:not(.logged-out)::after,
-  html:not([data-dark-theme="dark"]) body:not(.logged-out)::after {
+  html:not([data-light-theme="light"], [data-light-theme="dark"])
+    body:not(.logged-out)::after,
+  html:not([data-dark-theme="dark"], [data-dark-theme="light"])
+    body:not(.logged-out)::after {
     position: fixed;
     top: 0;
     left: 0;
@@ -140,6 +144,7 @@
     @accent-color: @catppuccin[@@lookup][@@accent];
 
     accent-color: @accent-color;
+    color: @text;
     --bgColor-default: @base;
     --color-page-header-bg: @base;
     --color-marketing-icon-primary: @sky;
@@ -389,6 +394,17 @@
       &:hover {
         background-color: var(--color-btn-primary-hover-bg) !important;
       }
+    }
+
+    /* Header */
+    .HeaderMenu-link {
+      color: @text;
+    }
+    .octicon.octicon-mark-github {
+      fill: @text;
+    }
+    .HeaderMenu-toggle-bar {
+      background-color: @text;
     }
 
     /* Search */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the selectors to work properly with "Sync with system" (closes #584) and updates the auto-detection for unsupported themes. Also, fixes the header when logged out (closes #285, closes #284).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
