### PR TITLE
fix(minesweeper): accent-color

### DIFF
--- a/styles/minesweeper/catppuccin.user.css
+++ b/styles/minesweeper/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Minesweeper Online Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/minesweeper
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/minesweeper
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/minesweeper/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aminesweeper
 @description Soothing pastel theme for Minesweeper Online
@@ -51,7 +51,7 @@
     @base: @catppuccin[@@lookup][@base];
     @mantle: @catppuccin[@@lookup][@mantle];
     @crust: @catppuccin[@@lookup][@crust];
-    @color: @catppuccin[@@lookup][@@accent];
+    @accent-color: @catppuccin[@@lookup][@@accent];
 
     :root {
       --b0: @crust;
@@ -118,7 +118,7 @@
     a,
     a:hover,
     .text-primary {
-      color: @color;
+      color: @accent-color;
     }
 
     .text-success,
@@ -266,8 +266,8 @@
     .btn-primary:hover,
     .btn-primary:active:hover,
     .btn-primary:active {
-      border-color: @color;
-      background-color: @color;
+      border-color: @accent-color;
+      background-color: @accent-color;
       color: @mantle;
     }
 
@@ -363,7 +363,7 @@
     .pagination > li > span {
       background-color: @mantle;
       border-color: @surface0 !important;
-      color: @color;
+      color: @accent-color;
     }
 
     .pagination > .disabled > a {
@@ -374,7 +374,7 @@
 
     .pagination > li > a:hover {
       background-color: @base;
-      color: @color;
+      color: @accent-color;
     }
 
     .pagination-sm > li:first-child > a,
@@ -386,7 +386,7 @@
 
     .pagination > .active > a,
     .pagination > .active > a:hover {
-      background-color: @color;
+      background-color: @accent-color;
       color: @mantle;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

title is clear enough

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
