### PR TITLE
fix(chatgpt): match website updates, arbitrary unthemed elements

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.2.3
+@version 0.2.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -133,7 +133,7 @@
       --brand-purple: @accent-color;
       --text-primary: var(--gray-100);
       --text-secondary: var(--gray-300);
-      --text-tertiary: var(--gray-500);
+      --text-tertiary: var(--gray-400);
       --text-quaternary: var(--gray-700);
       --main-surface-primary: var(--gray-800);
       --main-surface-secondary: var(--gray-700);
@@ -168,7 +168,7 @@
       --brand-purple: @accent-color;
       --text-primary: var(--gray-950);
       --text-secondary: var(--gray-600);
-      --text-tertiary: var(--gray-500);
+      --text-tertiary: var(--gray-400);
       --text-quaternary: var(--gray-300);
       --main-surface-primary: var(--gray-200);
       --main-surface-secondary: var(--gray-100);
@@ -897,6 +897,10 @@
       .dark\:focus\:border-white:focus {
         border-color: @text;
       }
+
+      .dark\:border-gray-700 {
+        border-color: var(--gray-700);
+      }
     }
 
     /* Other */
@@ -915,6 +919,10 @@
 
     .ring-offset-black {
       --tw-ring-offset-color: @base;
+    }
+
+    .katex-error {
+      color: @red !important;
     }
 
     [style="background-color: rgb(0, 0, 46);"],


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Updates CSS override variables to match ChatGPT updates, fixes a border in dark mode, and themes the inline style of katex errors.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
