### PR TITLE
fix(npm): legacy markdown syntax highlighting

### DIFF
--- a/styles/npm/catppuccin.user.css
+++ b/styles/npm/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name npm Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/npm
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/npm
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/npm/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anpm
 @description Soothing pastel theme for npm
@@ -193,6 +193,10 @@
 
               &::placeholder {
                 color: @overlay1;
+              }
+
+              &:focus {
+                box-shadow: none;
               }
 
               &::-webkit-search-cancel-button {
@@ -651,6 +655,31 @@
       code {
         background-color: darken(@base, 2.5%);
         color: @text;
+      }
+      pre.editor.editor-colors {
+        .keyword {
+          color: var(--color-prettylights-syntax-keyword);
+          font-weight: normal;
+        }
+        .string {
+          color: var(--color-prettylights-syntax-string);
+        }
+        .variable {
+          color: var(--color-prettylights-syntax-variable);
+        }
+        .entity,
+        .function {
+          color: var(--color-prettylights-syntax-entity);
+        }
+        .comment {
+          color: var(--color-prettylights-syntax-comment);
+        }
+        .storage.type.function {
+          color: var(--color-prettylights-syntax-keyword);
+        }
+        .punctuation.definition:not(.string) {
+          color: @text;
+        }
       }
       h1,
       h2 {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Some packages apparently have "legacy syntax highlighting". And it's actually way better than PrettyLights lol. Anyway, this themes it to my best ability.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
