### PR TITLE
fix(npm): more legacy syntax highlighting

### DIFF
--- a/styles/npm/catppuccin.user.css
+++ b/styles/npm/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name npm Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/npm
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/npm
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/npm/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anpm
 @description Soothing pastel theme for npm
@@ -657,7 +657,7 @@
         color: @text;
       }
       pre.editor.editor-colors {
-        .keyword {
+        .keyword, .storage.type {
           color: var(--color-prettylights-syntax-keyword);
           font-weight: normal; // stylelint-disable-line property-disallowed-list
         }
@@ -680,6 +680,9 @@
         .punctuation.definition:not(.string) {
           color: @text;
         }
+        .constant {
+            color: var(--color-prettylights-syntax-constant);
+          }
       }
       h1,
       h2 {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Noticed some more unthemed legacy syntax highlighting.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
