### PR TITLE
fix(npm): use mantle for `<code>` element backgrounds

### DIFF
--- a/styles/npm/catppuccin.user.css
+++ b/styles/npm/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name npm Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/npm
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/npm
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/npm/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anpm
 @description Soothing pastel theme for npm
@@ -653,7 +653,7 @@
       }
       pre,
       code {
-        background-color: darken(@base, 2.5%);
+        background-color: @mantle;
         color: @text;
       }
       pre.editor.editor-colors {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Sorry for the small change PRs. I realized I was darkening base instead of using a darker Catppuccin color for some reason... this fixes that.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
