### PR TITLE
ci(pr-labeler): disable on tree-wide PRs

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,6 +7,7 @@ jobs:
   triage:
     name: Add labels
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, '(tree-wide)') }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Disables it from running on PRs with a title containing `(tree-wide)` since those often edit so many files that the labeler workflow fails due to too many labels.

Side note: looks like we are pinned at a very specific version for the `actions/labeler` workflow - any reason for this? Can we / should we upgrade to https://github.com/actions/labeler/releases/tag/v5.0.0?