### PR TITLE
fix(nixos-search)!: update style to work with new UI

### DIFF
--- a/styles/nixos-search/catppuccin.user.css
+++ b/styles/nixos-search/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name NixOS Search Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/nixos-search
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/nixos-search
-@version 0.3.0
+@version 0.4.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/nixos-search/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anixos-search
 @description Soothing pastel theme for NixOS Search
@@ -53,338 +53,44 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
-    /* Generic */
-    html,
-    body {
-      background-color: @base;
-      color: @text;
+    :root {
+      --background-color: @base;
+      --badge-background: @accent-color;
+      --button-active-background: @surface1;
+      --button-active-hover-background: @surface2;
+      --button-background: @surface0;
+      --button-hover-background: @surface2;
+      --color-active-hover-tab: @surface1;
+      --color-active-tab: @surface0;
+      --color-hover-tab: @surface1;
+      --headerbar-background-color: @mantle;
+      --hover-background: @surface0;
+      --link-color: @accent-color;
+      --info-label-background: @accent-color;
+      --dark-blue: @accent-color;
+      --light-blue: @accent-color; // used by focus outline
+      --line-color: @surface0;
+      --search-result-short-details-color: @subtext1;
+      --search-result-divider-line-color: @surface0;
+      --search-result-title-color: @accent-color;
+      --search-sidebar-link-color: @text;
+      --search-sidebar-selected-link-background: @accent-color;
+      --search-sidebar-selected-link-color: @crust;
+      --terminal-background: @surface0;
+      --terminal-color: @red;
+      --text-color: @text;
+      --text-color-light: @text;
+      --text-color-warning: @yellow;
     }
 
-    code,
-    pre {
-      color: @red;
-      background-color: @surface0;
-      border-color: @mantle;
-    }
-
-    a,
-    a:hover,
-    a:focus {
-      color: @accent-color;
-    }
-
-    /* Navbar */
-    .navbar .navbar-static-top {
-      background-color: @mantle;
-    }
-
-    .navbar-inner {
-      background-color: @mantle;
-      background-image: none;
-      border-color: @base;
-    }
-
-    .nav-tabs {
-      border-bottom-color: @surface0;
-    }
-
-    .nav-tabs > .active > a,
-    .nav-tabs > .active > a:hover,
-    .nav-tabs > .active > a:focus {
-      background-color: @base;
-      border-color: @surface0;
-      color: @text;
-    }
-
-    .navbar .nav > li > a {
-      text-shadow: none;
-      color: @subtext0;
-    }
-
-    .navbar .nav > li > a:focus,
-    .navbar .nav > li > a:hover {
-      color: @text;
-    }
-
-    .navbar .nav > .active > a,
-    .navbar .nav > .active > a:hover,
-    .navbar .nav > .active > a:focus {
-      background-color: @surface0;
-      color: @text;
-    }
-
-    /* Installation instructions tabs */
-    .nav > li > a:hover,
-    .nav > li > a:focus {
-      background-color: @surface0;
-      border-color: @surface0;
-    }
-
-    /* "Experimental" label */
-    .label,
-    .badge {
-      background-color: @accent-color;
-      color: @crust;
-      text-shadow: none;
-    }
-
-    /* Buttons */
-    .btn {
-      background-color: @surface0;
-      background-image: none;
-      text-shadow: none;
-      box-shadow: none;
-      color: @text;
-      border-color: @base;
-    }
-
-    .btn:focus {
-      color: @text;
-      background-color: @surface1;
-    }
-
-    .btn:hover,
-    .btn:active,
-    .btn.active,
-    .btn.disabled,
-    .btn[disabled] {
-      background-color: @surface1;
-      color: @text;
-    }
-
-    /* "Sort" menu */
-    .dropdown-menu {
-      background-color: @mantle;
-      border-color: @crust;
-      box-shadow: 0 5px 10px @mantle;
-    }
-
-    .dropdown-menu > li > a {
-      color: @text;
-    }
-
-    .dropdown-menu > li > a:hover,
-    .dropdown-menu > li > a:focus,
-    .dropdown-submenu:hover > a,
-    .dropdown-submenu:focus > a {
-      background-color: @surface0;
-      background-image: none;
-    }
-
-    .dropdown-menu .divider {
-      background-color: @surface0;
-      border-bottom-color: @surface0;
-    }
-
-    .dropdown .caret {
-      border-top-color: @text;
-    }
-
-    /* Overrides menu item hover color */
-    .search-page
-      > .search-results
-      > div
-      > :first-child
-      > div:first-child
-      > ul
-      > li
-      > a {
-      color: @text;
-    }
-
-    /* Loading indicator */
-    .loader {
+    // hardcoded to #fff
+    .label, .badge {
       color: @crust;
     }
 
-    /* Input box */
-    textarea,
-    input[type="text"],
-    input[type="password"],
-    input[type="datetime"],
-    input[type="datetime-local"],
-    input[type="date"],
-    input[type="month"],
-    input[type="time"],
-    input[type="week"],
-    input[type="number"],
-    input[type="email"],
-    input[type="url"],
-    input[type="search"],
-    input[type="tel"],
-    input[type="color"],
-    .uneditable-input {
-      background-color: @surface0;
+    // hardcoded to #005580
+    a:hover, a:focus {
       color: @text;
-      border-color: @base;
-    }
-
-    textarea:focus,
-    input[type="text"]:focus,
-    input[type="password"]:focus,
-    input[type="datetime"]:focus,
-    input[type="datetime-local"]:focus,
-    input[type="date"]:focus,
-    input[type="month"]:focus,
-    input[type="time"]:focus,
-    input[type="week"]:focus,
-    input[type="number"]:focus,
-    input[type="email"]:focus,
-    input[type="url"]:focus,
-    input[type="search"]:focus,
-    input[type="tel"]:focus,
-    input[type="color"]:focus,
-    .uneditable-input:focus {
-      border-color: @accent-color;
-      box-shadow:
-        inset 0 1px 1px @crust,
-        0 0 8px @accent-color;
-    }
-
-    /* Fix input box placeholder text */
-    textarea::placeholder,
-    input[type="text"]::placeholder,
-    input[type="password"]::placeholder,
-    input[type="datetime"]::placeholder,
-    input[type="datetime-local"]::placeholder,
-    input[type="date"]::placeholder,
-    input[type="month"]::placeholder,
-    input[type="time"]::placeholder,
-    input[type="week"]::placeholder,
-    input[type="number"]::placeholder,
-    input[type="email"]::placeholder,
-    input[type="url"]::placeholder,
-    input[type="search"]::placeholder,
-    input[type="tel"]::placeholder,
-    input[type="color"]::placeholder,
-    .uneditable-input::placeholder {
-      color: @subtext0;
-    }
-
-    /* Search results */
-    .search-page > .search-results > div > :nth-child(2) > li {
-      border-bottom-color: @surface0;
-    }
-
-    .search-page > .search-results > div > :nth-child(2) > li > :first-child {
-      color: @accent-color;
-    }
-
-    .search-page
-      > .search-results
-      > div
-      > :nth-child(2)
-      > li.package
-      > :nth-child(5)
-      > :nth-child(2)
-      ul.nav-tabs
-      > li
-      > a {
-      color: @text;
-    }
-
-    .search-page
-      > .search-results
-      > div
-      > :nth-child(2)
-      > li.package
-      > :nth-child(5)
-      > :nth-child(2)
-      pre {
-      color: @text;
-      background-color: @mantle;
-    }
-
-    .search-page
-      > .search-results
-      > div
-      > :nth-child(2)
-      > li.package
-      .result-item-show-more {
-      background-color: @base;
-      color: @text;
-    }
-
-    .search-page
-      > .search-results
-      > div
-      > :nth-child(2)
-      > li.package
-      > :nth-child(3)
-      > li {
-      color: @text;
-    }
-
-    .search-page
-      > .search-results
-      > div
-      > :nth-child(2)
-      > li.package
-      > :nth-child(5)
-      > :nth-child(2)
-      div.tab-content {
-      border-color: @surface0;
-    }
-
-    .search-page
-      > .search-results
-      > div
-      > :nth-child(2)
-      > li.option
-      > :nth-child(2)
-      > div:nth-child(2n)
-      pre
-      code {
-      color: @text;
-      background-color: @mantle;
-    }
-
-    /* Search sidebar */
-    .search-page ul.search-sidebar > li {
-      border-color: @surface0;
-    }
-
-    .search-page ul.search-sidebar > li > ul > li > a {
-      color: @text;
-    }
-
-    .search-page ul.search-sidebar > li > ul > li > a:hover {
-      background-color: @surface0;
-    }
-
-    .search-page ul.search-sidebar > li > ul > li > a.selected {
-      color: @crust;
-      background-color: @accent-color;
-    }
-
-    /* Override sidebar labels (number of packages) */
-    .search-sidebar .label,
-    .search-sidebar .badge {
-      background-color: @surface0;
-      color: @text;
-      text-shadow: none;
-    }
-
-    /* Pager */
-    .pager li > a,
-    .pager li > span {
-      color: @text;
-      background-color: @surface0;
-      border-radius: 5px;
-    }
-
-    .pager li > a:hover,
-    .pager li > a:focus {
-      background-color: @surface1;
-    }
-
-    .pager .disabled > a,
-    .pager .disabled > a:hover,
-    .pager .disabled > a:focus,
-    .pager .disabled > span {
-      color: @text;
-      background-color: @mantle;
-      border-radius: 5px;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #619

[NixOS Search](https://search.nixos.org) has recently updated its frontend. This PR uses the new CSS variables to theme most of the website and using overrides for the remaining components.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
