### PR TITLE
fix(chatgpt): primary background override

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.2.4
+@version 0.2.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -98,6 +98,7 @@
     --ctp-crust: #rgbify(@crust) [];
     code.hljs {
       background: none;
+        color: @text;
     }
     pre {
       .bg-token-main-surface-secondary {
@@ -427,6 +428,9 @@
     }
 
     /* Backgrounds */
+      .bg-token-main-surface-primary {
+          background-color: var(--main-surface-primary);
+      }
 
     .\!bg-brand-purple {
       background-color: @accent-color !important;

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -98,7 +98,6 @@
     --ctp-crust: #rgbify(@crust) [];
     code.hljs {
       background: none;
-        color: @text;
     }
     pre {
       .bg-token-main-surface-secondary {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Adds an override for a primary background class due to specificity issues.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
