### PR TITLE
fix(wikipedia): black text -> white text in sidebar

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -797,6 +797,10 @@
 
     .cdx-typeahead-search__search-footer__icon.cdx-icon {
       color: @subtext0;
+    }
+    
+    .vector-toc .vector-toc-level-1-active:not(.vector-toc-list-item-active) > .vector-toc-link {
+      color: @text;
     }
 
     .lang-list-active .lang-list-button {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/catppuccin/userstyles/assets/42213155/2d568d5b-1cf1-4166-8f32-2213c8923a91)
![image](https://github.com/catppuccin/userstyles/assets/42213155/9a503c7e-15a7-42ba-9b6f-17cded983a29)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
