### PR TITLE
chore(youtube): enable youtube logo by default

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.4.2
+@version 3.4.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -14,7 +14,7 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire*", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 
-@var checkbox logo "Logo" 0
+@var checkbox logo "Enable YouTube logo" 1
 @var checkbox oledOn "Enable black bars" 0
 @var text scrollbar_width "Scrollbar width" 8px
 ==/UserStyle== */
@@ -49,7 +49,7 @@
         fill: @base !important;
       }
     }
-    & when (@logo =1) {
+    & when (@logo = 0) {
       ytd-topbar-logo-renderer,
       svg.ytd-consent-bump-v2-lightbox {
         display: none;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

enable yt logo by default
related to https://github.com/catppuccin/userstyles/issues/632

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
