### PR TITLE
chore(stylelint): disable font-family-no-missing-generic-family-keyword

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -27,6 +27,9 @@ const config = {
     "no-invalid-position-at-import-rule": null,
     "no-invalid-double-slash-comments": null,
 
+    // font-* properties are disallowed anyway.
+    "font-family-no-missing-generic-family-keyword": null,
+
     "at-rule-disallowed-list": [
       ["/^font.*/"],
       {


### PR DESCRIPTION
This rule is not needed since we outright disallow all `font-*` properties (and this just clogs up the maximum of 10 annotations that ca display on a PR).