### PR TITLE
fix(wikipedia): color redirect thingy into green

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.6
+@version 0.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -526,6 +526,10 @@
     .mw-highlight .linenos {
       color: @overlay0;
     } /* Line numbers */
+      
+    .mw-redirect {
+      color: @green !important;
+    }
 
     .mbox-text {
       color: @text !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

title

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
