### PR TITLE
fix(instagram): direct message bubble color

### DIFF
--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -654,32 +654,59 @@
     #catppuccin(@darkFlavor,
         @accentColor);
   }
+  @rosewater: @catppuccin[@@lookup][@rosewater];
+  @flamingo: @catppuccin[@@lookup][@flamingo];
+  @pink: @catppuccin[@@lookup][@pink];
+  @mauve: @catppuccin[@@lookup][@mauve];
+  @red: @catppuccin[@@lookup][@red];
+  @maroon: @catppuccin[@@lookup][@maroon];
+  @peach: @catppuccin[@@lookup][@peach];
+  @yellow: @catppuccin[@@lookup][@yellow];
+  @green: @catppuccin[@@lookup][@green];
+  @teal: @catppuccin[@@lookup][@teal];
+  @sky: @catppuccin[@@lookup][@sky];
+  @sapphire: @catppuccin[@@lookup][@sapphire];
+  @blue: @catppuccin[@@lookup][@blue];
+  @lavender: @catppuccin[@@lookup][@lavender];
+  @text: @catppuccin[@@lookup][@text];
+  @subtext1: @catppuccin[@@lookup][@subtext1];
+  @subtext0: @catppuccin[@@lookup][@subtext0];
+  @overlay2: @catppuccin[@@lookup][@overlay2];
+  @overlay1: @catppuccin[@@lookup][@overlay1];
+  @overlay0: @catppuccin[@@lookup][@overlay0];
+  @surface2: @catppuccin[@@lookup][@surface2];
+  @surface1: @catppuccin[@@lookup][@surface1];
+  @surface0: @catppuccin[@@lookup][@surface0];
+  @base: @catppuccin[@@lookup][@base];
+  @mantle: @catppuccin[@@lookup][@mantle];
+  @crust: @catppuccin[@@lookup][@crust];
+  @accent-color: @catppuccin[@@lookup][@@accent];
 
   #catppuccin(@lookup,
     @accent) {
     // Chat background
     .xnz67gz {
-      background-color: @catppuccin[@@lookup][@base];
+      background-color: @base;
     }
     [style*="background-color: rgb(55, 151, 240);"] {
-      background-color: @catppuccin[@@lookup] [ @blue] !important;
-      color: @catppuccin[@@lookup] [ @mantle];
+      background-color: @blue !important;
+      color: @mantle;
     }
     .xvbhtw8 {
-      background-color: @catppuccin[@@lookup][@mantle];
+      background-color: @mantle;
     }
 
     ._aa5c,
     ._aa4j,
     ._abyk {
-      background-color: @catppuccin[@@lookup][@crust];
+      background-color: @crust;
     } // New Chat Button
     .xk5f4mz {
-      background-color: @catppuccin[@@lookup][@surface0];
+      background-color: @surface0;
     } // Chat button
     .x1i10hfl:hover {
-      background-color: @catppuccin[@@lookup][@surface0];
-      color: @catppuccin[@@lookup][@text];
+      background-color: @surface0;
+      color: @text;
     }
   }
 }

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.1.8.1
+@version 0.1.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -654,36 +654,35 @@
     #catppuccin(@darkFlavor,
         @accentColor);
   }
-  @rosewater: @catppuccin[@@lookup][@rosewater];
-  @flamingo: @catppuccin[@@lookup][@flamingo];
-  @pink: @catppuccin[@@lookup][@pink];
-  @mauve: @catppuccin[@@lookup][@mauve];
-  @red: @catppuccin[@@lookup][@red];
-  @maroon: @catppuccin[@@lookup][@maroon];
-  @peach: @catppuccin[@@lookup][@peach];
-  @yellow: @catppuccin[@@lookup][@yellow];
-  @green: @catppuccin[@@lookup][@green];
-  @teal: @catppuccin[@@lookup][@teal];
-  @sky: @catppuccin[@@lookup][@sky];
-  @sapphire: @catppuccin[@@lookup][@sapphire];
-  @blue: @catppuccin[@@lookup][@blue];
-  @lavender: @catppuccin[@@lookup][@lavender];
-  @text: @catppuccin[@@lookup][@text];
-  @subtext1: @catppuccin[@@lookup][@subtext1];
-  @subtext0: @catppuccin[@@lookup][@subtext0];
-  @overlay2: @catppuccin[@@lookup][@overlay2];
-  @overlay1: @catppuccin[@@lookup][@overlay1];
-  @overlay0: @catppuccin[@@lookup][@overlay0];
-  @surface2: @catppuccin[@@lookup][@surface2];
-  @surface1: @catppuccin[@@lookup][@surface1];
-  @surface0: @catppuccin[@@lookup][@surface0];
-  @base: @catppuccin[@@lookup][@base];
-  @mantle: @catppuccin[@@lookup][@mantle];
-  @crust: @catppuccin[@@lookup][@crust];
-  @accent-color: @catppuccin[@@lookup][@@accent];
-
   #catppuccin(@lookup,
     @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
     // Chat background
     .xnz67gz {
       background-color: @base;

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -651,8 +651,8 @@
 
 @-moz-document regexp('^.*instagram.com/direct.*') {
   :root {
-    #catppuccin(@lookup,
-        @accent);
+    #catppuccin(@darkFlavor,
+        @accentColor);
   }
   #catppuccin(@lookup,
     @accent) {

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.1.8.1
+@version 0.1.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram
@@ -651,8 +651,8 @@
 
 @-moz-document regexp('^.*instagram.com/direct.*') {
   :root {
-    #catppuccin(@darkFlavor,
-        @accentColor);
+    #catppuccin(@lookup,
+        @accent);
   }
   #catppuccin(@lookup,
     @accent) {

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -66,7 +66,7 @@
     * {
       --web-always-black: #rgbify(@dark_color) [];
       --web-always-white: #rgbify(@light_color) [];
-
+      --always-white: #rgbify(@light_color) [];
       --overlay-alpha-80: fadeout(@dark_color, 50);
       --always-dark-overlay: fadeout(@surface0, 50);
 
@@ -112,6 +112,9 @@
       scrollbar-width: none;
       scrollbar-color: @accent-color @crust;
     } // Text selection
+    input::placeholder {
+      color: @text !important;
+    }
     *::selection {
       color: @dark_color;
       background-color: @accent-color;
@@ -123,7 +126,6 @@
         background-color: @mantle !important;
       }
     }
-
     .x1zvrr1 {
       background-color: @mantle;
     }
@@ -657,7 +659,10 @@
     .xnz67gz {
       background-color: @catppuccin[@@lookup][@base];
     }
-
+    [style*="background-color: rgb(55, 151, 240);"] {
+      background-color: @catppuccin[@@lookup] [ @blue] !important;
+      color: @catppuccin[@@lookup] [ @mantle];
+    }
     .xvbhtw8 {
       background-color: @catppuccin[@@lookup][@mantle];
     }

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.1.9
+@version 0.1.8.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram
@@ -111,10 +111,12 @@
 
       scrollbar-width: none;
       scrollbar-color: @accent-color @crust;
-    } // Text selection
-    input::placeholder {
-      color: @text !important;
     }
+    //placehoder textcolor
+    .xh8yej3 {
+      color: @subtext0 !important;
+    }
+    // Text selection
     *::selection {
       color: @dark_color;
       background-color: @accent-color;

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.1.8
+@version 0.1.8.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
dm bubble color

| Before | After |
| --- | --- |
| ![](https://github.com/catppuccin/userstyles/assets/29279972/2d0adc78-800c-4395-b162-dec80fc65b98) | ![](https://github.com/catppuccin/userstyles/assets/29279972/8e704069-c62d-433a-8c83-a09a4b9fc933) |

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
