### PR TITLE
fix(brave-search): search bar shadow

### DIFF
--- a/styles/brave-search/catppuccin.user.css
+++ b/styles/brave-search/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Brave Search Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/brave-search
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/brave-search
-@version 1.0.4
+@version 1.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/brave-search/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Abrave-search
 @description Soothing pastel theme for Brave Search
@@ -189,6 +189,9 @@
 
     #searchform > .searchbox-wrapper::after {
       background-image: none;
+    }
+    #searchform-actions::before {
+      background: none !important;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

It re-hides a shadow that is not visible on the default page.
I've kept the old selector in case Brave does A/B testing or maybe revert their change.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
