### PR TITLE
fix(github): code block backgrounds

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.3.13
+@version      1.3.14
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -295,8 +295,8 @@
     --color-fg-on-emphasis: @base;
     --color-canvas-default: @base;
     --color-canvas-overlay: @surface0;
-    --color-canvas-inset: @mantle; // background
-    --color-canvas-subtle: @surface0;
+    --color-canvas-inset: @crust; // background
+    --color-canvas-subtle: @mantle;
     --color-border-default: @surface1;
     --color-border-muted: @surface0;
     --color-shadow-medium: 0 3px 6px @crust;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #662. I don't use latte much but I think some other parts could use lighter colors. I'm going to leave this PR in limbo for a bit to mess around with it.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
