### PR TITLE
fix(google): selected image highlight

### DIFF
--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -77,6 +77,14 @@
     --t9ab8d922307d428d: @text;
     --t62e84c71989f1975: @red !important;
     --tc9db399ed82142e1: @green !important;
+    --uv-styles-color-text-default: @subtext0 !important;
+    --uv-styles-color-review-stars: @yellow !important;
+
+    /* selected image background */
+    .PNCib.fT6ABc::after {
+      background-color: @surface1 !important;
+      border-color: @blue !important;
+    }
 
     /* travel  */
     .Usd1Ac {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the selected image highlight + changes the review star color to be ctp yellow + description of image
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
