### PR TITLE
fix(google): selected image highlight

### DIFF
--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -80,6 +80,14 @@
     --uv-styles-color-text-default: @subtext0 !important;
     --uv-styles-color-review-stars: @yellow !important;
 
+    /* safe search toggle dropdown*/
+    .z4R3Z.yb2zA {
+      color: @blue !important;
+    }
+    .z4R3Z {
+      color: @text !important;
+    }
+
     /* selected image background */
     .PNCib.fT6ABc::after {
       background-color: @surface1 !important;

--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -80,7 +80,7 @@
     --uv-styles-color-text-default: @subtext0 !important;
     --uv-styles-color-review-stars: @yellow !important;
 
-    /* safe search toggle dropdown*/
+    /* safe search toggle dropdown */
     .z4R3Z.yb2zA {
       color: @blue !important;
     }

--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -77,6 +77,14 @@
     --t9ab8d922307d428d: @text;
     --t62e84c71989f1975: @red !important;
     --tc9db399ed82142e1: @green !important;
+    --uv-styles-color-text-default: @subtext0 !important;
+    --uv-styles-color-review-stars: @yellow !important;
+
+    /* selected image background */
+    .PNCib.fT6ABc::after {
+      background-color: @surface1 !important;
+      border-color: @blue !important;
+    }
 
     /* travel  */
     .Usd1Ac {

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -57,8 +57,11 @@
       // shadows
       .r-qo02w8,
       .r-15ce4ve {
-        @default-shadow: fade(@text, 20%) 0 0 15px, fade(@text, 15%) 0 0 3px 1px;
-        @black-shadow: rgba(0, 0, 0, 0.4) 0 0 15px,
+        @default-shadow:
+          fade(@text, 20%) 0 0 15px,
+          fade(@text, 15%) 0 0 3px 1px;
+        @black-shadow:
+          rgba(0, 0, 0, 0.4) 0 0 15px,
           rgba(0, 0, 0, 0.35) 0 0 3px 1px;
 
         box-shadow: @default-shadow;
@@ -80,9 +83,11 @@
       }
 
       .r-1uusn97 {
-        @default-shadow: fade(@text, 20%) 0 0 5px,
+        @default-shadow:
+          fade(@text, 20%) 0 0 5px,
           fade(@text, 15%) 0 1px 4px 1px;
-        @black-shadow: rgba(0, 0, 0, 0.4) 0 0 5px,
+        @black-shadow:
+          rgba(0, 0, 0, 0.4) 0 0 5px,
           rgba(0, 0, 0, 0.35) 0 1px 4px 1px;
 
         box-shadow: @default-shadow;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the selected image highlight + changes the review star color to be ctp yellow + description of image, border color is blue because the original was blue as well as the safesearch dropdown

<img width="550" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/b51dbb90-23bc-4f9a-9ba0-25064a6e10be">
<img width="190" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/c7368ff5-449d-4871-9cfa-5892db826c66">
<img width="440" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/42f95e7f-cd54-4194-8c35-f22182248cb5">


<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
