### PR TITLE
fix(duckduckgo): defenitions infobox coloring

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -238,7 +238,14 @@
     .module--definitions__usage {
       color: @subtext0 !important;
     }
+    .module__title,
+    .module--definitions__definition {
+      color: @text !important;
+    }
 
+    .play-btn__icn_hollow {
+      fill: @accent-color !important;
+    }
     .module__toggle {
       color: @accent-color !important;
     }
@@ -322,17 +329,13 @@
     }
 
     .tile__display {
-      box-shadow:
-        inset -1px -1px 0 @overlay0,
-        inset 1px 1px 0 @overlay0 !important;
+      box-shadow: inset -1px -1px 0 @overlay0, inset 1px 1px 0 @overlay0 !important;
       background-color: @base !important;
       border-color: @surface2 !important;
       color: @text !important;
     }
     .tile__display.selected {
-      box-shadow:
-        inset -1px -1px 0 @blue,
-        inset 1px 1px 0 @blue !important;
+      box-shadow: inset -1px -1px 0 @blue, inset 1px 1px 0 @blue !important;
     }
 
     .tile__ctrl--important {

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.0.9
+@version 0.1.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
definitions infobox coloring
| Before|After|
|---|---|
| ![image](https://github.com/catppuccin/userstyles/assets/29279972/34af53ea-f427-418b-aa5d-15bc8d8d2992) | ![image](https://github.com/catppuccin/userstyles/assets/29279972/1f6949e3-82d3-440b-bde8-69ef54978ca4)|

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
