### PR TITLE
fix(tabnews): Contrast between seen posts and new posts

### DIFF
--- a/styles/tabnews/catppuccin.user.css
+++ b/styles/tabnews/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name TabNews Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/tabnews
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/tabnews
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/tabnews/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atabnews
 @description Soothing pastel theme for TabNews
@@ -61,7 +61,7 @@
     --fgColor-accent: @accent-color;
     --fgColor-onEmphasis: @text;
     --color-accent-fg: @accent-color;
-    --fgColor-muted: @subtext1;
+    --fgColor-muted: @overlay0;
     --borderColor-default: @surface0;
     --button-default-bgColor-rest: @base;
     --button-default-bgColor-hover: @crust;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This fixes seen posts and new post having similar color. Now it's a darker color.
Preview:
![Preview](https://github.com/catppuccin/userstyles/assets/49736632/f369e4bd-0178-4707-bc5b-a4517d18c44f)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
