### PR TITLE
fix(homepage): api error, version number/update available text, and the top separator not being themed

### DIFF
--- a/styles/homepage/catppuccin.user.css
+++ b/styles/homepage/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name homepage Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/homepage
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/homepage
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/homepage/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahomepage
 @description Soothing pastel theme for homepage
@@ -153,7 +153,7 @@
 
     :is(.dark .dark\:border-theme-200\/50) {
       --tw-border-opacity: 1;
-      border-color: @overlay2; // top separator
+      border-color: @surface2; // top separator
     }
 
     :is(.dark .dark\:hover\:text-theme-300:hover) {

--- a/styles/homepage/catppuccin.user.css
+++ b/styles/homepage/catppuccin.user.css
@@ -89,7 +89,7 @@
     }
     .border-theme-300 {
       --tw-border-opacity: 1;
-      border-color: @accent-color; //Search bar Border
+      border-color: @accent-color !important; //Search bar Border (important is needed so top separator doesn't override)
     }
     :is(.dark .dark\:bg-white\/10) {
       background-color: @crust //Search bar background
@@ -149,6 +149,11 @@
     :is(.dark .dark\:text-theme-400) {
       --tw-border-opacity: 1;
       color: @text; // update and version text
+    }
+
+    :is(.dark .dark\:border-theme-200\/50) {
+      --tw-border-opacity: 1;
+      border-color: @overlay2; // top separator
     }
 
     :is(.dark .dark\:hover\:text-theme-300:hover) {

--- a/styles/homepage/catppuccin.user.css
+++ b/styles/homepage/catppuccin.user.css
@@ -133,6 +133,24 @@
     :is(.dark .dark\:text-theme-300) {
       color: @text; //Section Names + Container Description
     }
+
+    // api error
+    .text-theme-900 {
+      --tw-border-opacity: 1;
+      color: @base; // api error text color
+    }
+
+    .bg-rose-900\/80 {
+      --tw-border-opacity: 1;
+      background-color: @accent-color; // api error box color
+    }
+    //
+
+    :is(.dark .dark\:text-theme-400) {
+      --tw-border-opacity: 1;
+      color: @text; // update and version text
+    }
+
     :is(.dark .dark\:hover\:text-theme-300:hover) {
       --tw-text-opacity: 1;
       color: darken(


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

fixes api error, version number/update available text, and the top separator not being themed

before:
![before](https://raw.githubusercontent.com/BPplays/images/main/catppuccin_userstyles/verapisep/before.png)

after:
![after](https://raw.githubusercontent.com/BPplays/images/main/catppuccin_userstyles/verapisep/after.png)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
