### PR TITLE
fix(youtube): transparent header bar not being themed, but made header bar non-transparent

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -407,6 +407,17 @@
       background-color: @base !important;
     }
 
+    /* transparent header bar */
+    #container.ytd-masthead {
+      --iron-icon-fill-color: @text !important;
+      background-color: @base !important;
+    }
+
+    ytd-feed-filter-chip-bar-renderer[expand-instead-of-scroll] #chips-wrapper.ytd-feed-filter-chip-bar-renderer {
+      --iron-icon-fill-color: @text !important;
+      background-color: @base !important;
+    }
+
     /* change color of the player edges */
     #ytd-player #container when (@oledOn =0) {
       background: @base !important;
@@ -1426,6 +1437,8 @@
     .chip-bar {
       background-color: @base;
     }
+
+
 
     /* selected chip color */
     [chip-style="STYLE_DEFAULT"].selected .chip-container,

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.5.0
+@version 3.5.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

transparent header bar not being themed. but it makes it non-transparent

before
![before](https://raw.githubusercontent.com/BPplays/images/main/catppuccin_userstyles/ytheadernthmd/Screenshot%202024-03-15%20123200.png)


after
![after](https://raw.githubusercontent.com/BPplays/images/main/catppuccin_userstyles/ytheadernthmd/after.png)

Closes #677

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
