### PR TITLE
refactor(wikipedia): use syntax highlighting from python pygments port

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.7
+@version 0.0.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -16,6 +16,8 @@
 ==/UserStyle== */
 
 @-moz-document domain('wikipedia.org') {
+  @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
+
   /* prettier-ignore */
   @catppuccin: {
     @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
@@ -53,7 +55,35 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
-    html,
+    --ctp-rosewater: @rosewater;
+    --ctp-flamingo: @flamingo;
+    --ctp-pink: @pink;
+    --ctp-mauve: @mauve;
+    --ctp-red: @red;
+    --ctp-maroon: @maroon;
+    --ctp-peach: @peach;
+    --ctp-yellow: @yellow;
+    --ctp-green: @green;
+    --ctp-teal: @teal;
+    --ctp-sky: @sky;
+    --ctp-sapphire: @sapphire;
+    --ctp-blue: @blue;
+    --ctp-lavender: @lavender;
+    --ctp-text: @text;
+    --ctp-subtext1: @subtext1;
+    --ctp-subtext0: @subtext0;
+    --ctp-overlay2: @overlay2;
+    --ctp-overlay1: @overlay1;
+    --ctp-overlay0: @overlay0;
+    --ctp-surface2: @surface2;
+    --ctp-surface1: @surface1;
+    --ctp-surface0: @surface0;
+    --ctp-base: @crust;
+    --ctp-mantle: @mantle;
+    --ctp-crust: @crust;
+      
+    --background-color-base: @base;
+
     body,
     .vector-feature-zebra-design-enabled .vector-header-container .mw-header,
     .vector-feature-zebra-design-enabled .mw-page-container,
@@ -287,245 +317,6 @@
     .mw-content-ltr.content .mw-highlight-lines pre {
       box-shadow: inset 2.75em 0 0 @surface1;
     }
-
-    .mw-highlight .hll {
-      background-color: #ffc;
-    }
-    .mw-highlight .c {
-      color: @overlay0;
-    } /* Comment */
-    .mw-highlight .err {
-      color: @text;
-    } /* Error */
-    .mw-highlight .g {
-      color: @text;
-    } /* Generic */
-    .mw-highlight .k {
-      color: @mauve;
-    } /* Keyword */
-    .mw-highlight .l {
-      color: @text;
-    } /* Literal */
-    .mw-highlight .n {
-      color: @text;
-    } /* Name */
-    .mw-highlight .o {
-      color: @sky;
-    } /* Operator */
-    .mw-highlight .x {
-      color: @text;
-    } /* Other */
-    .mw-highlight .p {
-      color: @overlay2;
-    } /* Punctuation */
-    .mw-highlight .ch {
-      color: @overlay0;
-    } /* Comment.Hashbang */
-    .mw-highlight .cm {
-      color: @overlay0;
-    } /* Comment.Multiline */
-    .mw-highlight .cp {
-      color: @pink;
-    } /* Comment.Preproc */
-    .mw-highlight .cpf {
-      color: @overlay0;
-    } /* Comment.PreprocFile */
-    .mw-highlight .c1 {
-      color: @overlay0;
-    } /* Comment.Single */
-    .mw-highlight .cs {
-      color: @overlay0;
-    } /* Comment.Special */
-    .mw-highlight .gd {
-      color: @red;
-    } /* Generic.Deleted */
-    .mw-highlight .ge {
-      color: @text;
-      text-decoration: underline;
-    } /* Generic.Emph */
-    .mw-highlight .ges {
-      color: @text;
-    } /* Generic.EmphStrong */
-    .mw-highlight .gr {
-      color: @text;
-    } /* Generic.Error */
-    .mw-highlight .gh {
-      color: @text;
-    } /* Generic.Heading */
-    .mw-highlight .gi {
-      color: @text;
-    } /* Generic.Inserted */
-    .mw-highlight .go {
-      color: @overlay0;
-    } /* Generic.Output */
-    .mw-highlight .gp {
-      color: @text;
-    } /* Generic.Prompt */
-    .mw-highlight .gs {
-      color: @text;
-    } /* Generic.Strong */
-    .mw-highlight .gu {
-      color: @text;
-    } /* Generic.Subheading */
-    .mw-highlight .gt {
-      color: @text;
-    } /* Generic.Traceback */
-    .mw-highlight .kc {
-      color: @pink;
-    } /* Keyword.Constant */
-    .mw-highlight .kd {
-      color: @teal;
-    } /* Keyword.Declaration */
-    .mw-highlight .kn {
-      color: @mauve;
-    } /* Keyword.Namespace */
-    .mw-highlight .kp {
-      color: @pink;
-    } /* Keyword.Pseudo */
-    .mw-highlight .kr {
-      color: @pink;
-    } /* Keyword.Reserved */
-    .mw-highlight .kt {
-      color: @teal;
-    } /* Keyword.Type */
-    .mw-highlight .ld {
-      color: @text;
-    } /* Literal.Date */
-    .mw-highlight .m {
-      color: @peach;
-    } /* Literal.Number */
-    .mw-highlight .s {
-      color: @green;
-    } /* Literal.String */
-    .mw-highlight .na {
-      color: @green;
-    } /* Name.Attribute */
-    .mw-highlight .nb {
-      color: @peach;
-    } /* Name.Builtin */
-    .mw-highlight .nc {
-      color: @yellow;
-    } /* Name.Class */
-    .mw-highlight .no {
-      color: @text;
-    } /* Name.Constant */
-    .mw-highlight .nd {
-      color: @text;
-    } /* Name.Decorator */
-    .mw-highlight .ni {
-      color: @text;
-    } /* Name.Entity */
-    .mw-highlight .ne {
-      color: @text;
-    } /* Name.Exception */
-    .mw-highlight .nf {
-      color: @sapphire;
-    } /* Name.Function */
-    .mw-highlight .nl {
-      color: @teal;
-    } /* Name.Label */
-    .mw-highlight .nn {
-      color: @text;
-    } /* Name.Namespace */
-    .mw-highlight .nx {
-      color: @text;
-    } /* Name.Other */
-    .mw-highlight .py {
-      color: @text;
-    } /* Name.Property */
-    .mw-highlight .nt {
-      color: @pink;
-    } /* Name.Tag */
-    .mw-highlight .nv {
-      color: @text;
-    } /* Name.Variable */
-    .mw-highlight .ow {
-      color: @mauve;
-    } /* Operator.Word */
-    .mw-highlight .pm {
-      color: @overlay2;
-    } /* Punctuation.Marker */
-    .mw-highlight .w {
-      color: @text;
-    } /* Text.Whitespace */
-    .mw-highlight .mb {
-      color: @peach;
-    } /* Literal.Number.Bin */
-    .mw-highlight .mf {
-      color: @peach;
-    } /* Literal.Number.Float */
-    .mw-highlight .mh {
-      color: @peach;
-    } /* Literal.Number.Hex */
-    .mw-highlight .mi {
-      color: @peach;
-    } /* Literal.Number.Integer */
-    .mw-highlight .mo {
-      color: @peach;
-    } /* Literal.Number.Oct */
-    .mw-highlight .sa {
-      color: @green;
-    } /* Literal.String.Affix */
-    .mw-highlight .sb {
-      color: @green;
-    } /* Literal.String.Backtick */
-    .mw-highlight .sc {
-      color: @green;
-    } /* Literal.String.Char */
-    .mw-highlight .dl {
-      color: @green;
-    } /* Literal.String.Delimiter */
-    .mw-highlight .sd {
-      color: @green;
-    } /* Literal.String.Doc */
-    .mw-highlight .s2 {
-      color: @green;
-    } /* Literal.String.Double */
-    .mw-highlight .se {
-      color: @green;
-    } /* Literal.String.Escape */
-    .mw-highlight .sh {
-      color: @green;
-    } /* Literal.String.Heredoc */
-    .mw-highlight .si {
-      color: @green;
-    } /* Literal.String.Interpol */
-    .mw-highlight .sx {
-      color: @green;
-    } /* Literal.String.Other */
-    .mw-highlight .sr {
-      color: @green;
-    } /* Literal.String.Regex */
-    .mw-highlight .s1 {
-      color: @green;
-    } /* Literal.String.Single */
-    .mw-highlight .ss {
-      color: @green;
-    } /* Literal.String.Symbol */
-    .mw-highlight .bp {
-      color: @red;
-    } /* Name.Builtin.Pseudo */
-    .mw-highlight .fm {
-      color: @sapphire;
-    } /* Name.Function.Magic */
-    .mw-highlight .vc {
-      color: @yellow;
-    } /* Name.Variable.Class */
-    .mw-highlight .vg {
-      color: @text;
-    } /* Name.Variable.Global */
-    .mw-highlight .vi {
-      color: @text;
-    } /* Name.Variable.Instance */
-    .mw-highlight .vm {
-      color: @text;
-    } /* Name.Variable.Magic */
-    .mw-highlight .il {
-      color: @peach;
-    } /* Literal.Number.Integer.Long */
-    .mw-highlight .linenos {
-      color: @overlay0;
-    } /* Line numbers */
 
     .mw-redirect {
       color: @green !important;
@@ -1476,9 +1267,13 @@
   }
 
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Updates syntax highlighting to use the generated variables from our official Pygments addon to the Python port.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
