### PR TITLE
fix(duckduckgo): translations infobox

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.1.1
+@version 0.1.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -169,6 +169,32 @@
       .metabar:not(.is-stuck) {
       background-color: @base !important;
     }
+    // translation boxes
+    .module--translations .dropdown--translation-select,
+    .module--translations-translatedtext {
+      background: @surface0 !important;
+      border-color: @surface0;
+    }
+    .module--translations .module--translations-translatedtext.is-placeholder,
+    .module--translations-original textarea::placeholder {
+      color: @subtext1;
+    }
+    .module--translations-swap-svg {
+      fill: @text !important;
+    }
+    .module--translations-original textarea,
+    .module--translations-translatedtext,
+    .module--translations-footer a {
+      color: @text;
+    }
+    .module--translations-clear,
+    .module--translations-copy {
+      color: @subtext0 !important;
+    }
+    .modal__list__filter input {
+      background: @mantle;
+    }
+
     //coding info box
     .module:not(
         .module--carousel,
@@ -331,17 +357,13 @@
     }
 
     .tile__display {
-      box-shadow:
-        inset -1px -1px 0 @overlay0,
-        inset 1px 1px 0 @overlay0 !important;
+      box-shadow: inset -1px -1px 0 @overlay0, inset 1px 1px 0 @overlay0 !important;
       background-color: @base !important;
       border-color: @surface2 !important;
       color: @text !important;
     }
     .tile__display.selected {
-      box-shadow:
-        inset -1px -1px 0 @blue,
-        inset 1px 1px 0 @blue !important;
+      box-shadow: inset -1px -1px 0 @blue, inset 1px 1px 0 @blue !important;
     }
 
     .tile__ctrl--important {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
the translation infobox

<table>
<tr>
 <td>
before
 <td>
 after
<tr>
 <td>
<img width="691" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/8794d845-4f9e-4d74-b157-c8c634691aca">
 <td>
<img width="714" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/75516746-5380-45d8-98d1-e4fb7765787c">

</table>

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
