### PR TITLE
ci(website): dont bother with reusing workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,5 +8,13 @@ on:
 
 jobs:
   deploy:
-    uses: catppuccin/catppuccin/.github/workflows/website.yml@main
+    runs-on: ubuntu-latest
+    environment: website
+    name: Vercel Deploy
+    steps:
+      - name: Deploy via cURL
+        shell: bash
+        env:
+          DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: curl -X POST "$DEPLOY_HOOK"
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json


### PR DESCRIPTION
What I tried to do earlier is currently impossible, GitHub have it on their public roadmap for this functionality: https://github.com/github/roadmap/issues/636 

Frankly, I can't be bothered and it doesn't make sense to over-engineer the CI if I have to duplicate the secrets anyways, just copied the file from catppuccin/catppuccin
