### PR TITLE
fix(vercel): theme some regressions, use accent for link color

### DIFF
--- a/styles/vercel/catppuccin.user.css
+++ b/styles/vercel/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Vercel Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/vercel
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/vercel
-@version 0.0.5
+@version 0.0.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/vercel/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Avercel
 @description Soothing pastel theme for Vercel
@@ -70,20 +70,26 @@
     --accents-6: @overlay1;
     --accents-7: @overlay2;
     --accents-8: @subtext0;
-    --geist-link-color: @rosewater;
+    --geist-link-color: @accent-color;
     --geist-selection: @subtext0;
     --geist-success: @blue;
     --geist-error: @red;
     --geist-cyan: @teal;
+    --ds-red-400: @red;
 
     --ds-background-100: @base;
-    --ds-background-200: @surface0;
+    --ds-background-200: @mantle;
     --ds-gray-100: @base;
     --ds-gray-200: @surface0;
     --ds-gray-300: @surface1;
+    --ds-gray-400: @surface1;
     --ds-gray-1000: @text;
     --ds-gray-900: @subtext0;
     --ds-gray-800: @subtext1;
+    --ds-gray-700: @subtext1;
+    --ds-gray-alpha-400: @surface0;
+      
+    --themed-hover-bg: @subtext1;
 
     --ds-red-800: @red;
     --ds-red-900: lighten(@red, 5%);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed elements, updates some vars (link color, secondary bg color).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
