### PR TITLE
feat(twitch): predictions, inputs, pause/play button, ad text overlay

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.1.21
+@version 1.2.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.1.20
+@version 1.1.21
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -92,8 +92,7 @@
     div.hype-train-progress-bar-info-view__level-container p,
     div.hype-train-approaching-view__leftSide p,
     div.hype-train-expanded-layout p,
-    div.hype-train-expanded-layout svg,
-    .CoreText-sc-1txzju1-0 {
+    div.hype-train-expanded-layout svg {
       color: @text;
     }
 
@@ -596,7 +595,50 @@
       --color-background-overlay-alt: @mantle;
       --color-background-button-overlay-text-hover: @crust;
       --color-border-overlay: @surface0;
+      --color-background-button-disabled: @surface0;
+      --color-text-button-disabled: @subtext0;
     }
+      
+      /* Predictions */
+      .fixed-prediction-button {
+          color: @text !important;
+          
+          .channel-points-icon svg {
+              color: @text !important;
+          }
+      }
+      [style*="rgb(255, 255, 255)"] {
+          color: @base !important;
+      }
+      [style="color: rgb(56, 122, 255);"] {
+          color: @blue !important;
+      }
+      [style="color: rgb(245, 0, 155);"] {
+          color: @pink !important;
+      }
+      .fixed-prediction-button--blue, [style*="background-color: rgb(56, 122, 255);"], [style*="background: rgb(56, 122, 255);"] {
+          background-color: @blue !important;
+      }
+      .fixed-prediction-button--pink, [style*="background-color: rgb(245, 0, 155);"], [style*="background: rgb(245, 0, 155);"] {
+          background-color: @pink !important;
+      }
+
+      input[disabled] {
+          background-color: @surface0;
+      }
+      .chat-wysiwyg-input__placeholder {
+          color: @subtext0;
+      }
+      
+      button[aria-label="Play"], button[aria-label="Pause"] {
+          & + div svg {
+            color: @subtext0;
+          }
+      }
+      
+      [data-a-target="video-ad-label"], [data-a-target="video-ad-countdown"] {
+          color: @text !important;
+      }
   }
 }
 @-moz-document domain("dashboard.twitch.tv") {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes predictions, disabled inputs and input placeholder text, the pause/play button when you tap space bar, and the text overlay on ads.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
