### PR TITLE
feat: catppuccin loading gif, additional vars

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.4.1
+@version      1.5.0
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -295,7 +295,7 @@
     --control-bgColor-rest: #21262d;
     --control-bgColor-hover: #292e36;
     --control-bgColor-active: #31363e;
-    --control-bgColor-disabled: #21262db3;
+    --control-bgColor-disabled: fade(@mantle, 60%);
     --control-bgColor-selected: #161b22;
     --control-fgColor-rest: #c9d1d9;
     --control-fgColor-placeholder: #484f58;
@@ -326,10 +326,10 @@
     --control-checked-bgColor-disabled: #6e7681;
     --control-checked-fgColor-rest: @text;
     --control-checked-fgColor-disabled: #010409;
-    --control-checked-borderColor-rest: #1f6feb;
-    --control-checked-borderColor-hover: #2a7aef;
-    --control-checked-borderColor-active: #3685f3;
-    --control-checked-borderColor-disabled: #6e7681;
+    --control-checked-borderColor-rest: @blue;
+    --control-checked-borderColor-hover: @sapphire;
+    --control-checked-borderColor-active: @sky;
+    --control-checked-borderColor-disabled: @surface0;
     --controlTrack-bgColor-rest: @surface0;
     --controlTrack-bgColor-hover: @surface1;
     --controlTrack-bgColor-active: @surface2;
@@ -425,7 +425,7 @@
     --buttonCounter-danger-fgColor-hover: @text;
     --buttonCounter-danger-fgColor-disabled: fade(@red, 50%);
     --focus-outlineColor: @blue;
-    --menu-bgColor-active: #161b22;
+    --menu-bgColor-active: @mantle;
     --overlay-bgColor: @mantle;
     --overlay-borderColor: @surface0;
     --overlay-backdrop-bgColor: #161b2266;
@@ -671,6 +671,22 @@
         '<svg width="16" height="16" viewBox="0 0 16 16" fill="@{subtext0}" xmlns="http://www.w3.org/2000/svg"><path d="m4.427 9.427 3.396 3.396a.25.25 0 0 0 .354 0l3.396-3.396A.25.25 0 0 0 11.396 9H4.604a.25.25 0 0 0-.177.427M4.423 6.47 7.82 3.072a.25.25 0 0 1 .354 0L11.57 6.47a.25.25 0 0 1-.177.427H4.6a.25.25 0 0 1-.177-.427"/></svg>'
       );
       background-image: url("data:image/svg+xml,@{svg}");
+    }
+
+    picture:has(img[src="https://github.githubassets.com/assets/mona-loading-default-c3c7aad1282f.gif"])
+    {
+      justify-content: center;
+      display: flex;
+
+      img {
+        display: block;
+        box-sizing: border-box;
+        background: url("https://giscus.catppuccin.com/assets/loading_48x48.gif")
+          no-repeat;
+        width: 48px;
+        height: 48px;
+        padding-left: 48px;
+      }
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Replaces GitHub's mona loading gif with a spinny Catppuccin logo gif, themes some additional vars that fixes controls (radio buttons) and various other elements.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
