### PR TITLE
fix(github): use accent on radio buttons

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -326,9 +326,9 @@
     --control-checked-bgColor-disabled: #6e7681;
     --control-checked-fgColor-rest: @text;
     --control-checked-fgColor-disabled: #010409;
-    --control-checked-borderColor-rest: @blue;
-    --control-checked-borderColor-hover: @sapphire;
-    --control-checked-borderColor-active: @sky;
+    --control-checked-borderColor-rest: @accent-color;
+    --control-checked-borderColor-hover: @accent-color;
+    --control-checked-borderColor-active: @accent-color;
     --control-checked-borderColor-disabled: @surface0;
     --controlTrack-bgColor-rest: @surface0;
     --controlTrack-bgColor-hover: @surface1;


### PR DESCRIPTION
Make these accent:
![image](https://github.com/catppuccin/userstyles/assets/71222764/69850a92-771e-495c-8ad6-206e54485ba7)