### PR TITLE
chore(openmediavault): use correct brand name spelling

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -561,7 +561,7 @@ userstyles:
       app-link: "https://www.npmjs.com/"
       current-maintainers: [*uncenter]
   openmediavault:
-    name: OpenMediaVault
+    name: openmediavault
     categories: [productivity]
     color: sky
     readme:

--- a/styles/openmediavault/catppuccin.user.css
+++ b/styles/openmediavault/catppuccin.user.css
@@ -1,11 +1,11 @@
 /* ==UserStyle==
-@name OpenMediaVault Catppuccin
+@name openmediavault Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/openmediavault
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/openmediavault
 @version 0.0.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/openmediavault/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aopenmediavault
-@description Soothing pastel theme for OpenMediaVault
+@description Soothing pastel theme for openmediavault
 @author Catppuccin
 @license MIT
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Changes the spelling from "OpenMediaVault" to "openmediavault", which is how they spell it on their website/branding (https://www.openmediavault.org/).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
