### PR TITLE
chore(codeberg): use the ctp/gitea pages deployment urls

### DIFF
--- a/styles/codeberg/catppuccin.user.css
+++ b/styles/codeberg/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Codeberg Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/codeberg
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/codeberg
-@version 1.0.2
+@version 1.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/codeberg/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acodeberg
 @description Soothing pastel theme for Codeberg
@@ -16,10 +16,10 @@
 ==/UserStyle== */
 @-moz-document domain('codeberg.org') {
   @import (css)
-    url("https://git.isabelroses.com/assets/css/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
+    url("https://catppuccin.github.io/gitea/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
     (prefers-color-scheme: light);
   @import (css)
-    url("https://git.isabelroses.com/assets/css/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
+    url("https://catppuccin.github.io/gitea/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
     (prefers-color-scheme: dark);
 
   #catppuccin(@lookup, @accent) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Lets use the much much more robust ctp/gitea pages deployment urls instead of my forgejo instance

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
