### PR TITLE
ci: fix path bugs on windows

### DIFF
--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -9,9 +9,8 @@ import { join } from "std/path/mod.ts";
 
 const ROOT = import.meta.dirname;
 if (!ROOT) {
-  throw new Error("ROOT was not located.")
+  throw new Error("ROOT was not located.");
 }
-
 
 /**
  * absolute path to the repository

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -6,7 +6,13 @@ import userStylesSchema from "@/userstyles.schema.json" with {
 };
 
 import { join } from "std/path/mod.ts";
-const ROOT = new URL(".", import.meta.url).pathname;
+
+const ROOT = import.meta.dirname;
+if (!ROOT) {
+  throw new Error("ROOT was not located.")
+}
+
+
 /**
  * absolute path to the repository
  */

--- a/scripts/lint/metadata.ts
+++ b/scripts/lint/metadata.ts
@@ -17,7 +17,7 @@ export const verifyMetadata = async (
   userstyles: Userstyles,
 ) => {
   // `usercss-meta` prohibits any '\r' characters, which seem to be present on Windows.
-  content = content.replaceAll('\r\n', '\n');
+  content = content.replaceAll("\r\n", "\n");
 
   const assert = assertions(userstyle, userstyles);
   const file = relative(REPO_ROOT, entry.path);

--- a/scripts/lint/metadata.ts
+++ b/scripts/lint/metadata.ts
@@ -16,6 +16,9 @@ export const verifyMetadata = async (
   userstyle: string,
   userstyles: Userstyles,
 ) => {
+  // `usercss-meta` prohibits any '\r' characters, which seem to be present on Windows.
+  content = content.replaceAll('\r\n', '\n');
+
   const assert = assertions(userstyle, userstyles);
   const file = relative(REPO_ROOT, entry.path);
 


### PR DESCRIPTION
This fixes an issue where, on Windows, paths would be prefixed with a leading `/`. This is invalid and would cause path resolution to fail. 

This does bump the minimum deno version 1.40. This requirement will need further discussion.