### PR TITLE
feat(instagram): theme story ring around profile picture

### DIFF
--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -143,7 +143,7 @@
       }
       &[aria-label^="Story by"]:not([aria-label$="not seen"]) span {
         outline-color: @surface2;
-        outline-width: 0.1rem;
+        outline-width: 0.075rem;
       }
     }
 

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -125,6 +125,28 @@
       background-color: @accent-color !important;
     }
 
+    /* Story seen / not seen ring */
+    button:has(canvas + span > img[alt$="'s profile picture"]) {
+      canvas {
+        display: none;
+      }
+        
+      span {
+        outline-style: solid;
+        outline-offset: 0.15rem;
+      }
+        
+        
+      &[aria-label^="Story by"][aria-label$="not seen"] span {
+        outline-color: @mauve;
+        outline-width: 0.2rem;
+      }
+      &[aria-label^="Story by"]:not([aria-label$="not seen"]) span {
+        outline-color: @surface2;
+        outline-width: 0.1rem;
+      }
+    }
+
     /* Posts */
     ._aggc {
       background-color: @mantle;

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.2.0
+@version 0.2.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes the ring around a user's profile picture in the story bar up top.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
