### PR TITLE
fix(chatgpt): some other login page

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.2.5
+@version 0.2.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -927,6 +927,147 @@
   }
 }
 
+@-moz-document domain("auth.openai.com") {
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    color-scheme: if(@lookup = latte, light, dark);
+    color: @text;
+    caret-color: @text;
+
+    a {
+      color: @accent-color;
+    }
+
+    body,
+    .oai-header,
+    .login-container {
+      background-color: @base;
+    }
+
+    img[alt="OpenAI's Logo"] {
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="@{text}"><path d="M29.293 13.167a7.77 7.77 0 0 0-.668-6.388 7.87 7.87 0 0 0-8.472-3.774A7.77 7.77 0 0 0 14.288.39a7.87 7.87 0 0 0-7.504 5.446 7.78 7.78 0 0 0-5.201 3.773 7.87 7.87 0 0 0 .968 9.223 7.78 7.78 0 0 0 .668 6.388 7.87 7.87 0 0 0 8.473 3.774 7.78 7.78 0 0 0 5.866 2.615 7.87 7.87 0 0 0 7.506-5.449 7.78 7.78 0 0 0 5.2-3.773 7.87 7.87 0 0 0-.97-9.22M17.559 29.57a5.83 5.83 0 0 1-3.746-1.354c.048-.026.131-.071.185-.105l6.216-3.59a1.01 1.01 0 0 0 .511-.885v-8.765l2.627 1.517a.1.1 0 0 1 .052.072v7.258a5.86 5.86 0 0 1-5.846 5.85M4.989 24.2a5.83 5.83 0 0 1-.698-3.92c.047.028.126.077.185.11l6.216 3.59a1.01 1.01 0 0 0 1.021 0l7.59-4.382v3.034a.1.1 0 0 1-.038.08l-6.284 3.628a5.857 5.857 0 0 1-7.992-2.142M3.354 10.63A5.83 5.83 0 0 1 6.4 8.065l-.003.214v7.181a1.01 1.01 0 0 0 .51.884l7.589 4.382-2.627 1.517a.1.1 0 0 1-.089.008L5.495 18.62a5.857 5.857 0 0 1-2.141-7.99m21.587 5.024-7.59-4.382 2.628-1.516a.1.1 0 0 1 .088-.008l6.284 3.628a5.852 5.852 0 0 1-.904 10.558v-7.396a1.01 1.01 0 0 0-.507-.884m2.615-3.936-.184-.11-6.217-3.59a1.01 1.01 0 0 0-1.021 0L12.544 12.4V9.366a.1.1 0 0 1 .038-.08l6.283-3.625a5.851 5.851 0 0 1 8.691 6.059m-16.439 5.408-2.628-1.517a.1.1 0 0 1-.051-.072V8.281a5.851 5.851 0 0 1 9.594-4.492l-.184.105-6.217 3.59a1.01 1.01 0 0 0-.51.884zm1.428-3.078 3.38-1.952 3.381 1.951v3.902l-3.38 1.951-3.38-1.951z"/></svg>'
+      );
+      height: 0 !important;
+      width: 0 !important;
+      padding-left: 32px !important;
+      padding-top: 32px !important;
+      margin-top: 32px;
+      background: url("data:image/svg+xml,@{svg}") no-repeat !important;
+    }
+
+    .title {
+      color: @text;
+    }
+
+    .email-input {
+      background-color: @base;
+      border-color: @surface0;
+      color: @text;
+
+      &:focus,
+      &:valid {
+        border-color: @accent-color;
+
+        & + .email-label {
+          color: @accent-color;
+          background-color: @base;
+        }
+      }
+    }
+    .email-label {
+      background-color: @base;
+      color: @subtext0;
+    }
+
+    .continue-btn {
+      background-color: @accent-color;
+      color: @base;
+    }
+
+    .divider-wrapper {
+      &::before,
+      &::after {
+        border-bottom-color: @surface2;
+      }
+    }
+
+    .social-btn {
+      background-color: @mantle;
+      border-color: @surface0;
+      color: @text;
+    }
+
+    @orange: mix(@red, @yellow);
+
+    .social-logo {
+      height: 0 !important;
+      width: 0 !important;
+      padding-left: 20px !important;
+      padding-top: 20px !important;
+    }
+
+    img[alt="Google logo"] {
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 20 20" width="20" height="20"><defs><path id="a" d="M18.542 8.333H10v3.542h4.917c-.459 2.25-2.375 3.542-4.917 3.542C7 15.417 4.583 13 4.583 10S7 4.583 10 4.583c1.292 0 2.458.458 3.375 1.208l2.667-2.667C14.417 1.708 12.333.833 10 .833 4.917.833.833 4.917.833 10S4.916 19.167 10 19.167c4.583 0 8.75-3.333 8.75-9.167 0-.542-.083-1.125-.208-1.667"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path clip-path="url(#b)" fill="@{orange}" d="M0 15.417V4.583L7.083 10z"/><path clip-path="url(#b)" fill="@{red}" d="M0 4.583 7.083 10 10 7.458l10-1.625V0H0z"/><path clip-path="url(#b)" fill="@{green}" d="m0 15.417 12.5-9.583 3.292.417L20 0v20H0z"/><path clip-path="url(#b)" fill="@{blue}" d="M20 20 7.083 10 5.416 8.75l14.583-4.167z"/></svg>'
+      );
+      background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
+    }
+    img[alt="Microsoft logo"] {
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path fill="@{orange}" d="M.952.952h8.571v8.571H.952z"/><path fill="@{sapphire}" d="M.952 10.476h8.571v8.571H.952z"/><path fill="@{green}" d="M10.476.952h8.571v8.571h-8.571z"/><path fill="@{yellow}" d="M10.476 10.476h8.571v8.571h-8.571z"/></svg>'
+      );
+
+      background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
+    }
+    img[alt="Apple logo"] {
+      @svg: escape(
+        '<svg width="20" xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 20 20"><path fill="@{text}" d="M17.691 15.324a10.3 10.3 0 0 1-1.025 1.842q-.81 1.152-1.32 1.595-.79.727-1.696.747-.652 0-1.567-.374-.916-.373-1.687-.373-.808 0-1.735.373-.928.376-1.499.394-.87.037-1.735-.767-.553-.482-1.381-1.652-.888-1.249-1.46-2.9-.613-1.783-.613-3.456 0-1.916.829-3.302.65-1.112 1.736-1.756c1.086-.644 1.505-.648 2.347-.662q.69.001 1.815.422 1.123.422 1.44.423.238 0 1.596-.499 1.283-.462 2.17-.385 2.407.193 3.609 1.9-2.151 1.305-2.129 3.647.02 1.825 1.321 3.032a4.4 4.4 0 0 0 1.32.866 15 15 0 0 1-.336.884M14.013.852q0 1.43-1.042 2.667c-.838.979-1.851 1.545-2.95 1.456a3 3 0 0 1-.022-.361c0-.915.398-1.894 1.106-2.695q.53-.608 1.347-1.011.816-.398 1.541-.436.02.191.02.381z"/></svg>'
+      );
+      background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
+    }
+  }
+}
+
 @-moz-document domain("auth0.openai.com") {
   @media (prefers-color-scheme: light) {
     :root {
@@ -988,7 +1129,7 @@
     --gray-dark: @overlay2;
     --gray-darkest: @text;
 
-    .c4ca43590 {
+    .cb2dfcee4 {
       background-color: @accent-color;
       color: @base;
     }
@@ -1007,23 +1148,25 @@
 
     @orange: mix(@red, @yellow);
 
-    .c7e427425[data-provider^="google"] {
-      @svg: escape(
-        '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48"><defs><path id="a" d="M44.5 20H24v8.5h11.8C34.7 33.9 30.1 37 24 37c-7.2 0-13-5.8-13-13s5.8-13 13-13c3.1 0 5.9 1.1 8.1 2.9l6.4-6.4C34.6 4.1 29.6 2 24 2 11.8 2 2 11.8 2 24s9.8 22 22 22c11 0 21-8 21-22 0-1.3-.2-2.7-.5-4"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path clip-path="url(#b)" fill="@{orange}" d="M0 37V11l17 13z"/><path clip-path="url(#b)" fill="@{red}" d="m0 11 17 13 7-6.1L48 14V0H0z"/><path clip-path="url(#b)" fill="@{green}" d="m0 37 30-23 7.9 1L48 0v48H0z"/><path clip-path="url(#b)" fill="@{blue}" d="M48 48 17 24l-4-3 35-10z"/></svg>'
-      );
-      background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
-    }
-    .c7e427425[data-provider^="windowslive"] {
-      @svg: escape(
-        '<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21"><path fill="@{orange}" d="M1 1h9v9H1z"/><path fill="@{sapphire}" d="M1 11h9v9H1z"/><path fill="@{green}" d="M11 1h9v9h-9z"/><path fill="@{yellow}" d="M11 11h9v9h-9z"/></svg>'
-      );
-      background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
-    }
-    .c7e427425[data-provider^="apple"] {
-      @svg: escape(
-        '<svg width="170" xmlns="http://www.w3.org/2000/svg" height="170"><path fill="@{text}" d="M150.37 130.25c-2.45 5.66-5.35 10.87-8.71 15.66-4.58 6.53-8.33 11.05-11.22 13.56-4.48 4.12-9.28 6.23-14.42 6.35-3.69 0-8.14-1.05-13.32-3.18-5.197-2.12-9.973-3.17-14.34-3.17-4.58 0-9.492 1.05-14.746 3.17-5.262 2.13-9.501 3.24-12.742 3.35-4.929.21-9.842-1.96-14.746-6.52-3.13-2.73-7.045-7.41-11.735-14.04-5.032-7.08-9.169-15.29-12.41-24.65-3.471-10.11-5.211-19.9-5.211-29.378 0-10.857 2.346-20.221 7.045-28.068 3.693-6.303 8.606-11.275 14.755-14.925s12.793-5.51 19.948-5.629c3.915 0 9.049 1.211 15.429 3.591 6.362 2.388 10.447 3.599 12.238 3.599 1.339 0 5.877-1.416 13.57-4.239 7.275-2.618 13.415-3.702 18.445-3.275 13.63 1.1 23.87 6.473 30.68 16.153-12.19 7.386-18.22 17.731-18.1 31.002.11 10.337 3.86 18.939 11.23 25.769 3.34 3.17 7.07 5.62 11.22 7.36-.9 2.61-1.85 5.11-2.86 7.51M119.11 7.24c0 8.102-2.96 15.667-8.86 22.669-7.12 8.324-15.732 13.134-25.071 12.375a25 25 0 0 1-.188-3.07c0-7.778 3.386-16.102 9.399-22.908q4.504-5.168 11.45-8.597c4.62-2.252 8.99-3.497 13.1-3.71.12 1.083.17 2.166.17 3.24z"/></svg>'
-      );
-      background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
+    button > span {
+      &[data-provider^="google"] {
+        @svg: escape(
+          '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48"><defs><path id="a" d="M44.5 20H24v8.5h11.8C34.7 33.9 30.1 37 24 37c-7.2 0-13-5.8-13-13s5.8-13 13-13c3.1 0 5.9 1.1 8.1 2.9l6.4-6.4C34.6 4.1 29.6 2 24 2 11.8 2 2 11.8 2 24s9.8 22 22 22c11 0 21-8 21-22 0-1.3-.2-2.7-.5-4"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path clip-path="url(#b)" fill="@{orange}" d="M0 37V11l17 13z"/><path clip-path="url(#b)" fill="@{red}" d="m0 11 17 13 7-6.1L48 14V0H0z"/><path clip-path="url(#b)" fill="@{green}" d="m0 37 30-23 7.9 1L48 0v48H0z"/><path clip-path="url(#b)" fill="@{blue}" d="M48 48 17 24l-4-3 35-10z"/></svg>'
+        );
+        background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
+      }
+      &[data-provider^="windowslive"] {
+        @svg: escape(
+          '<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21"><path fill="@{orange}" d="M1 1h9v9H1z"/><path fill="@{sapphire}" d="M1 11h9v9H1z"/><path fill="@{green}" d="M11 1h9v9h-9z"/><path fill="@{yellow}" d="M11 11h9v9h-9z"/></svg>'
+        );
+        background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
+      }
+      &[data-provider^="apple"] {
+        @svg: escape(
+          '<svg width="170" xmlns="http://www.w3.org/2000/svg" height="170"><path fill="@{text}" d="M150.37 130.25c-2.45 5.66-5.35 10.87-8.71 15.66-4.58 6.53-8.33 11.05-11.22 13.56-4.48 4.12-9.28 6.23-14.42 6.35-3.69 0-8.14-1.05-13.32-3.18-5.197-2.12-9.973-3.17-14.34-3.17-4.58 0-9.492 1.05-14.746 3.17-5.262 2.13-9.501 3.24-12.742 3.35-4.929.21-9.842-1.96-14.746-6.52-3.13-2.73-7.045-7.41-11.735-14.04-5.032-7.08-9.169-15.29-12.41-24.65-3.471-10.11-5.211-19.9-5.211-29.378 0-10.857 2.346-20.221 7.045-28.068 3.693-6.303 8.606-11.275 14.755-14.925s12.793-5.51 19.948-5.629c3.915 0 9.049 1.211 15.429 3.591 6.362 2.388 10.447 3.599 12.238 3.599 1.339 0 5.877-1.416 13.57-4.239 7.275-2.618 13.415-3.702 18.445-3.275 13.63 1.1 23.87 6.473 30.68 16.153-12.19 7.386-18.22 17.731-18.1 31.002.11 10.337 3.86 18.939 11.23 25.769 3.34 3.17 7.07 5.62 11.22 7.36-.9 2.61-1.85 5.11-2.86 7.51M119.11 7.24c0 8.102-2.96 15.667-8.86 22.669-7.12 8.324-15.732 13.134-25.071 12.375a25 25 0 0 1-.188-3.07c0-7.778 3.386-16.102 9.399-22.908q4.504-5.168 11.45-8.597c4.62-2.252 8.99-3.497 13.1-3.71.12 1.083.17 2.166.17 3.24z"/></svg>'
+        );
+        background-image: url("data:image/svg+xml;charset=utf-8,@{svg}");
+      }
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

For some reason OpenAI has two nearly identical login/auth pages, but on different domains with different tech stacks. Anyways, this themes the newer one and updates the old one.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
