### PR TITLE
fix(duckduckgo): various unthemed elements

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -16,16 +16,12 @@
 ==/UserStyle== */
 
 @-moz-document domain(duckduckgo.com) {
-  @media (prefers-color-scheme: light) {
-    :root {
-      #catppuccin(@lightFlavor, @accentColor);
-    }
+  :root:not(.dark-bg) {
+    #catppuccin(@lightFlavor, @accentColor);
   }
 
-  @media (prefers-color-scheme: dark) {
-    :root {
-      #catppuccin(@darkFlavor, @accentColor);
-    }
+  :root.dark-bg {
+    #catppuccin(@darkFlavor, @accentColor);
   }
 
   /* prettier-ignore */
@@ -493,13 +489,8 @@
     .howItWorksSection_downloadsCard__U3Ph9,
     .metabar__grid-btn,
     .feedback-btn__icon-wrap .set-bookmarklet__input .btn,
-    .btn:visited,
-    .btn:active,
-    .btn.btn--primary,
     .btn.btn--secondary,
-    .btn--primary:hover,
     .btn.is-disabled,
-    .btn.is-disabled:hover,
     input,
     textarea,
     .frm__input,
@@ -510,10 +501,8 @@
     .zci--json_validator textarea,
     .colorpicker,
     .feedback-modal__submit.is-disabled,
-    .feedback-modal__submit.is-disabled:hover,
     .feedback-modal__submit.is-disabled:active,
     .feedback-modal__submit.is-disabled:focus,
-    .btn.btn--skeleton:hover,
     .module__section,
     .module--carousel__item,
     .is-related-search-exp.dark-bg,
@@ -526,6 +515,32 @@
       background-color: @surface0 !important;
     }
 
+    .btn.is-disabled:hover,
+    .frm__switch__label:hover,
+    .feedback-modal__submit.is-disabled:hover,
+    .btn.btn--skeleton:hover {
+      background-color: @surface2 !important;
+      border-color: @surface2 !important;
+    }
+    .is-checked .frm__switch__label.btn {
+      background-color: @accent-color !important;
+      color: @mantle !important;
+    }
+    .js-set-exit {
+      background-color: @accent-color !important;
+      border-color: @accent-color !important;
+      color: @base !important;
+    }
+    .js-set-exit:hover {
+      background-color: fade(@accent-color, 80%) !important;
+      border-color: fade(@accent-color, 80%) !important;
+      color: @base !important;
+    }
+    .frm__switch__label {
+      background-color: @surface0;
+      border-color: @surface0;
+      color: @text !important;
+    }
     .set-bookmarklet__data {
       background-color: @surface2;
       color: @text;
@@ -609,7 +624,6 @@
     .c-detail__desc,
     .c-detail__filemeta,
     .c-detail__more,
-    .btn,
     .frm__label,
     .js-cloudsave-new-suggestion {
       color: @text !important;
@@ -700,9 +714,6 @@
     .ddgsi-check::before {
       color: @mantle !important;
     }
-    .frm__switch__label {
-      background-color: @blue;
-    }
     .set-bookmarklet__title,
     .set-reset__title {
       color: @text !important;
@@ -720,9 +731,7 @@
     .switch.is-on {
       background-color: @accent-color;
     }
-
-    .dropdown__switch.is-on::before,
-    .frm__switch__label {
+    .dropdown__switch.is-on::before {
       color: @base !important;
     }
     .search--header {

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.1.3
+@version 0.1.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -21,6 +21,7 @@
       #catppuccin(@lightFlavor, @accentColor);
     }
   }
+
   @media (prefers-color-scheme: dark) {
     :root {
       #catppuccin(@darkFlavor, @accentColor);
@@ -683,10 +684,10 @@
       color: @base !important;
     }
 
-    .settings-page-wrapper .btn--primary {
+    .settings-page-wrapper.is-checked {
       border-color: @blue;
-      background-color: @blue !important;
-      color: @crust !important;
+      background-color: @sapphire !important;
+      color: @mantle !important;
     }
     .modal--dropdown--settings
       .settings-dropdown--section
@@ -696,14 +697,22 @@
         color: @text !important;
       }
     }
+    .ddgsi-check::before {
+      color: @mantle !important;
+    }
+    .frm__switch__label {
+      background-color: @blue;
+    }
+    .set-bookmarklet__title,
+    .set-reset__title {
+      color: @text !important;
+    }
     .frm__select::after {
       color: @accent-color !important;
     }
 
-    .js-region-filter-switch,
-    .frm__switch__label {
+    .js-region-filter-switch {
       background-color: @overlay0 !important;
-      border-color: @accent-color !important;
     }
     .switch__knob {
       background: @text !important;

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -514,11 +514,15 @@
     .js-definitions-internal {
       background-color: @surface0 !important;
     }
+    .module--carousel__item {
+      border-color: @surface1 !important;
+    }
 
     .btn.is-disabled:hover,
     .frm__switch__label:hover,
     .feedback-modal__submit.is-disabled:hover,
-    .btn.btn--skeleton:hover {
+    .btn.btn--skeleton:hover,
+    .module__footer-carousel__label:hover {
       background-color: @surface2 !important;
       border-color: @surface2 !important;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
 on/off buttons + save and exit buttons on settings page + selected theme checkmark, closes #735 
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
