### PR TITLE
feat(youtube): changed links and timecode to use accent color

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -572,9 +572,9 @@
 
     /* link */
     .yt-core-attributed-string__link--call-to-action-color {
-      color: @sapphire !important;
+      color: @accent-color !important;
       &:hover {
-        color: @teal !important;
+        color: lighten(@accent-color, 7.5) !important;
       }
     }
 

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.5.2
+@version 3.5.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
this changes link colors and timecodes to be based on accent

before:
![before](https://raw.githubusercontent.com/BPplays/images/main/catppuccin_userstyles/ytlcol/before.png)


after:
![after](https://raw.githubusercontent.com/BPplays/images/main/catppuccin_userstyles/ytlcol/after.png)



[here is the video that im testing on](https://www.youtube.com/watch?v=g0F_hTGYa0Y)
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
