### PR TITLE
fix(github): danger buttons, notifications bug

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -227,8 +227,8 @@
     --control-transparent-borderColor-hover: #0000;
     --control-transparent-borderColor-active: #0000;
     --control-danger-fgColor-rest: @red;
-    --control-danger-fgColor-hover: #ff7b72;
-    --control-danger-bgColor-hover: fade(@red, 26%);
+    --control-danger-fgColor-hover: @crust;
+    --control-danger-bgColor-hover: fade(@red, 80%);
     --control-danger-bgColor-active: @red;
     --control-checked-bgColor-rest: #1f6feb;
     --control-checked-bgColor-hover: #2a7aef;
@@ -466,7 +466,7 @@
     --color-prettylights-syntax-markup-changed-text: @text;
     --color-prettylights-syntax-markup-changed-bg: fadeout(@yellow, 60%);
     --color-prettylights-syntax-markup-ignored-text: @text;
-    --color-scale-white: @text;
+    --color-scale-white: @base;
     --color-scale-gray-3: @overlay2;
     --color-scale-gray-5: @overlay0;
     --color-scale-gray-6: @surface1;

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.5.2
+@version      1.5.3
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -178,7 +178,7 @@
     --codeMirror-gutterMarker-fgColor-default: @base;
     --codeMirror-gutterMarker-fgColor-muted: @overlay0;
     --codeMirror-lineNumber-fgColor: @subtext1;
-    --codeMirror-cursor-fgColor: #e6edf3;
+    --codeMirror-cursor-fgColor: @text;
     --codeMirror-selection-bgColor: #388bfd66;
     --codeMirror-activeline-bgColor: #6e768166;
     --codeMirror-matchingBracket-fgColor: @text;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes danger buttons properly, fixes a bug with unread notifications on latte.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
