### PR TITLE
fix(github): overlay background color, text selection

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.5.3
+@version      1.5.4
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -335,7 +335,7 @@
     --buttonCounter-danger-fgColor-disabled: fade(@red, 50%);
     --focus-outlineColor: @blue;
     --menu-bgColor-active: @mantle;
-    --overlay-bgColor: @mantle;
+    --overlay-bgColor: @base;
     --overlay-borderColor: @surface0;
     --overlay-backdrop-bgColor: #161b2266;
     --selectMenu-borderColor: #484f58;
@@ -347,7 +347,7 @@
     --underlineNav-borderColor-active: @accent-color;
     --underlineNav-borderColor-hover: #6e768166;
     --underlineNav-iconColor-rest: #848d97;
-    --selection-bgColor: #1f6febb3;
+    --selection-bgColor: fade(@accent-color, 30%);
     --reactionButton-selected-bgColor-rest: fade(@accent-color, 20%);
     --reactionButton-selected-bgColor-hover: fade(@accent-color, 35%);
     --reactionButton-selected-fgColor-rest: @accent-color;
@@ -466,6 +466,7 @@
     --color-prettylights-syntax-markup-changed-text: @text;
     --color-prettylights-syntax-markup-changed-bg: fadeout(@yellow, 60%);
     --color-prettylights-syntax-markup-ignored-text: @text;
+    --bgColor-white: @base;
     --color-scale-white: @base;
     --color-scale-gray-3: @overlay2;
     --color-scale-gray-5: @overlay0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the `--overlay-bgColor` variable being a shade wrong, themes the text selection color (in certain places).

| Before | After |
| --- | --- |
| ![Screenshot 2024-04-02 at 17 30 29 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/15b0f5a6-5418-47ab-a195-0b0baedb7ea6) | ![Screenshot 2024-04-02 at 17 30 13 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/ed7d8a41-e345-4d83-a528-3aad6dfd6b9c) |


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
