### PR TITLE
fix(youtube): misc

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.5.3
+@version 3.5.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -505,6 +505,7 @@
     .ytp-panel-header,
     .ytp-panel-footer,
     .ytp-menuitem-label,
+    .ytp-premium-label,
     .ytp-menuitem-content,
     .ytp-menuitem-label-count,
     .ytp-menu-label-secondary {
@@ -1039,9 +1040,8 @@
       fill: @accent-color !important;
     }
 
-    [fill="white"],
-    [fill="#fff"] {
-      fill: @base !important;
+    [fill="white"] {
+      fill: if(@lookup = latte, @base, @text) !important;
     }
 
     ::-webkit-scrollbar {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes a change I made in #745 that broke icons in dark themes and themes another label in a popup menu.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
