### PR TITLE
fix(duckduckgo): lyrics box text

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -167,6 +167,24 @@
       .metabar:not(.is-stuck) {
       background-color: @base !important;
     }
+
+    /* lyrics box */
+    .js-lyrics-module {
+      color: @subtext1 !important;
+    }
+    .module--lyrics__subtitle-box {
+      border-color: @surface2;
+    }
+    .module__inner-toggle--chevron {
+      color: @accent-color !important;
+      background-color: @surface1 !important;
+      border-color: @surface2;
+    }
+    .module__inner-toggle::before,
+    .module__inner-toggle::after {
+      background-color: @surface2 !important;
+    }
+
     // translation boxes
     .module--translations .dropdown--translation-select,
     .module--translations-translatedtext {
@@ -726,9 +744,6 @@
       color: @accent-color !important;
     }
 
-    .js-region-filter-switch {
-      background-color: @overlay0 !important;
-    }
     .switch__knob {
       background: @text !important;
     }

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.1.4
+@version 0.1.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
title.

<table>
<tr>
 <td>
Before
 <td>
 After
<tr>
 <td>
<img height="500" src="https://github.com/catppuccin/userstyles/assets/29279972/b99949b5-456c-4715-9ab7-f824600e7af4">
 <td>
 <img height="500" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/ec7e039d-5d3c-4b64-ba7f-703a73914520">
</table>

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
