### PR TITLE
fix(tree-wide): use base for --ctp-base variables

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.2.6
+@version 0.2.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -84,7 +84,7 @@
     --ctp-surface2: #rgbify(@surface2) [];
     --ctp-surface1: #rgbify(@surface1) [];
     --ctp-surface0: #rgbify(@surface0) [];
-    --ctp-base: #rgbify(@crust) [];
+    --ctp-base: #rgbify(@base) [];
     --ctp-mantle: #rgbify(@mantle) [];
     --ctp-crust: #rgbify(@crust) [];
 

--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name PyPI Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pypi
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pypi
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pypi/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apypi
 @description Soothing pastel theme for PyPI

--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -70,7 +70,7 @@
     --ctp-surface2: @surface2;
     --ctp-surface1: @surface1;
     --ctp-surface0: @surface0;
-    --ctp-base: @crust;
+    --ctp-base: @base;
     --ctp-mantle: @mantle;
     --ctp-crust: @crust;
 

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.11
+@version 0.0.12
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -78,7 +78,7 @@
     --ctp-surface2: @surface2;
     --ctp-surface1: @surface1;
     --ctp-surface0: @surface0;
-    --ctp-base: @crust;
+    --ctp-base: @base;
     --ctp-mantle: @mantle;
     --ctp-crust: @crust;
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

the `--ctp-base` variable used `@crust` instead of `@base`

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
