### PR TITLE
fix(youtube): misc player changes

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.5.6
+@version 3.5.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -512,6 +512,10 @@
       color: @text;
     }
 
+    .ytp-panel-header {
+      border-bottom-color: @surface2;
+    }
+
     .ytp-menuitem svg > path:not([fill="none"]) {
       fill: @text !important;
     }
@@ -723,10 +727,10 @@
       color: @text !important;
     }
 
-    /* Player tooltip background */
     .ytp-tooltip-text {
       background: @surface0 !important;
       color: @text;
+      text-shadow: none !important;
     }
 
     .iv-card:hover .iv-card-primary-link,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes a border in the video player's setting menu, removes `text-shadow` (blurry/fuzzy text) from the timestamp tooltip when hovering over the progress bar.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
