### PR TITLE
chore(lint): disable keyframes-name-pattern

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -24,6 +24,7 @@ export default {
     "alpha-value-notation": null,
     "color-function-notation": null,
     "hue-degree-notation": null,
+    "keyframes-name-pattern": null,
 
     // Needed for Stylus v1.5.35 workaround, see #341
     "media-feature-range-notation": "prefix",


### PR DESCRIPTION
https://github.com/catppuccin/userstyles/pull/760#discussion_r1551103677. I've confirmed that this fixes the lint message.