### PR TITLE
fix(github): misc + actions ansi text

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -202,12 +202,12 @@
     --avatar-shadow: 0px 0px 0px 2px #0d1117;
     --avatarStack-fade-bgColor-default: @surface1;
     --avatarStack-fade-bgColor-muted: #21262d;
-    --control-bgColor-rest: #21262d;
+    --control-bgColor-rest: @red;
     --control-bgColor-hover: #292e36;
-    --control-bgColor-active: #31363e;
+    --control-bgColor-active: @surface1;
     --control-bgColor-disabled: fade(@mantle, 60%);
     --control-bgColor-selected: #161b22;
-    --control-fgColor-rest: #c9d1d9;
+    --control-fgColor-rest: @text;
     --control-fgColor-placeholder: #484f58;
     --control-fgColor-disabled: @surface0;
     --control-borderColor-rest: @surface1;
@@ -355,7 +355,7 @@
     --fgColor-default: @text;
     --fgColor-muted: @subtext1;
     --fgColor-onEmphasis: @base;
-    --fgColor-white: @base;
+    --fgColor-white: if(@lookup = latte, @crust, @text);
     --fgColor-disabled: @surface2;
     --fgColor-link: @accent-color;
     --fgColor-neutral: #6e7681;
@@ -466,7 +466,7 @@
     --color-prettylights-syntax-markup-changed-text: @text;
     --color-prettylights-syntax-markup-changed-bg: fadeout(@yellow, 60%);
     --color-prettylights-syntax-markup-ignored-text: @text;
-    --bgColor-white: @base;
+    --bgColor-white: if(@lookup = latte, @crust, @text);
     --color-scale-white: @base;
     --color-scale-gray-3: @overlay2;
     --color-scale-gray-5: @overlay0;
@@ -532,6 +532,30 @@
     }
     .header-search-button.placeholder {
       color: @subtext0;
+    }
+
+    .CheckStep {
+      .ansifg-r {
+        color: var(--color-ansi-red) 
+      }
+      .ansifg-y {
+        color: var(--color-ansi-yellow) 
+      }
+      .ansifg-g {
+        color: var(--color-ansi-green) 
+      }
+      .ansifg-b {
+        color: var(--color-ansi-blue) 
+      }
+      .ansifg-c {
+        color: var(--color-ansi-cyan) 
+      }
+      .ansifg-m {
+        color: var(--color-ansi-magenta) 
+      }
+      .ansifg-gr {
+        color: var(--color-ansi-gray) 
+      }
     }
 
     ::selection {

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.0
+@version      1.6.1
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -170,7 +170,7 @@
     --diffBlob-deletion-bgColor-num: fadeout(@red, 70%);
     --diffBlob-deletion-bgColor-line: fadeout(@red, 85%);
     --diffBlob-deletion-bgColor-word: fadeout(@red, 70%);
-    --diffBlob-hunk-bgColor-num: fadeout(@blue, 60%);
+    --diffBlob-hunk-bgColor-num: fadeout(@accent-color, 60%);
     --diffBlob-expander-iconColor: #848d97;
     --codeMirror-fgColor: @text;
     --codeMirror-bgColor: @base;
@@ -230,11 +230,11 @@
     --control-danger-fgColor-hover: @crust;
     --control-danger-bgColor-hover: fade(@red, 80%);
     --control-danger-bgColor-active: @red;
-    --control-checked-bgColor-rest: #1f6feb;
-    --control-checked-bgColor-hover: #2a7aef;
-    --control-checked-bgColor-active: #3685f3;
+    --control-checked-bgColor-rest: @accent-color;
+    --control-checked-bgColor-hover: lighten(@accent-color, 5%);
+    --control-checked-bgColor-active: lighten(@accent-color, 5%);
     --control-checked-bgColor-disabled: #6e7681;
-    --control-checked-fgColor-rest: @text;
+    --control-checked-fgColor-rest: @crust;
     --control-checked-fgColor-disabled: #010409;
     --control-checked-borderColor-rest: @accent-color;
     --control-checked-borderColor-hover: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes various parts around GitHub Actions, including ansi text within Actions logs.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
