### PR TITLE
fix(github): improvements to disabled buttons

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.2
+@version      1.6.3
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -209,7 +209,7 @@
     --control-bgColor-selected: #161b22;
     --control-fgColor-rest: @text;
     --control-fgColor-placeholder: #484f58;
-    --control-fgColor-disabled: @surface0;
+    --control-fgColor-disabled: fade(@subtext0, 70%);
     --control-borderColor-rest: @surface1;
     --control-borderColor-emphasis: #666e79;
     --control-borderColor-disabled: fade(@surface1, 75%);
@@ -259,11 +259,11 @@
     --button-default-bgColor-hover: @surface1;
     --button-default-bgColor-active: @surface2;
     --button-default-bgColor-selected: @surface2;
-    --button-default-bgColor-disabled: fade(@base, 70%);
+    --button-default-bgColor-disabled: fade(@surface0, 70%);
     --button-default-borderColor-rest: @surface1;
     --button-default-borderColor-hover: @surface1;
     --button-default-borderColor-active: @surface1;
-    --button-default-borderColor-disabled: #21262db3;
+    --button-default-borderColor-disabled: fade(@surface0, 70%);
     --button-default-shadow-resting: 0px 0px 0px 0px #000;
     --button-primary-fgColor-rest: @base;
     --button-primary-fgColor-disabled: fade(@base, 60%);
@@ -271,7 +271,7 @@
     --button-primary-bgColor-rest: @green;
     --button-primary-bgColor-hover: lighten(@green, 5%);
     --button-primary-bgColor-active: saturate(@green, 5%);
-    --button-primary-bgColor-disabled: darken(desaturate(@green, 10%), 10%);
+    --button-primary-bgColor-disabled: fade(@green, 70%);
     --button-primary-borderColor-rest: @green;
     --button-primary-borderColor-hover: @green;
     --button-primary-borderColor-active: @green;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Various fixes to disabled buttons to make them properly have contrast while sticking with Catppuccin theme.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
