### PR TITLE
fix(instagram): direct messages not respecting chosen flavor

### DIFF
--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.2.1
+@version 0.2.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -65,6 +65,7 @@
     .x1iyjqo2,
     .xl56j7k {
       --web-always-black: #rgbify(@dark-color) [];
+      --ig-primary-icon: #rgbify(@text) [];
       --web-always-white: #rgbify(@light-color) [];
       --always-white: #rgbify(@light-color) [];
       --overlay-alpha-80: fadeout(@dark-color, 50);
@@ -730,9 +731,11 @@
 }
 
 @-moz-document regexp('^.*instagram.com/direct.*') {
-  :root {
-    #catppuccin(@darkFlavor,
-        @accentColor);
+  ._aa4d {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+  ._aa4c {
+    #catppuccin(@lightFlavor, @accentColor);
   }
   #catppuccin(@lookup,
     @accent) {
@@ -770,7 +773,7 @@
     }
     [style*="background-color: rgb(55, 151, 240);"] {
       background-color: @blue !important;
-      color: @mantle;
+      color: @mantle !important;
     }
     .xvbhtw8 {
       background-color: @mantle;

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -108,7 +108,6 @@
       --ig-stroke-prism: #rgbify(@crust) [];
       scrollbar-color: @accent-color @crust;
     }
-
     #splash-screen {
       background-color: @base !important;
     }
@@ -225,6 +224,12 @@
     }
     span[data-bloks-name="bk.components.TextSpan"] {
       color: @accent-color !important;
+    }
+    .xs7f9wi {
+      background-color: @mantle !important;
+    }
+    .x1d72o {
+      background-color: @surface0;
     }
     /* Log In With Facebook text */
     ._ab37 {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
title

<table>
<tr>
 <td>
Before
 <td>
 After
<tr>
 <td>
<img width="1000" src="https://github.com/catppuccin/userstyles/assets/29279972/8c6aa5c0-a6d7-4559-8cb0-d1b46db00b32">
 <td>
<img width="1036" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/7d2422d9-684a-4668-bad0-4365981f8e84">

</table>

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
