### PR TITLE
fix(youtube): hide weird canvas behind video player

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.5.7
+@version 3.5.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -800,6 +800,10 @@
     /* ambient mode */
     #cinematics {
       mix-blend-mode: lighten;
+
+      canvas {
+        display: none;
+      }
     }
 
     /* badges e.g. popular */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

| Unthemed | Before | After |
| --- | --- | --- |
| ![image](https://github.com/catppuccin/userstyles/assets/47499684/3f3fa6e4-9994-4376-afd6-b7b705f4e4e6) | ![image](https://github.com/catppuccin/userstyles/assets/47499684/2f6d2397-a00f-437e-ab21-1fc2367a27fe) | ![image](https://github.com/catppuccin/userstyles/assets/47499684/fbd437fc-7496-48de-b44c-6fbd0d400a42)

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
