### PR TITLE
fix(youtube): ambient mode header improvments

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 3.5.7
+@version 3.5.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -390,10 +390,9 @@
       background-color: @base !important;
     }
 
-    /* transparent header bar */
+    /* header bar icons */
     #container.ytd-masthead {
       --iron-icon-fill-color: @text !important;
-      background-color: @base !important;
     }
 
     ytd-feed-filter-chip-bar-renderer[expand-instead-of-scroll]


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Example of ambient mode flowing into header.

![image](https://github.com/catppuccin/userstyles/assets/71222764/aa278b07-d4ee-49c4-91f2-e56e8ba77593)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
