### PR TITLE
docs(README): link to `userstylesyml.md` for maintainer requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,10 @@ See [CONTRIBUTING.md](docs/CONTRIBUTING.md).
 ## 🖌 Userstyles
 
 > [!IMPORTANT]
-> Userstyles labeled with the "🚧" emoji are looking for maintainers, and may not work as intended. Contributions are still welcome and encouraged. If you would like to become a maintainer, add your username to the `current-maintainers` array in the [userstyles.yml](./scripts/userstyles.yml) file.
+> Userstyles labeled with the "🚧" emoji are looking for maintainers, and may
+> not work as intended. Contributions are still welcome and encouraged. If you
+> would like to become a maintainer, follow the instructions outlined in
+> "[Adding yourself as a maintainer](https://github.com/catppuccin/userstyles/blob/main/docs/userstylesyml.md#adding-yourself-as-a-maintainer)."
 
 <!-- AUTOGEN:USERSTYLES START -->
 <!-- the following section is auto-generated, do not edit -->


### PR DESCRIPTION
I don't think you can do relative markdown links with anchors in other files, happy to change it if you can.

I've followed the link format widely seen in [GitHub's documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository#troubleshooting-cloning-errors).