### PR TITLE
fix(github): "invisible" button bg color, focus outline

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.3
+@version      1.6.4
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -286,10 +286,10 @@
     --button-invisible-bgColor-rest: #0000;
     --button-invisible-bgColor-hover: #b1bac41f;
     --button-invisible-bgColor-active: #b1bac433;
-    --button-invisible-bgColor-disabled: #21262db3;
+    --button-invisible-bgColor-disabled: fade(@surface1, 70%);
     --button-invisible-borderColor-rest: #0000;
     --button-invisible-borderColor-hover: #0000;
-    --button-invisible-borderColor-disabled: #21262db3;
+    --button-invisible-borderColor-disabled: fade(@surface1, 70%);
     --button-outline-fgColor-rest: #388bfd;
     --button-outline-fgColor-hover: #58a6ff;
     --button-outline-fgColor-active: @text;
@@ -333,7 +333,7 @@
     --buttonCounter-danger-fgColor-rest: @red;
     --buttonCounter-danger-fgColor-hover: @text;
     --buttonCounter-danger-fgColor-disabled: fade(@red, 50%);
-    --focus-outlineColor: @blue;
+    --focus-outlineColor: @accent-color;
     --menu-bgColor-active: @mantle;
     --overlay-bgColor: @base;
     --overlay-borderColor: @surface0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes one very specific button (the "suggest changes" button in the toolbar of PR comment box on some occasions), changes the outline color of input elements from blue to accent.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
