### PR TITLE
fix(youtube): text on top of reels video player

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.1
+@version 4.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -489,7 +489,7 @@
         fill: @crust !important;
       }
     }
-    .yt-spec-icon-badge-shape--style-overlay .yt-spec-icon-badge-shape__icon {
+    .yt-spec-icon-badge-shape--style-overlay .yt-spec-icon-badge-shape__icon, .yt-spec-icon-badge-shape {
       color: @text;
     }
 
@@ -803,6 +803,11 @@
     }
 
     #shorts-container {
+      --yt-spec-static-overlay-text-primary: @white;
+      .yt-spec-button-shape-next--overlay.yt-spec-button-shape-next--tonal {
+        color: @white;
+      }
+
       ytd-reel-video-renderer:not([is-watch-while-mode]) {
         .yt-spec-button-shape-with-label__label {
           color: @subtext1;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the text on top of the reels video player being `@text` all the time instead of `@white`. Also themes the notification bell button properly.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
