### PR TITLE
chore(deps): update `catppuccin/catppuccin` schema

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "@/": "./scripts/",
     "std/": "https://deno.land/std@0.206.0/",
-    "catppuccin-repo/": "https://raw.githubusercontent.com/catppuccin/catppuccin/35662dbfb46b23d63eca9d3794cdc107c8ff92d3/",
+    "catppuccin-repo/": "https://raw.githubusercontent.com/catppuccin/catppuccin/7c731582d0df386727304360972b4a993120e33d/",
     "@actions/core": "npm:@actions/core@1.10.1",
     "@octokit/rest": "npm:@octokit/rest@20.0.2",
     "ajv": "npm:ajv@8.12.0",

--- a/deno.lock
+++ b/deno.lock
@@ -1641,7 +1641,7 @@
     "https://esm.sh/v135/type-fest@4.8.1/denonext/source/union-to-intersection.d.js": "4dda98575465ccb71439587d666e602980113bf8d01bb42067ca6ffeb4fae0e3",
     "https://esm.sh/v135/type-fest@4.8.1/source/simplify.d": "7359c9f2ef1a0d33486b54d31afe5a266317a370d20fe6947f245f4dca9de376",
     "https://esm.sh/v135/type-fest@4.8.1/source/union-to-intersection.d": "8a73c629d0507dd707e4cbaa3f745ffbd74b5073191ce522afc2ac0639f748cd",
-    "https://raw.githubusercontent.com/catppuccin/catppuccin/35662dbfb46b23d63eca9d3794cdc107c8ff92d3/resources/ports.schema.json": "72f41d9f98ec8e747c66ec98c2d159c10990be5a169c214c7f7c2167c83dab56",
+    "https://raw.githubusercontent.com/catppuccin/catppuccin/7c731582d0df386727304360972b4a993120e33d/resources/ports.schema.json": "19ddf4faf970a93acfb666541e37ba41d7d6c298d265255bd3d56dc9af45d91e",
     "https://raw.githubusercontent.com/catppuccin/palette/v0.2.0/palette-porcelain.json": "a13a97027e630bdac3a498696b9465f6f947ec6abc2acfee9084e9a951effe4b"
   },
   "workspace": {

--- a/scripts/types/userstyles.d.ts
+++ b/scripts/types/userstyles.d.ts
@@ -48,7 +48,7 @@ export type Category =
   | "wiki"
   | "window_manager";
 /**
- * The fill color for the icon on the Catppuccin website.
+ * The fill color for the icon on the Catppuccin website, which should match the color used by Simple Icons. If the icon does not exist in Simple Icons, choose the most suitable color from the branding.
  */
 export type Color =
   | "rosewater"


### PR DESCRIPTION
Fixes the generate workflow, might be worth looking into if we can make it not fail on purely additive properties but unsure if that's possible and/or a slippery slope to worse behaviour.