### PR TITLE
fix(github): header shenanigans

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.4
+@version      1.6.5
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -201,10 +201,10 @@
     --codeMirror-syntax-fgColor-support: #79c0ff;
     --codeMirror-syntax-fgColor-variable: @peach;
     --header-fgColor-default: @text;
-    --header-fgColor-logo: #f0f6fc;
+    --header-fgColor-logo: @text;
     --header-bgColor: @crust;
     --header-borderColor-divider: #8b949e;
-    --headerSearch-bgColor: @base;
+    --headerSearch-bgColor: @mantle;
     --headerSearch-borderColor: @surface0;
     --avatar-bgColor: fade(@text, 26%);
     --avatar-borderColor: @surface0;
@@ -315,7 +315,7 @@
     --button-danger-fgColor-active: @base;
     --button-danger-fgColor-disabled: fade(@red, 50%);
     --button-danger-iconColor-rest: @red;
-    --button-danger-iconColor-hover: @text;
+    --button-danger-iconColor-hover: @crust;
     --button-danger-bgColor-rest: @surface0;
     --button-danger-bgColor-hover: @red;
     --button-danger-bgColor-active: darken(@red, 5%);
@@ -541,6 +541,9 @@
     }
     .header-search-button.placeholder {
       color: @subtext0;
+    }
+    .HeaderMenu-toggle-bar {
+      background-color: @text;
     }
 
     .CheckStep {

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -545,6 +545,9 @@
     .HeaderMenu-toggle-bar {
       background-color: @text;
     }
+    .notification-indicator .mail-status {
+      background-image: linear-gradient(@accent-color, darken(@accent-color, 5%));
+    }
 
     .CheckStep {
       .ansifg-r {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the header (on the Gists website at least) and an unthemed hamburger menu on the main website's logged out header.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
