### PR TITLE
fix(youtube): misc

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -620,6 +620,11 @@
       visibility: hidden;
     }
 
+    /* "Suggestion removed" */
+    .sbpqs_c {
+      color: @overlay1;
+    }
+
     .sbpqs_a::before,
     .sbqs_c::before {
       @svg: escape(

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -656,14 +656,26 @@
     }
 
     /* Thumbnails */
+
     #time-status:has([aria-label="LIVE"]),
     .badge[aria-label="LIVE"] {
       --yt-spec-static-overlay-text-primary: @crust;
       --yt-spec-static-overlay-icon-active-other: @crust;
     }
     #thumbnail [style="background-color: rgba(51, 51, 51, 0.8);"],
-    #video-preview .ytp-inline-preview-scrim + .ytp-inline-preview-controls {
+    .YtInlinePlayerControlsTopRightControlsCircleButton,
+    .badge-shape-wiz--default.badge-shape-wiz--overlay,
+    .branding-context-container-inner {
       background-color: @surface0 !important;
+      color: @text;
+    }
+    .ytp-sb-unsubscribe {
+      background-color: @surface2;
+      color: @text;
+    }
+    .ytp-sb-subscribe {
+      background-color: @accent-color;
+      color: @crust;
     }
 
     /* Panels, popups, tooltips */

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.3
+@version 4.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -615,8 +615,8 @@
     /* Video description */
 
     #description {
-      [style="color: rgb(255, 255, 255);"],
-      [style="color: rgb(19, 19, 19);"] {
+      [style*="color: rgb(255, 255, 255);"],
+      [style*="color: rgb(19, 19, 19);"] {
         color: @text !important;
       }
     }

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.4
+@version 4.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
Fixes the selectors to theme description text no matter what other styles are together with the listed rule inline.

Also themes this:
![image](https://github.com/catppuccin/userstyles/assets/47499684/2acbbc76-9504-4393-a5dd-4eab9adf9a9e)

And:
![image](https://github.com/catppuccin/userstyles/assets/47499684/d285ebec-586a-469e-94d5-d8e9e8b9695d)
