### PR TITLE
chore(maintainers): update url for `Tnixc`

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -49,7 +49,7 @@ collaborators:
     url: https://github.com/GitMuslim
   - &tnixc
     name: Tnixc
-    url: https://github.com/tnixc
+    url: https://github.com/Tnixc
   - &elkrien
     name: Elkrien
     url: https://github.com/elkrien


### PR DESCRIPTION
This avoids a headache I ran into while implementing https://github.com/catppuccin/website/issues/61 as the URL in [catppuccin/catppuccin](https://github.com/catppuccin/catppuccin/blob/89111dff968c42f9774c18c2957465616b51b205/resources/ports.yml#L256) is `Tnixc`.

We may want to enforce our own rules such as lowercase URLs to avoid this type of mismatch between repositories in the future.

Also this does raise consistency concerns which should be discussed further in another issue, e.g. the `name` field could potentially be different too.