### PR TITLE
fix(twitter): translated by google svg

### DIFF
--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitter Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitter
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitter
-@version 1.0.4
+@version 1.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitter/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitter
 @description Soothing pastel theme for Twitter
@@ -763,6 +763,10 @@
         fill: @accent-color !important;
       }
     }
+      
+      a[aria-label^="Translated from"][aria-label$="by Google"] svg path {
+          fill: @text !important;
+      }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

| Before | After |
| --- | --- |
| ![Screenshot 2024-04-11 at 16 18 29 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/dd892de3-74eb-45fd-ac5c-f164cd4e9bd4) | ![Screenshot 2024-04-11 at 16 17 57 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/5cbc8142-60bf-413e-8cf3-2da43b37fc87) |

Wasn't sure where to put it, just stuck at at the end. Lmk if I should move it somewhere else!

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
