### PR TITLE
fix(snapchat-web): Story reply text.

### DIFF
--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Snapchat Web Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/snapchat-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/snapchat-web
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/snapchat-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Asnapchat-web
 @description Soothing pastel theme for Snapchat Web

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -150,6 +150,11 @@
       }
     }
 
+    // story reply text
+    li button[type="button"].replyText {
+      background-color: rgba(30, 30, 30, 0.8);
+    }
+
     // buttons when in call
     [data-projection-id] button {
       --sigColorAlwaysWhite: @surface0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the story reply text background.
Without theme:
![image](https://github.com/catppuccin/userstyles/assets/50887230/a0e89f9c-7393-4058-aec3-c21e5c3d3e63)
Old version of theme:
![image](https://github.com/catppuccin/userstyles/assets/50887230/20b0e80b-8446-4720-a37e-4fb92631a55e)
New version of theme:
![image](https://github.com/catppuccin/userstyles/assets/50887230/6f950f23-a470-4101-934f-f1126cb2d4b5)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
