### PR TITLE
fix(youtube): additional button variant

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.5
+@version 4.0.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -560,6 +560,11 @@
       &.yt-spec-button-shape-next--tonal,
       &.yt-spec-button-shape-next--text {
         color: @text;
+      }
+        
+      &.yt-spec-button-shape-next--filled {
+        color: @crust;
+        background-color: @accent-color;
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes the subscribe button on youtube shorts.
![Screenshot 2024-04-12 at 18 22 37 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/00a95933-454f-4dfc-a180-57d3958b8e84)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
