### PR TITLE
refactor(tree-wide): cleanup extra syntax

### DIFF
--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -315,7 +315,7 @@
     div[style*="background-color: rgb(191, 225, 255)"],
     div[style*="background-color: rgb(1, 37, 97)"] {
       background-color: fadeout(@accent-color, 70%) !important;
-      & > svg > path[fill="#52acfe"] {
+      > svg > path[fill="#52acfe"] {
         fill: @accent-color;
       }
     }

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -1022,7 +1022,7 @@
       &:valid {
         border-color: @accent-color;
 
-        & + .email-label {
+        + .email-label {
           color: @accent-color;
           background-color: @base;
         }

--- a/styles/formative/catppuccin.user.css
+++ b/styles/formative/catppuccin.user.css
@@ -251,7 +251,7 @@
       &.IconWarningButton__RootButton-sc-1b683n6-0:hover {
         border-color: @red;
       }
-      & > svg[width="16"] {
+      > svg[width="16"] {
         path {
           stroke: @red;
         }

--- a/styles/hackage/catppuccin.user.css
+++ b/styles/hackage/catppuccin.user.css
@@ -193,7 +193,7 @@
         a {
           color: @text !important;
         }
-        & + li {
+        + li {
           border-color: @overlay2;
         }
       }

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -99,8 +99,8 @@
     .subtext,
     .comhead {
       &,
-      & a:link,
-      & a:visited {
+      a:link,
+      a:visited {
         color: @overlay2;
       }
     }

--- a/styles/minesweeper/catppuccin.user.css
+++ b/styles/minesweeper/catppuccin.user.css
@@ -178,13 +178,13 @@
     }
 
     #premium_content > div:nth-child(21) {
-      & > p:nth-child(3) > code:nth-child(1) {
+      > p:nth-child(3) > code:nth-child(1) {
         color: @peach !important;
       }
-      & > p:nth-child(4) > code:nth-child(1) {
+      > p:nth-child(4) > code:nth-child(1) {
         color: @blue !important;
       }
-      & > p:nth-child(5) > code:nth-child(1) {
+      > p:nth-child(5) > code:nth-child(1) {
         color: @green !important;
       }
     }

--- a/styles/npm/catppuccin.user.css
+++ b/styles/npm/catppuccin.user.css
@@ -199,14 +199,14 @@
           background-color: @subtext1;
         }
 
-        & > div {
+        > div {
           border-color: @crust;
 
           &:focus-within {
             border-color: @subtext1;
           }
 
-          & > div {
+          > div {
             background-color: @crust;
 
             input[type="search"] {
@@ -239,7 +239,7 @@
         img[alt="avatar"] {
           border-color: @text;
 
-          & + div > svg {
+          + div > svg {
             fill: @text;
           }
         }
@@ -480,7 +480,7 @@
 
     /* Sidebar provenance popup */
     button[aria-label="View more provenance details"] {
-      & + div > div > div {
+      + div > div > div {
         background-color: @base;
         border-color: @surface0;
 
@@ -492,7 +492,7 @@
           border-bottom-color: @surface0;
         }
 
-        & > div {
+        > div {
           div:nth-of-type(2) {
             border-color: @surface0;
           }
@@ -728,7 +728,7 @@
     #user-content-keywords {
       color: @text;
 
-      & + ul a {
+      + ul a {
         color: @red;
 
         &:hover {
@@ -812,7 +812,7 @@
             color: @subtext0;
           }
         }
-        & + div {
+        + div {
           color: @text;
         }
       }
@@ -911,7 +911,7 @@
       color: @text;
 
       &,
-      & + div {
+      + div {
         border-color: @surface0;
       }
     }
@@ -1022,7 +1022,7 @@
     /* --- SEARCH RESULTS --- */
 
     [aria-labelledby="search_ranking_radiogroup_label"] {
-      & > div:focus-within {
+      > div:focus-within {
         outline-style: none;
       }
 
@@ -1102,11 +1102,11 @@
     footer {
       a[href="https://github.com/npm"] svg
       {
-        & > polygon {
+        > polygon {
           fill: @base;
         }
 
-        & > rect {
+        > rect {
           fill: @text;
         }
       }

--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -136,12 +136,12 @@
       > div.col-span-4
       > div
       > div:nth-child(2) {
-      & > div:nth-child(1):hover,
-      & > div:nth-child(2):hover,
-      & > div:nth-child(3) > div > div:hover {
+      > div:nth-child(1):hover,
+      > div:nth-child(2):hover,
+      > div:nth-child(3) > div > div:hover {
         background: @surface1 !important;
       }
-      & path {
+      path {
         fill: @accent-color;
       }
     }
@@ -162,7 +162,7 @@
 
     .sc-aXZVg {
       background: @mantle;
-      & path {
+      path {
         fill: @text !important;
       }
     }

--- a/styles/planet-minecraft/catppuccin.user.css
+++ b/styles/planet-minecraft/catppuccin.user.css
@@ -167,7 +167,7 @@
       .content-actions li {
         background: @surface0;
 
-        & a,
+        a,
         .link,
         .js_link,
         .js_link_m {
@@ -179,7 +179,7 @@
       .content-actions li .js_link_m:hover,
       .content-actions li .link:hover,
       .content-actions li a:hover {
-        & .material-icons {
+        .material-icons {
           color: @text !important;
         }
 
@@ -291,7 +291,7 @@
       background: @green;
       color: @base;
 
-      & .material-icons {
+      .material-icons {
         color: @base;
       }
     }
@@ -340,7 +340,7 @@
         .content-actions li {
           background: @surface0;
 
-          & a,
+          a,
           .link,
           .js_link,
           .js_link_m {
@@ -352,7 +352,7 @@
         .content-actions li .js_link_m:hover,
         .content-actions li .link:hover,
         .content-actions li a:hover {
-          & .material-icons {
+          .material-icons {
             color: @accent-color !important;
           }
           color: @accent-color !important;

--- a/styles/spotify-web/catppuccin.user.css
+++ b/styles/spotify-web/catppuccin.user.css
@@ -336,8 +336,8 @@
     .tippy-box[data-theme~="activation"] {
       background-color: @accent-color;
       color: @crust;
-      & .c0KyMkxeMCWQGE7cR8s_ *,
-      & .TextForLabel-sc-1jqya9m-0.kIsEKW {
+      .c0KyMkxeMCWQGE7cR8s_ *,
+      .TextForLabel-sc-1jqya9m-0.kIsEKW {
         color: @crust;
       }
     }

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -65,7 +65,7 @@
       }
     }
 
-    & body {
+    body {
       background-color: @base;
     }
 
@@ -327,10 +327,10 @@
       color: @text;
     }
 
-    & .carousel-metadata {
+    .carousel-metadata {
       background: @crust;
     }
-    & .carousel-metadata--fadeout {
+    .carousel-metadata--fadeout {
       background: @crust;
     }
     .chat-line__message-body--highlighted {
@@ -389,17 +389,17 @@
     .footer {
       background: @crust;
     }
-    & .whispers-list-item--selected,
-    & .whispers-list-item:hover {
+    .whispers-list-item--selected,
+    .whispers-list-item:hover {
       background-color: @surface0;
     }
-    & .thread-header__title-bar-container--focused {
+    .thread-header__title-bar-container--focused {
       background-color: @mantle;
     }
-    & .thread-header__title-bar-container {
+    .thread-header__title-bar-container {
       background: @mantle;
     }
-    & .thread-header__click-area:focus .thread-header__title-bar-container {
+    .thread-header__click-area:focus .thread-header__title-bar-container {
       background-color: @mantle;
     }
     .navigation-link {
@@ -649,7 +649,7 @@
 
     button[aria-label="Play"],
     button[aria-label="Pause"] {
-      & + div svg {
+      + div svg {
         color: @subtext0;
       }
     }

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -936,12 +936,12 @@
     }
 
     #session .user-menu {
-      & a:focus,
-      & a:hover,
-      & button:focus,
-      & button:hover,
-      & input:focus,
-      & input:hover {
+      a:focus,
+      a:hover,
+      button:focus,
+      button:hover,
+      input:focus,
+      input:hover {
         color: if(@lookup=latte, #fff, @crust);
         background-color: @accent-color;
       }

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -884,7 +884,7 @@
       border-top-color: @surface2;
       border-left-color: @surface2;
       border-right-color: @surface2;
-      & > figcaption {
+      > figcaption {
         background-color: @mantle !important;
         color: @text !important;
         border-bottom-color: @surface2;

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -517,7 +517,7 @@
           g path[fill] {
             fill: @accent-color !important;
 
-            & + [stroke] {
+            + [stroke] {
               stroke: @accent-color !important;
             }
           }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This removes extra `&<space>` syntax. `&` followed by a space is the same thing as if it weren't there (useless).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
