### PR TITLE
fix(youtube): theming for skeleton

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -455,11 +455,7 @@
     #home-chips,
     #search-container {
       background-color: @base;
-    }
-
-    .masthead-skeleton-icon,
-    #menu-icon {
-      z-index: 1;
+      z-index: -1;
     }
 
     #guide-skeleton .guide-ghost-icon,

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.6
+@version 4.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -447,6 +447,26 @@
       --ytd-author-comment-badge-background-color: @surface0 !important;
       --ytd-author-comment-badge-name-color: @text !important;
       --ytd-author-comment-badge-icon-color: @text !important;
+    }
+
+    /* Skeleton */
+    #guide-skeleton,
+    #home-container-skeleton,
+    #home-chips,
+    #search-container {
+      background-color: @base;
+    }
+
+    .masthead-skeleton-icon,
+    #menu-icon {
+      z-index: 1;
+    }
+
+    #guide-skeleton .guide-ghost-icon,
+    #guide-skeleton .guide-ghost-text,
+    .masthead-skeleton-icon,
+    #home-page-skeleton .skeleton-bg-color {
+      background-color: @surface1;
     }
 
     /* Ambient mode */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This PR adds Theming to the skeleton when loading the youtube homepage.

![image](https://github.com/catppuccin/userstyles/assets/69157453/e661dbce-afc9-4fb6-a62f-2ca13c8fde85)
Note: Top is new opened in chromium and bottom is old opened in firefox

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
