### PR TITLE
fix(youtube): custom wiz elements on channel page

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.7
+@version 4.0.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -896,6 +896,23 @@
     }
     .yt-tab-shape-wiz:hover .yt-tab-shape-wiz__tab-bar {
       background-color: @subtext1;
+    }
+    .truncated-text-wiz, .page-header-view-model-wiz__page-header-content-metadata {
+      color: @subtext1;
+    }
+    .page-header-view-model-wiz__page-header-title, [style="color: rgb(255, 255, 255);"]:has(svg), .truncated-text-wiz__absolute-button {
+      color: @text !important;
+    }
+    .yt-contextual-sheet-layout-wiz {
+      background-color: @mantle;
+          
+      .yt-list-item-view-model-wiz__container--tappable:hover {
+        background-color: @surface0;
+      }
+          
+      .yt-list-item-view-model-wiz__title, .yt-list-item-view-model-wiz__accessory, .radio-shape-wiz__label-container {
+        color: @text;
+      }
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes description text, icons, and popup menus on channel pages.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
