### PR TITLE
fix(pypi): misc

### DIFF
--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -90,6 +90,7 @@
 
     ::selection {
       background-color: fade(@accent-color, 30%);
+      color: unset;
     }
 
     input,
@@ -338,6 +339,9 @@
 
     .search-form__search {
       background-color: @surface0 !important;
+    }
+    .search-form__button {
+      color: @subtext0;
     }
 
     .button {
@@ -930,6 +934,27 @@
       }
     }
 
+    .filter-badge {
+      background-color: @accent-color;
+
+      &,
+      .filter-badge__remove-button,
+      .filter-badge__icon {
+        color: @crust;
+      }
+      .filter-badge__remove-button {
+        border-left-color: if(
+          @lookup = latte,
+          lighten(@accent-color, 10%),
+          darken(@accent-color, 5%)
+        );
+
+        &:hover {
+          background-color: darken(@accent-color, 10%);
+        }
+      }
+    }
+
     @media (min-width: 801px) {
       .package-snippet,
       .package-snippet:hover {
@@ -965,7 +990,7 @@
 
     .release__node[src*="blue"] {
       @svg: escape(
-        '<svg xmlns="http://www.w3.org/2000/svg" width="33.809" height="32.025" viewBox="0 0 31.696 30.024"><g stroke="@{text}" stroke-linejoin="bevel" stroke-width=".355"><path fill="@{accent-color}" d="m.178 5.912 15.555 5.662L31.519 5.83 15.963.167z"/><path fill="@{accent-color}" d="M15.733 11.574v18.283l15.786-5.746V5.83zM.178 5.912l15.555 5.662v18.283L.178 24.195z"/></g></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg" width="33.809" height="32.025" viewBox="0 0 31.696 30.024"><g stroke="@{crust}" stroke-linejoin="bevel" stroke-width=".355"><path fill="@{accent-color}" d="m.178 5.912 15.555 5.662L31.519 5.83 15.963.167z"/><path fill="@{accent-color}" d="M15.733 11.574v18.283l15.786-5.746V5.83zM.178 5.912l15.555 5.662v18.283L.178 24.195z"/></g></svg>'
       );
       content: url("data:image/svg+xml,@{svg}");
       background-color: @mantle !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Unsets the color set by PyPI for selected text:

| Before | After |
| --- | --- |
| ![Screenshot 2024-04-15 at 19 46 30 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/524e9c82-1044-495d-9c80-ae6ea926754d) | ![Screenshot 2024-04-15 at 19 46 51 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/ad510857-68f7-4bce-b72b-53253386555b) |

Themes the magnifying glass icon in the search bar:

![Screenshot 2024-04-15 at 19 47 30 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/29c48c6d-97f2-41a3-9720-f442a318dc16)

Themes the filter button/indicator on the results/browse page:

![Screenshot 2024-04-15 at 19 48 27 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/345fa2a7-a564-4a8d-8b4c-24cdf7aefea6)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
