### PR TITLE
fix(youtube): low contrast for the progress bar on thumbails

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -702,8 +702,8 @@
     .ytp-sb-subscribe {
       background-color: @accent-color;
       color: @crust;
-    ;
-    ytd-thumbnail-overlay-resume-playback-renderer ;
+    }
+    ytd-thumbnail-overlay-resume-playback-renderer {
       background-color: @surface1;
     }
 

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.8
+@version 4.0.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -702,6 +702,9 @@
     .ytp-sb-subscribe {
       background-color: @accent-color;
       color: @crust;
+    ;
+    ytd-thumbnail-overlay-resume-playback-renderer ;
+      background-color: @surface1;
     }
 
     /* Panels, popups, tooltips */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes low contrast for the YouTube progress bar on thumbnails

Before: 
![image](https://github.com/catppuccin/userstyles/assets/55464333/63501e66-4c85-445e-9f43-e87033b33c37)

After:
![image](https://github.com/catppuccin/userstyles/assets/55464333/231539c3-7397-4b1b-904a-3e2c452d5bcb)

## 🗒 Checklist 🗒

- [ ] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
