### PR TITLE
fix(pypi): unstyled text

### DIFF
--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -790,6 +790,10 @@
       outline-color: @accent-color !important;
     }
 
+    .verified small {
+      color: @subtext0 !important;
+    }
+
     .sidebar-section .sidebar-section__user-gravatar:active,
     .sidebar-section .sidebar-section__user-gravatar:focus {
       outline-color: @accent-color !important;

--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name PyPI Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pypi
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pypi
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pypi/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apypi
 @description Soothing pastel theme for PyPI


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
this

![image](https://github.com/catppuccin/userstyles/assets/97406176/34bc1556-d978-4430-aee6-3808f404baef)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
