### PR TITLE
fix(github): update markdown headings zindex

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -512,6 +512,11 @@
       content: url("https://giscus.catppuccin.com/assets/loading_48x48.gif");
     }
 
+    article.markdown-body .markdown-heading {
+      z-index: -1;
+      position: relative;
+    }
+
     /* Header when logged out */
     .HeaderMenu-link {
       color: var(--fgColor-default);


### PR DESCRIPTION
Update **GitHub** Userstyle

- Add style for `markdown-headings`, i.e. `#`/`##` in markdown bodys (like `README.md`'s).


## Before

![image](https://github.com/catppuccin/userstyles/assets/7415984/84e0b976-f675-45fa-8313-d6fc75eea3b6)

## After

![image](https://github.com/catppuccin/userstyles/assets/7415984/51d586e1-7a1b-4755-90d4-c77208a93508)
