### PR TITLE
feat(wikipedia): add option for redirect highlight

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -351,7 +351,6 @@
     .mw-redirect when (@highlight-redirect = 1) {
         color: @green !important;
     }
-    
 
     .mbox-text {
       color: @text !important;

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.14
+@version 0.0.15
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -13,6 +13,7 @@
 @var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire*", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+@var checkbox highlight-redirect "Highlight redirect links" 0
 ==/UserStyle== */
 
 @-moz-document domain('wikipedia.org') {
@@ -346,10 +347,11 @@
     .mw-content-ltr.content .mw-highlight-lines pre {
       box-shadow: inset 2.75em 0 0 @surface1;
     }
-
-    .mw-redirect {
-      color: @green !important;
+    
+    .mw-redirect when (@highlight-redirect = 1) {
+        color: @green !important;
     }
+    
 
     .mbox-text {
       color: @text !important;
@@ -884,7 +886,7 @@
       border-top-color: @surface2;
       border-left-color: @surface2;
       border-right-color: @surface2;
-      > figcaption {
+      & > figcaption {
         background-color: @mantle !important;
         color: @text !important;
         border-bottom-color: @surface2;

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -349,7 +349,7 @@
     }
 
     .mw-redirect when (@highlight-redirect = 1) {
-        color: @green !important;
+      color: @green !important;
     }
 
     .mbox-text {

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -347,7 +347,7 @@
     .mw-content-ltr.content .mw-highlight-lines pre {
       box-shadow: inset 2.75em 0 0 @surface1;
     }
-    
+
     .mw-redirect when (@highlight-redirect = 1) {
         color: @green !important;
     }
@@ -886,7 +886,7 @@
       border-top-color: @surface2;
       border-left-color: @surface2;
       border-right-color: @surface2;
-      & > figcaption {
+      > figcaption {
         background-color: @mantle !important;
         color: @text !important;
         border-bottom-color: @surface2;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This puts the green redirect highlight behind an option, as it does not seem to be Wikipedia's default behavior and feels opinionated.

I've done this instead of outright requesting to remove it, as the [contributing guide](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md) does not seem to outright prevent this since it's just a color change. However, it feels against the spirit of the opinionated section to me, and I also just don't like the green 🙃

On (previously the only behavior):
![image](https://github.com/catppuccin/userstyles/assets/55464333/b7b59ce0-da0c-4b1a-b0aa-3c9566755882)

Off (added in this PR):
![image](https://github.com/catppuccin/userstyles/assets/55464333/07c845f7-34c6-49f3-9fdb-c886146e2d7b)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
