### PR TITLE
fix(youtube): low contrast for video player progress

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -423,10 +423,10 @@
     }
     
     .ytp-progress-list {
-      background: fade(@surface1, 30%);
+      background: fade(@surface0, 80%);
     }
     .ytp-load-progress {
-      background: fade(@surface1, 80%);
+      background: fade(@overlay0, 100%);
     }
 
     ytd-expandable-metadata-renderer {

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.9
+@version 4.0.10
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -420,6 +420,13 @@
 
     #ytd-player #container when (@oled =0) {
       background: @crust !important;
+    }
+    
+    .ytp-progress-list {
+      background: fade(@surface1, 30%);
+    }
+    .ytp-load-progress {
+      background: fade(@surface1, 80%);
     }
 
     ytd-expandable-metadata-renderer {

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -422,10 +422,10 @@
       background: @crust !important;
     }
     
-    .ytp-progress-list {
+    .ytp-progress-list when not(@lookup = latte) {
       background: fade(@surface0, 80%);
     }
-    .ytp-load-progress {
+    .ytp-load-progress when not(@lookup = latte) {
       background: fade(@overlay0, 100%);
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Low contrast for the YouTube video player's progress bar

Before, the background was unstyled and could be hard to see at times on Mocha.

![image](https://github.com/catppuccin/userstyles/assets/55464333/26aca765-5b0e-416c-b81e-79b377ab54ba)

After, the background now uses a translucent Surface 0, and the buffer indicator uses an opaque Overlay 0, making it easier to see:

![image](https://github.com/catppuccin/userstyles/assets/55464333/abfaa7b1-588f-44f2-af53-aab7049badca)
![image](https://github.com/catppuccin/userstyles/assets/55464333/f035d120-ec83-4ddc-8121-de2ede10080f)
![image](https://github.com/catppuccin/userstyles/assets/55464333/e366f394-8c82-4920-ae70-eca0791db2ff)

The white background makes the buffer indicator slightly harder to see, but I do not think this is an issue as the YouTube default also has bad contrast:

![image](https://github.com/catppuccin/userstyles/assets/55464333/5d27eeec-ad6c-47b0-9c5f-b21da3c30891)

Latte's contrast suffers from this, so the progress bar is untouched there.

![image](https://github.com/catppuccin/userstyles/assets/55464333/3b60e853-2dde-4371-8aad-3c8b20661595)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
