### PR TITLE
fix(whatsapp-web): nav bar background

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.css
+++ b/styles/whatsapp-web/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name WhatsApp Web Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/whatsapp-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/whatsapp-web
-@version 0.0.7
+@version 0.0.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/whatsapp-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awhatsapp-web
 @description Soothing pastel theme for WhatsApp Web
@@ -95,6 +95,8 @@
     --app-background: @base !important;
 
     /* CHAT LIST */
+    /* nav bar */
+    --navbar-background: @mantle !important;
     /* chat list background */
     --background-default: @base !important;
     /* chat list header */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Whatsapp added a nav bar to the left side. It had the wrong background color so I fixed it.

| Before | After |
|-|-|
|![image](https://github.com/catppuccin/userstyles/assets/27358071/f892b4f5-15ac-4632-bc62-c5602f7bafb5)|![image](https://github.com/catppuccin/userstyles/assets/27358071/a5adeec3-7647-47ac-a568-48b1ce086668)|

Closes #816.


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
