### PR TITLE
fix(github): danger button hover/active border

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.6
+@version      1.6.7
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -313,8 +313,8 @@
     --button-danger-bgColor-active: darken(@red, 5%);
     --button-danger-bgColor-disabled: @base;
     --button-danger-borderColor-rest: @surface1;
-    --button-danger-borderColor-hover: @surface2;
-    --button-danger-borderColor-active: @surface2;
+    --button-danger-borderColor-hover: @red;
+    --button-danger-borderColor-active: darken(@red, 5%);
     --button-danger-shadow-selected: 0px 0px 0px 0px #000;
     --button-inactive-fgColor: #8b949e;
     --button-inactive-bgColor: #21262d;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Changes the borders of danger buttons to match the background color on hover/active. Looks way better :p

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
