### PR TITLE
fix(tldraw): sticky note + white pen color

### DIFF
--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -182,7 +182,8 @@
       [fill="#1d1d1d"],
       [fill="#494949"],
       [fill="#989898"],
-      [fill="#FFFFFF"] {
+      [fill="#FFFFFF"],
+      [fill="#f9f9f9"] {
         fill: var(--color-black) !important;
       }
       [fill="#010403"] {

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -245,7 +245,9 @@
         fill: var(--color-light-violet) !important;
       }
       [stroke="#e1e1e1"],
-      [stroke="#1d1d1d"] {
+      [stroke="#1d1d1d"],
+      [stroke="#f3f3f3"],
+      [stroke="#FFFFFF"] {
         stroke: var(--color-black) !important;
       }
       [stroke="#9398b0"],

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -247,7 +247,8 @@
       [stroke="#e1e1e1"],
       [stroke="#1d1d1d"],
       [stroke="#f3f3f3"],
-      [stroke="#FFFFFF"] {
+      [stroke="#FFFFFF"],
+      [stroke="#f2f2f2"] {
         stroke: var(--color-black) !important;
       }
       [stroke="#9398b0"],
@@ -371,7 +372,9 @@
     }
 
     .tl-note__container {
-      &[style*="rgb(44, 44, 44);"] {
+      &[style*="rgb(44, 44, 44);"],
+      &[style*="rgb(234, 234, 234)"],
+      &[style*="rgb(255, 255, 255)"] {
         background-color: var(--color-black) !important;
       }
       &[style*="rgb(252, 225, 156);"] {
@@ -424,55 +427,53 @@
     }
 
     div:has(.tl-text.tl-text-content) {
-      &[style*="color: rgb(225, 225, 225);"],
+      &[style*="color: rgb(242, 242, 242);"],
+      &[style*="color: rgb(243, 243, 243);"],
+      &[style*="color: rgb(255, 255, 255)"],
       &[style*="color: rgb(29, 29, 29);"] {
         color: var(--color-black) !important;
       }
       &[style*="color: rgb(147, 152, 176);"],
-      &[style*="color: rgb(173, 181, 189);"] {
+      &[style*="color: rgb(173, 181, 189);"],
+      &[style*="color: rgb(159, 168, 178);"] {
         color: var(--color-gray) !important;
-        background-color: var(--color-gray) !important;
-      }
-      &[style*="color: rgb(224, 49, 49);"] {
-        color: var(--color-red) !important;
-        background-color: var(--color-red) !important;
-      }
-      &[style*="color: rgb(255, 135, 135);"] {
-        color: var(--color-light-red) !important;
-        background-color: var(--color-light-red) !important;
-      }
-      &[style*="color: rgb(247, 103, 7);"] {
-        color: var(--color-orange) !important;
-        background-color: var(--color-orange) !important;
-      }
-      &[style*="color: rgb(255, 192, 52);"],
-      &[style*="color: rgb(255, 192, 120);"] {
-        color: var(--color-yellow) !important;
-        background-color: var(--color-yellow) !important;
-      }
-      &[style*="color: rgb(9, 146, 104);"] {
-        color: var(--color-green) !important;
-        background-color: var(--color-green) !important;
-      }
-      &[style*="color: rgb(64, 192, 87);"] {
-        color: var(--color-light-green) !important;
-        background-color: var(--color-light-green) !important;
-      }
-      &[style*="color: rgb(66, 99, 235);"] {
-        color: var(--color-blue) !important;
-        background-color: var(--color-blue) !important;
-      }
-      &[style*="color: rgb(77, 171, 247);"] {
-        color: var(--color-light-blue) !important;
-        background-color: var(--color-light-blue) !important;
       }
       &[style*="color: rgb(174, 62, 201);"] {
         color: var(--color-violet) !important;
-        background-color: var(--color-violet) !important;
       }
       &[style*="color: rgb(229, 153, 247);"] {
         color: var(--color-light-violet) !important;
-        background-color: var(--color-light-violet) !important;
+      }
+      &[style*="color: rgb(79, 114, 252);"],
+      &[style*="color: rgb(68, 101, 233);"] {
+        color: var(--color-blue) !important;
+      }
+      &[style*="color: rgb(77, 171, 247);"],
+      &[style*="color: rgb(75, 161, 241);"] {
+        color: var(--color-light-blue) !important;
+      }
+      &[style*="color: rgb(247, 103, 7);"],
+      &[style*="color: rgb(225, 105, 25);"] {
+        color: var(--color-orange) !important;
+      }
+      &[style*="color: rgb(255, 192, 52);"],
+      &[style*="color: rgb(255, 192, 120);"],
+      &[style*="color: rgb(241, 172, 75);"] {
+        color: var(--color-yellow) !important;
+      }
+      &[style*="color: rgb(9, 146, 104);"] {
+        color: var(--color-green) !important;
+      }
+      &[style*="color: rgb(64, 192, 87);"],
+      &[style*="color: rgb(76, 176, 94);"] {
+        color: var(--color-light-green) !important;
+      }
+      &[style*="color: rgb(224, 49, 49);"] {
+        color: var(--color-red) !important;
+      }
+      &[style*="color: rgb(255, 135, 135);"],
+      &[style*="color: rgb(248, 119, 119);"] {
+        color: var(--color-light-red) !important;
       }
     }
   }

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -193,7 +193,8 @@
       [fill="#9398b0"],
       [fill="#adb5bd"],
       [fill="#bcc3c9"],
-      [fill="#7c8187"] {
+      [fill="#7c8187"],
+      [fill="#9fa8b2"] {
         fill: var(--color-gray) !important;
       }
       [fill="#e03131"],
@@ -203,17 +204,20 @@
       }
       [fill="#ff8787"],
       [fill="#fe9e9e"],
-      [fill="#a56767"] {
+      [fill="#a56767"],
+      [fill="#f87777"] {
         fill: var(--color-light-red) !important;
       }
       [fill="#f76707"],
       [fill="#f78438"],
-      [fill="#9f552d"] {
+      [fill="#9f552d"],
+      [fill="#e16919"] {
         fill: var(--color-orange) !important;
       }
       [fill="#ffc034"],
       [fill="#ffc078"],
-      [fill="#fecb92"] {
+      [fill="#fecb92"],
+      [fill="#f1ac4b"] {
         fill: var(--color-yellow) !important;
       }
       [fill="#099268"],
@@ -223,17 +227,20 @@
       }
       [fill="#40c057"],
       [fill="#65cb78"],
-      [fill="#4e874e"] {
+      [fill="#4e874e"],
+      [fill="#4cb05e"] {
         fill: var(--color-light-green) !important;
       }
       [fill="#4263eb"],
       [fill="#6681ee"],
-      [fill="#3a4b9e"] {
+      [fill="#3a4b9e"],
+      [fill="#4465e9"] {
         fill: var(--color-blue) !important;
       }
       [fill="#4dabf7"],
       [fill="#6fbbf8"],
-      [fill="#4d7aa9"] {
+      [fill="#4d7aa9"],
+      [fill="#4ba1f1"] {
         fill: var(--color-light-blue) !important;
       }
       [fill="#ae3ec9"],
@@ -243,9 +250,11 @@
       }
       [fill="#e599f7"],
       [fill="#e9acf8"],
-      [fill="#9770a9"] {
+      [fill="#9770a9"],
+      [fill="#e085f4"] {
         fill: var(--color-light-violet) !important;
       }
+
       [stroke="#e1e1e1"],
       [stroke="#1d1d1d"],
       [stroke="#f3f3f3"],

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -260,10 +260,12 @@
       [stroke="#e03131"] {
         stroke: var(--color-red) !important;
       }
-      [stroke="#ff8787"] {
+      [stroke="#ff8787"],
+      [stroke="#f87777"] {
         stroke: var(--color-light-red) !important;
       }
-      [stroke="#f76707"] {
+      [stroke="#f76707"],
+      [stroke="#e16919"] {
         stroke: var(--color-orange) !important;
       }
       [stroke="#ffc034"],
@@ -274,19 +276,23 @@
       [stroke="#099268"] {
         stroke: var(--color-green) !important;
       }
-      [stroke="#40c057"] {
+      [stroke="#40c057"],
+      [stroke="#4cb05e"] {
         stroke: var(--color-light-green) !important;
       }
-      [stroke="#4263eb"] {
+      [stroke="#4263eb"],
+      [stroke="#4465e9"] {
         stroke: var(--color-blue) !important;
       }
-      [stroke="#4dabf7"] {
+      [stroke="#4dabf7"],
+      [stroke="#4ba1f1"] {
         stroke: var(--color-light-blue) !important;
       }
       [stroke="#ae3ec9"] {
         stroke: var(--color-violet) !important;
       }
-      [stroke="#e599f7"] {
+      [stroke="#e599f7"],
+      [stroke="#e085f4"] {
         stroke: var(--color-light-violet) !important;
       }
 

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name tldraw Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/tldraw
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/tldraw
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/tldraw/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atldraw
 @description Soothing pastel theme for tldraw

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -267,7 +267,8 @@
         stroke: var(--color-orange) !important;
       }
       [stroke="#ffc034"],
-      [stroke="#ffc078"] {
+      [stroke="#ffc078"],
+      [stroke="#f1ac4b"] {
         stroke: var(--color-yellow) !important;
       }
       [stroke="#099268"] {

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -181,7 +181,8 @@
       [fill="#e1e1e1"],
       [fill="#1d1d1d"],
       [fill="#494949"],
-      [fill="#989898"] {
+      [fill="#989898"],
+      [fill="#FFFFFF"] {
         fill: var(--color-black) !important;
       }
       [fill="#010403"] {
@@ -282,6 +283,7 @@
       [stroke="#e599f7"] {
         stroke: var(--color-light-violet) !important;
       }
+
       [stroke="color(display-p3 0.8078 0.7225 0.0312)"],
       [stroke="color(display-p3 0.972 0.8705 0.05)"] {
         stroke: var(--color-yellow) !important;
@@ -363,6 +365,59 @@
       }
       &[style*="color: rgb(255, 135, 135);"] {
         color: var(--color-light-red) !important;
+      }
+    }
+
+    .tl-note__container {
+      &[style*="rgb(44, 44, 44);"] {
+        background-color: var(--color-black) !important;
+      }
+      &[style*="rgb(252, 225, 156);"] {
+        background-color: fade(@yellow, 30%) !important;
+      }
+      &[style*="rgb(86, 89, 95);"],
+      &[style*="rgb(192, 202, 211);"] {
+        background-color: var(--color-gray) !important;
+      }
+      &[style*="rgb(118, 47, 142);"],
+      &[style*="rgb(223, 176, 249);"] {
+        background-color: var(--color-light-violet) !important;
+      }
+      &[style*="rgb(104, 22, 131);"],
+      &[style*="rgb(219, 145, 253);"] {
+        background-color: var(--color-violet) !important;
+      }
+      &[style*="rgb(42, 63, 152);"],
+      &[style*="rgb(138, 163, 255);"] {
+        background-color: var(--color-blue) !important;
+      }
+      &[style*="rgb(31, 84, 149);"],
+      &[style*="rgb(155, 196, 253);"] {
+        background-color: var(--color-light-blue) !important;
+      }
+      &[style*="rgb(152, 87, 27);"],
+      &[style*="rgb(254, 212, 154);"] {
+        background-color: var(--color-yellow) !important;
+      }
+      &[style*="rgb(132, 57, 6);"],
+      &[style*="rgb(250, 164, 117);"] {
+        background-color: var(--color-orange) !important;
+      }
+      &[style*="rgb(1, 68, 41);"],
+      &[style*="rgb(111, 200, 150);"] {
+        background-color: var(--color-green) !important;
+      }
+      &[style*="rgb(33, 88, 29);"],
+      &[style*="rgb(152, 208, 138);"] {
+        background-color: var(--color-light-green) !important;
+      }
+      &[style*="rgb(146, 54, 50);"],
+      &[style*="rgb(247, 165, 161);"] {
+        background-color: var(--color-light-red) !important;
+      }
+      &[style*="rgb(137, 35, 26);"],
+      &[style*="rgb(252, 130, 130);"] {
+        background-color: var(--color-red) !important;
       }
     }
 

--- a/styles/tldraw/catppuccin.user.css
+++ b/styles/tldraw/catppuccin.user.css
@@ -183,7 +183,8 @@
       [fill="#494949"],
       [fill="#989898"],
       [fill="#FFFFFF"],
-      [fill="#f9f9f9"] {
+      [fill="#f9f9f9"],
+      [fill="#f5f5f5"] {
         fill: var(--color-black) !important;
       }
       [fill="#010403"] {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the colors of the sticky note not being themed as well as add support for their secret white pen color
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
