### PR TITLE
fix(chatreplay): respect chat colors

### DIFF
--- a/styles/chatreplay/catppuccin.user.css
+++ b/styles/chatreplay/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatReplay Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatreplay
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatreplay
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatreplay/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatreplay
 @description Soothing pastel theme for ChatReplay

--- a/styles/chatreplay/catppuccin.user.css
+++ b/styles/chatreplay/catppuccin.user.css
@@ -74,7 +74,7 @@
     @accent-color: @catppuccin[@@lookup][@@accent];
 
     & when (@platform = chat) {
-      a,
+      a:not(.username),
       i {
         color: @accent-color;
       }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<img width="268" alt="image" src="https://github.com/catppuccin/userstyles/assets/102488279/ac1690b8-2812-496b-a4e2-ab340ed23ca4">

<img width="273" alt="image" src="https://github.com/catppuccin/userstyles/assets/102488279/463ff2ff-216d-4bd6-aaa4-36eda5c77fd5">

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
