### PR TITLE
fix(wikipedia): theming broken at ja.wikipedia.org home page

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -390,6 +390,11 @@
       border-left-color: @yellow !important;
     }
 
+    .mw-parser-output .mainpage-frame {
+      background: @surface0 !important;
+      border: 1px solid @surface0 !important;
+    }
+
     .hidden-title {
       background-color: @green !important;
       color: @mantle !important;

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -395,6 +395,10 @@
       border: 1px solid @surface0 !important;
     }
 
+    .mw-parser-output .mainpage-heading-title {
+      background: linear-gradient(to right,rgba(@accent-color, 0.4),@surface0) !important;
+    }
+
     .hidden-title {
       background-color: @green !important;
       color: @mantle !important;

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -392,7 +392,7 @@
 
     .mw-parser-output .mainpage-frame {
       background: @surface0 !important;
-      border: 1px solid @surface0 !important;
+      border-color: @surface0 !important;
     }
 
     .mw-parser-output .mainpage-heading-title {

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.15
+@version 0.0.16
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -396,7 +396,7 @@
     }
 
     .mw-parser-output .mainpage-heading-title {
-      background: linear-gradient(to right,rgba(@accent-color, 0.4),@surface0) !important;
+      background: linear-gradient(to right,rgba(saturate(lighten(@accent-color, 4%), -3%), 0.4),@surface0) !important;
     }
 
     .hidden-title {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

this fixes theming issues at [ja.wikipedia.org](https://ja.wikipedia.org/wiki/%E3%83%A1%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
