### PR TITLE
fix(youtube): shorts comments popup backdrop

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.12
+@version 4.0.13
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -165,9 +165,9 @@
       --yt-spec-static-grey: @subtext0 !important;
       --yt-spec-static-overlay-background-solid: @crust !important;
       --yt-spec-static-overlay-background-heavy: @surface0;
-      --yt-spec-static-overlay-background-medium: fadeout(
+      --yt-spec-static-overlay-background-medium: fade(
         @crust,
-        0.6
+        50%
       ) !important;
       --yt-spec-static-overlay-background-medium-light: fadeout(
         @crust,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

| Before | After |
| - | - |
| ![Screenshot 2024-04-26 at 16 21 19 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/fa7b9cb0-b9be-4827-97aa-4757169151c0) | ![Screenshot 2024-04-26 at 16 20 49 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/5a8b56c5-8dc6-4700-a778-ad8a0be2f9c6) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
