### PR TITLE
fix(trinket): Style "beta" text

### DIFF
--- a/styles/trinket/catppuccin.user.css
+++ b/styles/trinket/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Trinket Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/trinket
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/trinket
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/trinket/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atrinket
 @description Soothing pastel theme for Trinket
@@ -444,6 +444,10 @@
 
     .codelines {
       background-color: @mantle !important;
+    }
+
+    span.beta {
+      color: @accent-color !important;
     }
 
     .resources a {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
this

![image](https://github.com/catppuccin/userstyles/assets/97406176/0d6a28a9-2810-44b2-b8d7-3c78ed8c681e)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
