### PR TITLE
fix(elk): disable saturation filter

### DIFF
--- a/styles/elk/catppuccin.user.css
+++ b/styles/elk/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Elk Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/elk
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/elk
-@version 0.2.2
+@version 0.2.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/elk/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aelk
 @description Soothing pastel theme for Elk
@@ -152,6 +152,10 @@
     [group-hover^="bg-purple/10"]:hover {
       background-color: alpha(@lavender, 0.1);
     }
+      
+      .filter-saturate-0, [filter-saturate-0=""] {
+          filter: none;
+      }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![Screenshot 2024-04-30 at 07 56 56 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/996828e8-1b6b-4aae-9fa1-68b58348c27a)

Fixes that button being a different color than the background.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
