### PR TITLE
fix(chatgpt): misc login page and border theming

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.2.8
+@version 0.2.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -918,6 +918,11 @@
       --tw-ring-offset-color: @base;
     }
 
+    /* Circle around OpenAI logo in center of chat */
+    .gizmo-shadow-stroke::after {
+      --tw-shadow: inset 0 0 0 1px @surface0;
+    }
+
     .katex-error {
       color: @red !important;
     }
@@ -1002,6 +1007,7 @@
         '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="@{text}"><path d="M29.293 13.167a7.77 7.77 0 0 0-.668-6.388 7.87 7.87 0 0 0-8.472-3.774A7.77 7.77 0 0 0 14.288.39a7.87 7.87 0 0 0-7.504 5.446 7.78 7.78 0 0 0-5.201 3.773 7.87 7.87 0 0 0 .968 9.223 7.78 7.78 0 0 0 .668 6.388 7.87 7.87 0 0 0 8.473 3.774 7.78 7.78 0 0 0 5.866 2.615 7.87 7.87 0 0 0 7.506-5.449 7.78 7.78 0 0 0 5.2-3.773 7.87 7.87 0 0 0-.97-9.22M17.559 29.57a5.83 5.83 0 0 1-3.746-1.354c.048-.026.131-.071.185-.105l6.216-3.59a1.01 1.01 0 0 0 .511-.885v-8.765l2.627 1.517a.1.1 0 0 1 .052.072v7.258a5.86 5.86 0 0 1-5.846 5.85M4.989 24.2a5.83 5.83 0 0 1-.698-3.92c.047.028.126.077.185.11l6.216 3.59a1.01 1.01 0 0 0 1.021 0l7.59-4.382v3.034a.1.1 0 0 1-.038.08l-6.284 3.628a5.857 5.857 0 0 1-7.992-2.142M3.354 10.63A5.83 5.83 0 0 1 6.4 8.065l-.003.214v7.181a1.01 1.01 0 0 0 .51.884l7.589 4.382-2.627 1.517a.1.1 0 0 1-.089.008L5.495 18.62a5.857 5.857 0 0 1-2.141-7.99m21.587 5.024-7.59-4.382 2.628-1.516a.1.1 0 0 1 .088-.008l6.284 3.628a5.852 5.852 0 0 1-.904 10.558v-7.396a1.01 1.01 0 0 0-.507-.884m2.615-3.936-.184-.11-6.217-3.59a1.01 1.01 0 0 0-1.021 0L12.544 12.4V9.366a.1.1 0 0 1 .038-.08l6.283-3.625a5.851 5.851 0 0 1 8.691 6.059m-16.439 5.408-2.628-1.517a.1.1 0 0 1-.051-.072V8.281a5.851 5.851 0 0 1 9.594-4.492l-.184.105-6.217 3.59a1.01 1.01 0 0 0-.51.884zm1.428-3.078 3.38-1.952 3.381 1.951v3.902l-3.38 1.951-3.38-1.951z"/></svg>'
       );
       content: url("data:image/svg+xml,@{svg}");
+      background-color: transparent;
     }
 
     .title {
@@ -1128,10 +1134,12 @@
     --gray-lightest: @base;
     --gray-light: @crust;
     --gray-mid: @surface0;
+    --gray-mid-dark: @surface1;
     --gray-dark: @overlay2;
     --gray-darkest: @text;
+    --gray-social-border: @surface0;
 
-    .cb2dfcee4 {
+    ._button-login-password {
       background-color: @accent-color;
       color: @base;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes some new issues on the two login pages of ChatGPT and themes a border around the OpenAI logo that seems to have changed (or maybe just my eyesight has improved and I didn't notice it earlier, who knows).
 
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
