### PR TITLE
refactor(nixos.wiki): use pygments for syntax highlighting

### DIFF
--- a/styles/nixos.wiki/catppuccin.user.css
+++ b/styles/nixos.wiki/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name NixOS Wiki Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/nixos.wiki
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/nixos.wiki
-@version 0.0.5
+@version 0.0.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/nixos.wiki/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anixos.wiki
 @description Soothing pastel theme for NixOS Wiki
@@ -16,6 +16,8 @@
 ==/UserStyle== */
 
 @-moz-document domain('nixos.wiki') {
+  @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
+    
   @media (prefers-color-scheme: light) {
     :root {
       #catppuccin(@lightFlavor, @accentColor);
@@ -55,6 +57,33 @@
     @mantle: @catppuccin[@@lookup][@mantle];
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
+
+    --ctp-rosewater: @rosewater;
+    --ctp-flamingo: @flamingo;
+    --ctp-pink: @pink;
+    --ctp-mauve: @mauve;
+    --ctp-red: @red;
+    --ctp-maroon: @maroon;
+    --ctp-peach: @peach;
+    --ctp-yellow: @yellow;
+    --ctp-green: @green;
+    --ctp-teal: @teal;
+    --ctp-sky: @sky;
+    --ctp-sapphire: @sapphire;
+    --ctp-blue: @blue;
+    --ctp-lavender: @lavender;
+    --ctp-text: @text;
+    --ctp-subtext1: @subtext1;
+    --ctp-subtext0: @subtext0;
+    --ctp-overlay2: @overlay2;
+    --ctp-overlay1: @overlay1;
+    --ctp-overlay0: @overlay0;
+    --ctp-surface2: @surface2;
+    --ctp-surface1: @surface1;
+    --ctp-surface0: @surface0;
+    --ctp-base: @base;
+    --ctp-mantle: @mantle;
+    --ctp-crust: @crust;
 
     color-scheme: if(@lookup = latte, light, dark);
 
@@ -237,80 +266,6 @@
       color: @text !important;
       background-color: fade(@overlay0, 15%) !important;
       border-color: @overlay0 !important;
-    }
-
-    .mw-highlight,
-    .mw-highlight > pre {
-      color: @text !important;
-      background-color: @mantle !important;
-
-      // env assignment
-      .nv {
-        color: @text;
-      }
-      // dollar sign
-      .gp {
-        color: @pink;
-      }
-      // comment
-      .c1,
-      .cm {
-        color: @overlay2;
-      }
-      // strings
-      .s1,
-      .s2,
-      .se {
-        color: @green;
-      }
-      // string interpolation
-      .si {
-        color: @pink;
-      }
-      // lhe
-      .ss,
-      .nb {
-        color: @blue;
-      }
-      // operators
-      .p,
-      .o {
-        color: @teal;
-      }
-      // numbers, boolean
-      .mi,
-      .no {
-        color: @peach;
-      }
-      // keyword
-      .k,
-      .ow {
-        color: @mauve;
-      }
-      // shebangs
-      .ch {
-        color: @pink;
-      }
-      // etc
-      .go {
-        color: @text;
-      }
-      // diff added
-      .gi {
-        color: @green;
-      }
-      // diff removed
-      .gd {
-        color: @red;
-      }
-      // diff header
-      .gh {
-        color: @text;
-      }
-      // diff changes
-      .gu {
-        color: @peach;
-      }
     }
 
     .suggestions {


### PR DESCRIPTION
## 🔧 What does this change? 🔧

Switches to using our Python Pygments port for theming syntax highlighting (it is mediawiki as well, like Wikipedia). Upon thinking about it we don't have this stuff mentioned anywhere in the docs... 👀 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
