### PR TITLE
fix(gmail): assorted changes

### DIFF
--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Gmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/gmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
-@version 0.1.5
+@version 0.2.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agmail
 @description Soothing pastel theme for Gmail

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -80,11 +80,6 @@
     }
 
     /* input box */
-    .nr {
-      background-color: @surface0 !important;
-      color: @text !important;
-    }
-
     .bs0 > .acM,
     .bti > .btg {
       color: @text !important;
@@ -505,7 +500,8 @@
     .xY > .T-Jo,
     .T-I .T-I-J3,
     td.apU > .T-KT.aXw::before,
-    .bqX:not(.pW):hover::before {
+    .bqX:not(.pW):hover::before,
+    .nZ > .TN.aHS-bnt .qj::before{
       filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%)
         hue-rotate(196deg) brightness(250%) contrast(75%);
     }

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -221,6 +221,115 @@
     .bkK > .nH {
       background: @mantle !important;
     }
+
+      /* selected unread email */
+    .x7 {
+      color: @mantle !important;
+      background: @accent-color !important;
+    }
+
+    /* checkbox */
+    .bzn .G-tF .T-Jo {
+      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(150%) contrast(75%);
+    }
+
+    /* input box */
+    .nr {
+      background-color: @surface0 !important;
+      color: @text !important;
+    }
+
+    .bs0 > .acM,
+    .bti > .btg {
+      color: @text !important;
+    }
+
+    /* keyboard dropdown */
+    .d-Na-JG-M {
+      background-color: @surface1 !important;
+    }
+    .d-Na-N {
+      color: @text !important;
+    }
+    .d-Na-N-JW {
+      background-color: fade(@accent-color, 20%) !important;
+    }
+    .d-Na-JX-I,
+    .d-Na-J3,
+    .d-Na-N.d-Na-KO .d-Na-Jo {
+      filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(250%) contrast(75%);
+    }
+    .d-Na-axR,
+    .RK-Jk.RK-Qq-axH {
+      border-color: @overlay0;
+    }
+
+    /* virtual keyboard */
+    .RK-H {
+      background-color: @surface0 !important;
+    }
+    .RK-QJ {
+      color: @text;
+    }
+    .RK-Jk {
+      color: @text !important;
+      background-image: linear-gradient(to bottom, @surface1, @surface2);
+    }
+
+    /* compose window */
+    .afW {
+      border-color: @surface1;
+    }
+    .afV {
+      background: @surface2 !important;
+      box-shadow: 0 0 0 1px @overlay0 inset;
+      color: @text !important;
+    }
+    .akl,
+    .aoT,
+    .aYF,
+    .agP,
+    .az9,
+    .gQ {
+      color: @text;
+    }
+    .IZ,
+    .agP,
+    .agh,
+    .gQ,
+    .afx {
+      background: @surface0 !important;
+    }
+    .oL,
+    .gO {
+      color: @subtext0;
+    }
+    /* message sent dialog */
+    .vh {
+      color: @text !important;
+    }
+    /* Gmail logos*/
+    [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_default_1x_r5.png"],
+    [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_dark_1x_r5.png"]
+    {
+      height: unset !important;
+      width: unset !important;
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="17.727 14.319 30 22.5" width="30" height="22.5"><path fill="@{blue}" d="M19.773 36.819h4.773V25.227l-6.819-5.114v14.659a2.044 2.044 0 0 0 2.045 2.045"/><path fill="@{green}" d="M40.909 36.819h4.773a2.044 2.044 0 0 0 2.045-2.045v-14.66l-6.819 5.114"/><path fill="@{yellow}" d="M40.909 16.364v8.864l6.819-5.114v-2.727c0-2.529-2.888-3.971-4.909-2.455"/><path fill="@{red}" d="M24.545 25.227v-8.863l8.181 6.136 8.181-6.136v8.864l-8.181 6.136m-15-13.977v2.727l6.819 5.114v-8.864l-1.909-1.431c-2.025-1.517-4.91-.075-4.91 2.455"/></svg>'
+      );
+      content: url("data:image/svg+xml,@{svg}");
+    }
+    /* x new */
+    .aDG {
+      background-color: @crust !important;
+      color: @text !important;
+    }
+    .aKs {
+      color: @subtext1 !important;
+    }
+    
     /* inbox item */
     .yO {
       background: @mantle !important;
@@ -437,9 +546,14 @@
     .aAy > .aKp,
     .xY > .T-Jo,
     .T-I .T-I-J3,
-    td.apU > .T-KT.aXw::before {
-      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
-        hue-rotate(196deg) brightness(150%) contrast(75%);
+    td.apU > .T-KT.aXw::before,
+    .bqX:not(.pW):hover::before {
+      filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(250%) contrast(75%);
+    }
+    .WR .z0 > .L3::before {
+      filter: brightness(0) saturate(80%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(20%) contrast(75%);
     }
     td.apU > .T-KT.T-KT-Jp::before {
       filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
@@ -453,7 +567,12 @@
       filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
         hue-rotate(196deg) brightness(250%) contrast(75%);
     }
-
+    .brC-aMv-auO .aT5-aOt-I-JX {
+      fill: @accent-color;
+    }
+    .brC-aMv-auO .brC-dA-I.aT5-aOt-I-Jp .aT5-aOt-I-JX-atM {
+      background-color: @base;
+    }
     /* sidebar icons */
     .TO:not(.nZ) .qj:not(.aEe),
     .n3 .CL.Q7::before,

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Gmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/gmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
-@version 0.2.0
+@version 0.1.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agmail
 @description Soothing pastel theme for Gmail
@@ -78,6 +78,18 @@
     body {
       color: @text !important;
     }
+
+    /* input box */
+    .nr {
+      background-color: @surface0 !important;
+      color: @text !important;
+    }
+
+    .bs0 > .acM,
+    .bti > .btg {
+      color: @text !important;
+    }
+
     /* quick settings */
     .IU {
       background: @base !important;
@@ -167,6 +179,50 @@
       background: @surface0 !important;
       color: @text !important;
     }
+    /* selected unread email */
+    .x7 {
+      color: @mantle !important;
+      background: @accent-color !important;
+    }
+
+    /* checkbox */
+    .bzn .G-tF .T-Jo {
+      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(150%) contrast(75%);
+    }
+
+    /* keyboard dropdown */
+    .d-Na-JG-M {
+      background-color: @surface1 !important;
+    }
+    .d-Na-N {
+      color: @text !important;
+    }
+    .d-Na-N-JW {
+      background-color: fade(@accent-color, 20%) !important;
+    }
+    .d-Na-JX-I,
+    .d-Na-J3,
+    .d-Na-N.d-Na-KO .d-Na-Jo {
+      filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(250%) contrast(75%);
+    }
+    .d-Na-axR,
+    .RK-Jk.RK-Qq-axH {
+      border-color: @overlay0;
+    }
+
+    /* virtual keyboard */
+    .RK-H {
+      background-color: @surface0 !important;
+    }
+    .RK-QJ {
+      color: @text;
+    }
+    .RK-Jk {
+      color: @text !important;
+      background-image: linear-gradient(to bottom, @surface1, @surface2);
+    }
 
     /* left bar */
     .CL.Q7:hover,
@@ -221,115 +277,6 @@
     .bkK > .nH {
       background: @mantle !important;
     }
-
-      /* selected unread email */
-    .x7 {
-      color: @mantle !important;
-      background: @accent-color !important;
-    }
-
-    /* checkbox */
-    .bzn .G-tF .T-Jo {
-      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
-        hue-rotate(196deg) brightness(150%) contrast(75%);
-    }
-
-    /* input box */
-    .nr {
-      background-color: @surface0 !important;
-      color: @text !important;
-    }
-
-    .bs0 > .acM,
-    .bti > .btg {
-      color: @text !important;
-    }
-
-    /* keyboard dropdown */
-    .d-Na-JG-M {
-      background-color: @surface1 !important;
-    }
-    .d-Na-N {
-      color: @text !important;
-    }
-    .d-Na-N-JW {
-      background-color: fade(@accent-color, 20%) !important;
-    }
-    .d-Na-JX-I,
-    .d-Na-J3,
-    .d-Na-N.d-Na-KO .d-Na-Jo {
-      filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%)
-        hue-rotate(196deg) brightness(250%) contrast(75%);
-    }
-    .d-Na-axR,
-    .RK-Jk.RK-Qq-axH {
-      border-color: @overlay0;
-    }
-
-    /* virtual keyboard */
-    .RK-H {
-      background-color: @surface0 !important;
-    }
-    .RK-QJ {
-      color: @text;
-    }
-    .RK-Jk {
-      color: @text !important;
-      background-image: linear-gradient(to bottom, @surface1, @surface2);
-    }
-
-    /* compose window */
-    .afW {
-      border-color: @surface1;
-    }
-    .afV {
-      background: @surface2 !important;
-      box-shadow: 0 0 0 1px @overlay0 inset;
-      color: @text !important;
-    }
-    .akl,
-    .aoT,
-    .aYF,
-    .agP,
-    .az9,
-    .gQ {
-      color: @text;
-    }
-    .IZ,
-    .agP,
-    .agh,
-    .gQ,
-    .afx {
-      background: @surface0 !important;
-    }
-    .oL,
-    .gO {
-      color: @subtext0;
-    }
-    /* message sent dialog */
-    .vh {
-      color: @text !important;
-    }
-    /* Gmail logos*/
-    [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_default_1x_r5.png"],
-    [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_dark_1x_r5.png"]
-    {
-      height: unset !important;
-      width: unset !important;
-      @svg: escape(
-        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="17.727 14.319 30 22.5" width="30" height="22.5"><path fill="@{blue}" d="M19.773 36.819h4.773V25.227l-6.819-5.114v14.659a2.044 2.044 0 0 0 2.045 2.045"/><path fill="@{green}" d="M40.909 36.819h4.773a2.044 2.044 0 0 0 2.045-2.045v-14.66l-6.819 5.114"/><path fill="@{yellow}" d="M40.909 16.364v8.864l6.819-5.114v-2.727c0-2.529-2.888-3.971-4.909-2.455"/><path fill="@{red}" d="M24.545 25.227v-8.863l8.181 6.136 8.181-6.136v8.864l-8.181 6.136m-15-13.977v2.727l6.819 5.114v-8.864l-1.909-1.431c-2.025-1.517-4.91-.075-4.91 2.455"/></svg>'
-      );
-      content: url("data:image/svg+xml,@{svg}");
-    }
-    /* x new */
-    .aDG {
-      background-color: @crust !important;
-      color: @text !important;
-    }
-    .aKs {
-      color: @subtext1 !important;
-    }
-    
     /* inbox item */
     .yO {
       background: @mantle !important;
@@ -438,8 +385,9 @@
     .IZ,
     .agP,
     .agh,
-    .gQ {
-      background-color: @surface0;
+    .gQ,
+    .afx {
+      background: @surface0 !important;
     }
     .oL,
     .gO {
@@ -449,7 +397,17 @@
     .vh {
       color: @text !important;
     }
-
+    /* Gmail logo */
+    [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_default_1x_r5.png"],
+    [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_dark_1x_r5.png"]
+    {
+      height: unset !important;
+      width: unset !important;
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="17.727 14.319 30 22.5" width="30" height="22.5"><path fill="@{blue}" d="M19.773 36.819h4.773V25.227l-6.819-5.114v14.659a2.044 2.044 0 0 0 2.045 2.045"/><path fill="@{green}" d="M40.909 36.819h4.773a2.044 2.044 0 0 0 2.045-2.045v-14.66l-6.819 5.114"/><path fill="@{yellow}" d="M40.909 16.364v8.864l6.819-5.114v-2.727c0-2.529-2.888-3.971-4.909-2.455"/><path fill="@{red}" d="M24.545 25.227v-8.863l8.181 6.136 8.181-6.136v8.864l-8.181 6.136m-15-13.977v2.727l6.819 5.114v-8.864l-1.909-1.431c-2.025-1.517-4.91-.075-4.91 2.455"/></svg>'
+      );
+      content: url("data:image/svg+xml,@{svg}");
+    }
     /* x new */
     .aDG {
       background-color: @crust !important;
@@ -551,10 +509,12 @@
       filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%)
         hue-rotate(196deg) brightness(250%) contrast(75%);
     }
+
     .WR .z0 > .L3::before {
       filter: brightness(0) saturate(80%) invert(28%) sepia(17%) saturate(835%)
         hue-rotate(196deg) brightness(20%) contrast(75%);
     }
+
     td.apU > .T-KT.T-KT-Jp::before {
       filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
         hue-rotate(337deg) brightness(300%);
@@ -573,6 +533,7 @@
     .brC-aMv-auO .brC-dA-I.aT5-aOt-I-Jp .aT5-aOt-I-JX-atM {
       background-color: @base;
     }
+
     /* sidebar icons */
     .TO:not(.nZ) .qj:not(.aEe),
     .n3 .CL.Q7::before,
@@ -581,8 +542,8 @@
     .n6 .n4 .G-asx,
     .n6 .air .G-asx,
     .TN .TH {
-      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
-        hue-rotate(196deg) brightness(250%) contrast(75%);
+      filter: brightness(0) saturate(80%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(220%) contrast(75%);
     }
 
     /* help dropdown */

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Gmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/gmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
-@version 0.1.4
+@version 0.1.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agmail
 @description Soothing pastel theme for Gmail
@@ -78,18 +78,6 @@
     body {
       color: @text !important;
     }
-
-    /* input box */
-    .nr {
-      background-color: @surface1 !important;
-      color: @text !important;
-    }
-
-    .bs0 > .acM,
-    .bti > .btg {
-      color: @text !important;
-    }
-
     /* quick settings */
     .IU {
       background: @base !important;
@@ -159,7 +147,8 @@
       background: @surface0 !important;
     }
     .gb_Lc .gb_3e,
-    .gb_Ee.gb_Fe .gb_Ze {
+    .gb_Ee.gb_Fe .gb_Ze,
+    .gb_Pc .gb_we {
       color: @text !important;
     }
     .gb_Ee.gb_Fe button svg {
@@ -284,17 +273,81 @@
     .T-I-JW > .asa::before {
       background: @surface0 !important;
     }
-    /* forward/reply buttons */
-    .amn > .ams {
+
+    /* attachements in comfortable mode */
+    .brg {
       color: @text !important;
     }
-    .amr .amn > .ams {
-      background: @base !important;
-      border-color: @surface0 !important;
+
+    /* date when the message was sent */
+    .yO > .xW {
+      color: fade(@text, 50%) !important;
+    }
+    .bq3 {
+      color: @text !important;
+    }
+
+    /* unsub button */
+    .aJ6 {
+      color: @text;
+    }
+    .aOd.T-I {
+      box-shadow: inset 0 0 0 1px fade(@text, 50%) !important;
+    }
+
+    /* svgs */
+    .gb_Pc svg,
+    .gb_Uc.gb_Zc svg,
+    .gb_Pc .gb_gd .gb_od,
+    .gb_Pc .gb_gd .gb_Oc,
+    .gb_Pc .gb_gd .gb_id,
+    .gb_Uc.gb_Zc .gb_od {
+      color: @text !important;
     }
     /* send one now */
     .x0 {
       color: @text !important;
+    }
+
+    /* compose window */
+    .afW {
+      border-color: @surface1;
+    }
+    .afV {
+      background: @surface2 !important;
+      box-shadow: 0 0 0 1px @overlay0 inset;
+      color: @text !important;
+    }
+    .akl,
+    .aoT,
+    .aYF,
+    .agP,
+    .az9,
+    .gQ {
+      color: @text;
+    }
+    .IZ,
+    .agP,
+    .agh,
+    .gQ {
+      background-color: @surface0;
+    }
+    .oL,
+    .gO {
+      color: @subtext0;
+    }
+    /* message sent dialog */
+    .vh {
+      color: @text !important;
+    }
+
+    /* x new */
+    .aDG {
+      background-color: @crust !important;
+      color: @text !important;
+    }
+    .aKs {
+      color: @subtext1 !important;
     }
 
     /* theme */
@@ -397,7 +450,51 @@
     .OB,
     .Q1:not(:checked) + .Vo::before,
     .SV {
-      filter: invert(1);
+      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(250%) contrast(75%);
+    }
+
+    /* sidebar icons */
+    .TO:not(.nZ) .qj:not(.aEe),
+    .n3 .CL.Q7::before,
+    .n3 .CL.Wj::before,
+    .n3 .CL.H5o3mc::before,
+    .n6 .n4 .G-asx,
+    .n6 .air .G-asx,
+    .TN .TH {
+      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(250%) contrast(75%);
+    }
+
+    /* help dropdown */
+    .t9 {
+      background-color: @surface0 !important;
+    }
+    .ua {
+      color: @text !important;
+    }
+    .ua.bk5 {
+      background-color: @overlay0;
+    }
+
+    /* labels */
+    .J-awr {
+      color: @text;
+    }
+    .J-N-Jz {
+      color: @text !important;
+    }
+    .J-Kh {
+      border-color: @text;
+    }
+
+    /* sidebar */
+    .bsU {
+      color: @text;
+    }
+    .aAw .aAu {
+      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(250%) contrast(75%);
     }
 
     /* svgs */
@@ -435,7 +532,8 @@
     .aaZ .J-N-JX.a5,
     .aaZ .J-N-JX.a2X,
     [role="toolbar"] [role="button"]:not(.H2, .Ol) {
-      filter: invert(1) !important;
+      filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%)
+        hue-rotate(196deg) brightness(250%) contrast(75%) !important;
     }
 
     /* advanced settings */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
uh good question, off the top of my head, i can think of a few:
- removes styling for emails

<img width="516" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/e78eb568-4b05-4487-8034-7ae78cf1d081">

- dropdown menu icons in email
<img width="255" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/a15b5e89-06ee-46cc-b203-8303dc9dcd0f">


- the x new as well as it's subtext
<img width="207" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/2934ddfa-ad7f-4f35-b044-c32a2640f0b5">

- some assorted icons
<img width="672" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/1e293ca7-5773-461d-96f7-b54d3d5010e8">

- the unsub button on a newsletter
<img width="112" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/4bc7b58b-328b-4b96-8da1-853ab4fae8cc">


- label drop down
<img width="201" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/9fef62f5-cc59-4667-b60a-24bce9820d7c">

- closes #553 as well
- no i do not plan on maintaining this userstyle, i only fixed it up because it was annoying me lol and i hope you're happy uncenter

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
