### PR TITLE
fix(whatsapp-web): filters fix

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.css
+++ b/styles/whatsapp-web/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name WhatsApp Web Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/whatsapp-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/whatsapp-web
-@version 0.0.8
+@version 0.0.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/whatsapp-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awhatsapp-web
 @description Soothing pastel theme for WhatsApp Web
@@ -95,8 +95,20 @@
     --app-background: @base !important;
 
     /* CHAT LIST */
-    /* nav bar */
+    /* nav bar background */
     --navbar-background: @mantle !important;
+    /* filters container background */
+    --filters-container-background: @base !important;
+    /* filters item background */
+    --filters-item-background: @surface0 !important;
+    /* filters item color */
+    --filters-item-color: @subtext0 !important;
+    /* filters item background hover */
+    --filters-item-background-hover: @surface1 !important;
+    /* filters item active background */
+    --filters-item-active-background: fadeout(@accent-color, 70%) !important;
+    /* filters item active color */
+    --filters-item-active-color: @accent-color !important;
     /* chat list background */
     --background-default: @base !important;
     /* chat list header */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Whatsapp added a filter bar. It had the wrong colors so I fixed it.
Also closes #837.

| Before | After |
|-|-|
| ![Screenshot 2024-05-06 194836](https://github.com/catppuccin/userstyles/assets/27358071/f4546164-5dcf-4f96-af8b-3a4dcf4addf5) | ![Screenshot 2024-05-06 194746](https://github.com/catppuccin/userstyles/assets/27358071/05db651c-6801-4a2d-8a7d-195a6b286c02) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
