### PR TITLE
fix(migadu-webmail): untheme message content

### DIFF
--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Migadu Webmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/migadu-webmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/migadu-webmail
-@version 0.0.8
+@version 0.0.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/migadu-webmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amigadu-webmail
 @description Soothing pastel theme for Migadu Webmail
@@ -474,6 +474,12 @@
       li a {
         color: @surface0;
       }
+    }
+
+    /* Untheme message content */
+    div:has(> .mail-body) {
+      color: #333;
+      background-color: #fff;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Messages are much easier to read with these default styles.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
