### PR TITLE
fix: account iframe themed correctly

### DIFF
--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google
-@version 0.2.2
+@version 0.2.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle
 @description Soothing pastel theme for Google
@@ -57,6 +57,9 @@
     @accent-color: @catppuccin[@@lookup][@@accent];
 
     color-scheme: if(@lookup = latte, light, dark);
+    iframe {
+      color-scheme: none !important;
+    }
 
     ::selection {
       background-color: fade(@accent-color, 30%);
@@ -1852,6 +1855,16 @@
 
 @-moz-document regexp("^https?://(ogs\\.)?google\\..*")
 {
+  @media (prefers-color-scheme: light) {
+    body {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    body {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
   #catppuccin(@lookup, @accent) {
     @flamingo: @catppuccin[@@lookup][@flamingo];
     @pink: @catppuccin[@@lookup][@pink];


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes un-themed account (`iframe`) menu.
|Before|After|
|--------|--------|
|![image](https://github.com/catppuccin/userstyles/assets/29287159/be977994-06b2-4ac1-ac15-2f7071bb54e6)|![image](https://github.com/catppuccin/userstyles/assets/29287159/e7240d72-7d74-4b0c-b30e-6b23c8684097)|
 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
