### PR TITLE
fix(duckduckgo): misc

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -150,13 +150,12 @@
 
     .footer,
     .footer--mobile,
-    .switch__knob .modal--dropdown--settings,
+    .modal--dropdown--settings,
     .settings-dropdown--section,
     .frm__field,
     .frm__switch,
     .tileview .metabar--fixed,
     body,
-    .frm__switch__label.btn::after,
     .zci,
     html,
     .body--home,
@@ -592,11 +591,6 @@
       border-color: fade(@accent-color, 80%) !important;
       color: @base !important;
     }
-    .frm__switch__label {
-      background-color: @surface0;
-      border-color: @surface0;
-      color: @text !important;
-    }
     .set-bookmarklet__data {
       background-color: @surface2;
       color: @text;
@@ -792,18 +786,35 @@
     .frm__select::after {
       color: @accent-color !important;
     }
-     .switch, .frm__switch__label {
-      background-color: @mantle !important;
+
+.switch, .frm__switch__label {
+      background-color: @crust !important;
     }
-    .switch__knob, .frm__switch__label::after {
+    
+    .frm__switch__label::after {
+      background: @overlay2 !important
+   }
+   
+   .is-checked .frm__switch__label::after {
+      background: @base !important
+   }
+   
+    .switch__knob,  {
+      background: @overlay2 !important;
+   }
+   
+    .is-on .switch__knob,  {
       background: @base !important;
-    }
+   }
+   
     .switch.is-on {
       background-color: @accent-color !important;
     }
+    
     .dropdown__switch.is-on::before {
       color: @base !important;
     }
+    
     .search--header {
       background-color: @surface0;
       border-color: @surface0;

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -630,7 +630,14 @@
     .zcm--right-fade::before {
       background: linear-gradient(90deg, rgba(255,255,255,0), @mantle)
     }
-    
+    .search-filters-wrap::before {
+     background: linear-gradient(90deg, @base, rgba(255,255,255,0))
+    }
+      
+    .search-filters-wrap::after {
+     background: linear-gradient(90deg, rgba(255,255,255,0), @base)
+    }
+      
     .footer, .footer--mobile {
       border-top-color: @surface0;
     }
@@ -743,7 +750,7 @@
       color: @subtext0 !important;
     }
 
-    .dropdown--region.has-inactive-region .dropdown__button::after,
+    .dropdown--region.has-inactive-region .dropdown__button:::after,
     .modal--dropdown--region.modal--popout .modal__header::before,
     .js-carousel-module-title,
     .tile--pr__brand,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -146,6 +146,7 @@
     --theme-browser-comparison-table-icon-bg: @mantle !important;
     --theme-col-bg-ui: @mantle !important;
     --theme-col-bg-header-modal: @surface0 !important;
+    --theme-col-bg-button-primary: @blue !important;
 
     .footer,
     .switch__knob .modal--dropdown--settings,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -437,6 +437,10 @@
       background-color: @surface0 !important;
       border-color: @surface0 !important;
     }
+      
+    .open-in-app__deep-link {
+      color: @mantle
+    }
 
     .modal__header__clear,
     .sep--before,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -149,6 +149,7 @@
     --theme-col-bg-button-primary: @blue !important;
 
     .footer,
+    .footer--mobile,
     .switch__knob .modal--dropdown--settings,
     .settings-dropdown--section,
     .frm__field,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -508,8 +508,11 @@
     .sep {
       border-left-color: @surface2;
     }
-
-    .header-wrap,
+      
+    .header-wrap {
+      box-shadow: none !important;
+    }
+      
     .module--carousel__left,
     .module--carousel__right,
     .detail,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -750,7 +750,7 @@
       color: @subtext0 !important;
     }
 
-    .dropdown--region.has-inactive-region .dropdown__button:::after,
+    .dropdown--region.has-inactive-region .dropdown__button::after,
     .modal--dropdown--region.modal--popout .modal__header::before,
     .js-carousel-module-title,
     .tile--pr__brand,
@@ -795,7 +795,7 @@
      .switch, .frm__switch__label {
       background-color: @mantle !important;
     }
-    .switch__knob, .frm__switch__label:after {
+    .switch__knob, .frm__switch__label::after {
       background: @base !important;
     }
     .switch.is-on {

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -780,7 +780,7 @@
       background-color: @mantle !important;
     }
     .switch__knob {
-      background: @text !important;
+      background: @base !important;
     }
     .switch.is-on {
       background-color: @accent-color !important;

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -498,6 +498,7 @@
     .frm__input,
     .frm__color__swatch {
       border-color: @surface0 !important;
+      background-color: @crust !important;
     }
 
     .sep--before::before,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -777,10 +777,10 @@
     .frm__select::after {
       color: @accent-color !important;
     }
-    .switch {
+     .switch, .frm__switch__label {
       background-color: @mantle !important;
     }
-    .switch__knob {
+    .switch__knob, .frm__switch__label:after {
       background: @base !important;
     }
     .switch.is-on {

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.1.7
+@version 0.1.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -620,6 +620,10 @@
       border-bottom-color: @surface2;
     }
 
+    .zcm--right-fade::before {
+      linear-gradient(90deg, rgba(255,255,255,0), @mantle)
+    }
+    
     .footer {
       border-top-color: @surface0;
     }

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -624,7 +624,7 @@
     }
 
     .zcm--right-fade::before {
-      linear-gradient(90deg, rgba(255,255,255,0), @mantle)
+      background: linear-gradient(90deg, rgba(255,255,255,0), @mantle)
     }
     
     .footer, .footer--mobile {

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -627,7 +627,7 @@
       linear-gradient(90deg, rgba(255,255,255,0), @mantle)
     }
     
-    .footer {
+    .footer, .footer--mobile {
       border-top-color: @surface0;
     }
 

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -642,6 +642,10 @@
       border-color: @accent-color !important;
     }
 
+    #more-results{
+      background-color: @surface0 !important;
+    }
+
     input,
     select,
     h1,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
- Fixed Text overflow fade in scrollable toolbox
- Themed Duckduckgo open in application button in header of the page
- Themed Mobile footer and footer separator 
- Tweaked settings panel's colors
- Themed Mobile More results button
- Edited On/Off switches for clarity

note: still needs some aditional finishing touches, but this should be the majority of the fixes I could find


<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.