### PR TITLE
fix(chatgpt): swap two vars, theme toggle and "which response do you prefer"

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -646,15 +646,15 @@
     }
 
     .bg-white {
-      background-color: @crust;
+      background-color: @white;
     }
 
     .bg-white\/20 {
-      background-color: fade(@crust, 20%);
+      background-color: fade(@white, 20%);
     }
 
     .bg-white\/25 {
-      background-color: fade(@crust, 25%);
+      background-color: fade(@white, 25%);
     }
 
     .bg-yellow-100 {
@@ -875,7 +875,11 @@
       }
 
       .dark\:bg-white {
-        background-color: @text;
+        background-color: @white;
+      }
+        
+      .dark\:bg-gray-700 {
+        background-color: var(--gray-700);
       }
 
       /* "Was this response better or worse" dialog button hover */

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.2.10
+@version 0.2.11
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -120,8 +120,8 @@
     & when not (@lookup = latte) {
       --gray-50: lighten(mix(@text, @subtext0), 5%);
       --gray-100: @text;
-      --gray-200: @subtext0;
-      --gray-300: @subtext1;
+      --gray-200: @subtext1;
+      --gray-300: @overlay2;
       --gray-400: @overlay0;
       --gray-500: @surface2;
       --gray-600: @surface1;
@@ -646,15 +646,15 @@
     }
 
     .bg-white {
-      background-color: @white;
+      background-color: @crust;
     }
 
     .bg-white\/20 {
-      background-color: fade(@white, 20%);
+      background-color: fade(@crust, 20%);
     }
 
     .bg-white\/25 {
-      background-color: fade(@white, 25%);
+      background-color: fade(@crust, 25%);
     }
 
     .bg-yellow-100 {
@@ -673,8 +673,12 @@
       background-color: darken(@yellow, 10%);
     }
 
-    .radix-state-checked\:bg-green-600[data-state="checked"] {
-      background-color: darken(@green, 10%);
+    .radix-state-checked\:\!bg-green-600[data-state="checked"] {
+      background-color: @accent-color !important;
+    }
+      
+    .dark\:radix-state-checked\:border-green-600[data-state=checked]:is(.dark *) {
+      border-color: @accent-color;
     }
 
     .hover\:bg-blue-700:hover {
@@ -871,7 +875,7 @@
       }
 
       .dark\:bg-white {
-        background-color: @white;
+        background-color: @text;
       }
 
       /* "Was this response better or worse" dialog button hover */

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -677,7 +677,7 @@
       background-color: @accent-color !important;
     }
       
-    .dark\:radix-state-checked\:border-green-600[data-state=checked]:is(.dark *) {
+    .dark\:radix-state-checked\:border-green-600[data-state="checked"]:is(.dark *) {
       border-color: @accent-color;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #626.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
