### PR TITLE
feat(github): theme activity overview graph

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.7
+@version      1.6.8
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -276,7 +276,7 @@
     --button-primary-borderColor-rest: @green;
     --button-primary-borderColor-hover: @green;
     --button-primary-borderColor-active: @green;
-    --button-primary-borderColor-disabled: #77c982;
+    --button-primary-borderColor-disabled: fade(@green, 70%);
     --button-primary-shadow-selected: 0px 0px 0px 0px #000;
     --button-invisible-fgColor-rest: @accent-color;
     --button-invisible-fgColor-hover: lighten(@accent-color, 10%);
@@ -556,6 +556,11 @@
         color: var(--color-ansi-gray);
       }
     }
+      
+      .js-activity-overview-graph .js-highlight-blob {
+          fill: @accent-color;
+          stroke: @accent-color;
+      }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

| Before | After |
| - | - |
| ![image](https://github.com/catppuccin/userstyles/assets/47499684/7d2b4e72-ec08-454a-8dfc-1c17b21dd9d7) | ![image](https://github.com/catppuccin/userstyles/assets/47499684/5ddb08e6-2640-4be2-b39b-bd05cdf942ee) | 

Also there is another change in here for a random button border.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
