### PR TITLE
fix(migadu-webmail): adjust message content selector

### DIFF
--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Migadu Webmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/migadu-webmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/migadu-webmail
-@version 0.0.9
+@version 0.0.10
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/migadu-webmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amigadu-webmail
 @description Soothing pastel theme for Migadu Webmail

--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -477,7 +477,7 @@
     }
 
     /* Untheme message content */
-    div:has(> .mail-body) {
+    div:has(> .bodyText) {
       color: #333;
       background-color: #fff;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Previous selector wasn't working 100% of the time for some reason.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
