### PR TITLE
fix(github): fade --bgColor-neutral-muted

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.8
+@version      1.6.9
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -376,7 +376,7 @@
     --bgColor-inverse: @text;
     --bgColor-disabled: #21262db3;
     --bgColor-transparent: #0000;
-    --bgColor-neutral-muted: @surface0;
+    --bgColor-neutral-muted: fade(@surface0, 40%);
     --bgColor-neutral-emphasis: @subtext0;
     --bgColor-accent-muted: fade(@accent-color, 20%);
     --bgColor-accent-emphasis: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Teeny fix for a background color used in like one place.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
