### PR TITLE
fix(codeberg): active tab text color

### DIFF
--- a/styles/codeberg/catppuccin.user.css
+++ b/styles/codeberg/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Codeberg Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/codeberg
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/codeberg
-@version 1.1.0
+@version 1.1.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/codeberg/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acodeberg
 @description Soothing pastel theme for Codeberg
@@ -64,6 +64,7 @@
     .ui.secondary.menu .dropdown.item:hover,
     .ui.secondary.menu a.item:hover {
       background-color: var(--color-nav-hover-bg);
+      color: var(--color-black);
     }
 
     .ui.basic.red.buttons .button,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

| Before | After |
| - | - |
| ![Screenshot 2024-05-16 at 10 16 54 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/75d85b18-8a3b-460a-af01-4c4b15672b5d) | ![Screenshot 2024-05-16 at 10 16 43 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/928522fa-5556-4565-80fe-7563c341a7b2) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
