### PR TITLE
fix(youtube): theme some live & premiere badges

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.14
+@version 4.0.15
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -694,9 +694,15 @@
     /* Thumbnails */
 
     #time-status:has([aria-label="LIVE"]),
-    .badge[aria-label="LIVE"] {
+    .badge[aria-label="LIVE"],
+    .badge[aria-label="PREMIERE"],
+    .badge-shape-wiz--live.badge-shape-wiz--overlay {
       --yt-spec-static-overlay-text-primary: @crust;
       --yt-spec-static-overlay-icon-active-other: @crust;
+    }
+    .badge-shape-wiz--live.badge-shape-wiz--overlay {
+      background: var(--yt-spec-static-overlay-background-brand);
+      color: var(--yt-spec-static-overlay-text-primary);
     }
     #thumbnail [style="background-color: rgba(51, 51, 51, 0.8);"],
     .YtInlinePlayerControlsTopRightControlsCircleButton,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes premiere badges on thumbnails and both live and premier on channel pages.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
