### PR TITLE
fix(twitter): Add missing x.com URLs

### DIFF
--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitter Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitter
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitter
-@version 1.0.6
+@version 1.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitter/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitter
 @description Soothing pastel theme for Twitter
@@ -771,7 +771,8 @@ domain("x.com") {
   }
 }
 
-@-moz-document domain("api.twitter.com") {
+@-moz-document domain("api.twitter.com")
+domain("api.x.com") {
   @media (prefers-color-scheme: light) {
     :root {
       #catppuccin(@lightFlavor, @accentColor);
@@ -892,7 +893,8 @@ domain("x.com") {
   }
 }
 
-@-moz-document domain("twitter.com") {
+@-moz-document domain("twitter.com")
+domain("x.com") {
   @media (prefers-color-scheme: light) {
     :root {
       #catppuccin(@lightFlavor, @accentColor);

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -893,7 +893,7 @@ domain("api.x.com") {
   }
 }
 
-@-moz-document domain("twitter.com")
+@-moz-document domain("twitter.com"),
 domain("x.com") {
   @media (prefers-color-scheme: light) {
     :root {

--- a/styles/twitter/catppuccin.user.css
+++ b/styles/twitter/catppuccin.user.css
@@ -771,7 +771,7 @@ domain("x.com") {
   }
 }
 
-@-moz-document domain("api.twitter.com")
+@-moz-document domain("api.twitter.com"),
 domain("api.x.com") {
   @media (prefers-color-scheme: light) {
     :root {


### PR DESCRIPTION
I missed some of the URLs by mistake

## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

This should add the remaining X URLs that I forgot to add in my last PR, I made sure api.x.com was in use via inspect element. However, the CDN still references Twitter somewhat so it is still unchanged from twimg.com however might change in the future

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
