### PR TITLE
fix(github): misc vars

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.9
+@version      1.6.10
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -215,9 +215,9 @@
     --control-borderColor-emphasis: #666e79;
     --control-borderColor-disabled: fade(@surface1, 75%);
     --control-borderColor-selected: #f0f6fc;
-    --control-borderColor-success: #238636;
-    --control-borderColor-danger: #da3633;
-    --control-borderColor-warning: #9e6a03;
+    --control-borderColor-success: @green;
+    --control-borderColor-danger: @red;
+    --control-borderColor-warning: @yellow;
     --control-iconColor-rest: #848d97;
     --control-transparent-bgColor-rest: #0000;
     --control-transparent-bgColor-hover: fade(@surface2, 20%);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes some status border colors (e.g. delete repo input border).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
