### PR TITLE
fix(ddg): more news in carousel button background

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -168,6 +168,7 @@
     .vertical--map__sidebar,
     .vertical--map__sidebar__header,
     .page-chrome_newtab,
+    .js-carousel-module-more,
     .zci--type--tiles:not(.is-fallback).is-full-page.is-expanded,
     .zci--type--tiles:not(.is-fallback).is-full-page.is-expanded
       .metabar:not(.is-stuck) {
@@ -487,7 +488,6 @@
     .modal__footer,
     .modal__box,
     .tile,
-    .js-carousel-module-more,
     .related-searches__item,
     .bg-clr--white,
     .tile__media__free-shipping-label,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.1.8
+@version 0.1.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<table>
<tr>
 <td>
before
 <td>
after
<tr>
 <td>
<img width="725" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/350f0a53-34a3-4101-b9c2-e587a96557ad">
 <td>
<img width="725" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/c05c768e-3b5f-42b3-94c2-27b53b5aca8f">

</table>

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
