### PR TITLE
fix(chatgpt): inline style override

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.3.0
+@version 0.3.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -859,6 +859,10 @@
       color: darken(@yellow, 30%);
     }
 
+    [style*="color: rgb(204, 0, 0)"] {
+      color: @red;
+    }
+
     /* Dark mode overrides */
     /* stylelint-disable-next-line no-duplicate-selectors */
     & when not (@lookup = latte) {

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -931,7 +931,7 @@
       --tw-ring-offset-color: @base;
     }
 
-    /* Gives themed color to invalid LaTeX expressions */
+    /* Invalid LaTeX expressions */
     [style*="color: rgb(204, 0, 0)"] {
       color: @red;
     }

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -859,10 +859,6 @@
       color: darken(@yellow, 30%);
     }
 
-    [style*="color: rgb(204, 0, 0)"] {
-      color: @red;
-    }
-
     /* Dark mode overrides */
     /* stylelint-disable-next-line no-duplicate-selectors */
     & when not (@lookup = latte) {
@@ -933,6 +929,10 @@
 
     .ring-offset-black {
       --tw-ring-offset-color: @base;
+    }
+
+    [style*="color: rgb(204, 0, 0)"] {
+      color: @red;
     }
 
     /* Circle around OpenAI logo in center of chat */

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -931,6 +931,7 @@
       --tw-ring-offset-color: @base;
     }
 
+    /* Gives themed color to invalid LaTeX expressions */
     [style*="color: rgb(204, 0, 0)"] {
       color: @red;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes #904 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.