### PR TITLE
fix(youtube): premiere badge is too low contrast

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -382,9 +382,6 @@
       --yt-endpoint-visited-color: @accent-color !important;
       color: @accent-color !important;
     }
-    .badge-style-type-live-now-alternate.ytd-badge-supported-renderer[aria-label="PREMIERE"] {
-      color: @surface0 !important;
-    }
 
     /* Selected chapter */
     ytd-macro-markers-list-item-renderer {
@@ -702,6 +699,7 @@
     .badge-shape-wiz--live.badge-shape-wiz--overlay {
       --yt-spec-static-overlay-text-primary: @crust;
       --yt-spec-static-overlay-icon-active-other: @crust;
+      color: @surface0 !important;
     }
     .badge-shape-wiz--live.badge-shape-wiz--overlay {
       background: var(--yt-spec-static-overlay-background-brand);

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.0.15
+@version 4.0.16
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -381,6 +381,9 @@
       --yt-endpoint-color: @accent-color !important;
       --yt-endpoint-visited-color: @accent-color !important;
       color: @accent-color !important;
+    }
+    .badge-style-type-live-now-alternate.ytd-badge-supported-renderer[aria-label="PREMIERE"] {
+      color: @surface0 !important;
     }
 
     /* Selected chapter */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

the premiere badge to indicate a video is a premiere was colored with light text color and light accent color it's now a dark text color

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
