### PR TITLE
feat(mdbook): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -516,6 +516,14 @@ userstyles:
           answer: "Your Mastodon instance may be using its own custom CSS, which is changing the look of the theme."
       current-maintainers: [*isabelroses]
       past-maintainers: [*andreasgrafen]
+  mdbook:
+    name: mdBook
+    categories: [wiki, development]
+    icon: mdbook
+    color: text
+    readme:
+      app-link: "https://rust-lang.github.io/mdBook/"
+      current-maintainers: [*uncenter]
   mdn:
     name: MDN
     categories: [development, wiki]

--- a/styles/mdbook/catppuccin.user.css
+++ b/styles/mdbook/catppuccin.user.css
@@ -1,0 +1,168 @@
+/* ==UserStyle==
+@name mdBook Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/mdbook
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mdbook
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mdbook/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amdbook
+@description Soothing pastel theme for mdBook
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain('doc.rust-lang.org') {
+  @import url("https://unpkg.com/@catppuccin/highlightjs@0.2.2/css/catppuccin.variables.css");
+
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    --ctp-rosewater: #rgbify(@rosewater) [];
+    --ctp-flamingo: #rgbify(@flamingo) [];
+    --ctp-pink: #rgbify(@pink) [];
+    --ctp-mauve: #rgbify(@mauve) [];
+    --ctp-red: #rgbify(@red) [];
+    --ctp-maroon: #rgbify(@maroon) [];
+    --ctp-peach: #rgbify(@peach) [];
+    --ctp-yellow: #rgbify(@yellow) [];
+    --ctp-green: #rgbify(@green) [];
+    --ctp-teal: #rgbify(@teal) [];
+    --ctp-sky: #rgbify(@sky) [];
+    --ctp-sapphire: #rgbify(@sapphire) [];
+    --ctp-blue: #rgbify(@blue) [];
+    --ctp-lavender: #rgbify(@lavender) [];
+    --ctp-text: #rgbify(@text) [];
+    --ctp-subtext1: #rgbify(@subtext1) [];
+    --ctp-subtext0: #rgbify(@subtext0) [];
+    --ctp-overlay2: #rgbify(@overlay2) [];
+    --ctp-overlay1: #rgbify(@overlay1) [];
+    --ctp-overlay0: #rgbify(@overlay0) [];
+    --ctp-surface2: #rgbify(@surface2) [];
+    --ctp-surface1: #rgbify(@surface1) [];
+    --ctp-surface0: #rgbify(@surface0) [];
+    --ctp-base: #rgbify(@base) [];
+    --ctp-mantle: #rgbify(@mantle) [];
+    --ctp-crust: #rgbify(@crust) [];
+
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    --bg: @base;
+    --fg: @text;
+    --sidebar-bg: @mantle;
+    --sidebar-fg: @text;
+    --sidebar-non-existant: @overlay0;
+    --sidebar-active: @blue;
+    --sidebar-spacer: @overlay0;
+    --scrollbar: @overlay0;
+    --icons: @overlay0;
+    --icons-hover: @overlay1;
+    --links: @blue;
+    --inline-code-color: @peach;
+    --theme-popup-bg: @mantle;
+    --theme-popup-border: @overlay0;
+    --theme-hover: @overlay0;
+    --quote-bg: @mantle;
+    --quote-border: @crust;
+    --table-border-color: @crust;
+    --table-header-bg: @mantle;
+    --table-alternate-bg: @mantle;
+    --searchbar-border-color: @crust;
+    --searchbar-bg: @mantle;
+    --searchbar-fg: @text;
+    --searchbar-shadow-color: @crust;
+    --searchresults-header-fg: @text;
+    --searchresults-border-color: @crust;
+    --searchresults-li-bg: @base;
+    --search-mark-bg: @peach;
+    --warning-border: @peach;
+
+    code.hljs {
+      color: @text;
+      background: @mantle;
+    }
+    blockquote blockquote {
+      border-top: 0.1em solid @surface2;
+      border-bottom: 0.1em solid @surface2;
+    }
+    hr {
+      color: @surface2;
+    }
+    del {
+      color: @overlay2;
+    }
+    .ace_gutter {
+      color: @overlay1;
+      background: @mantle;
+    }
+    .ace_gutter-active-line.ace_gutter-cell {
+      color: @pink;
+      background: @mantle;
+    }
+  }
+}
+
+#rgbify(@color) {
+  @rgb-raw: red(@color), green(@color), blue(@color);
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}
+
+// vim:ft=less

--- a/styles/mdbook/catppuccin.user.css
+++ b/styles/mdbook/catppuccin.user.css
@@ -15,7 +15,8 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document domain('doc.rust-lang.org') {
+@-moz-document url-prefix('https://rust-lang.github.io/mdBook/'), domain('doc.rust-lang.org')
+{
   @import url("https://unpkg.com/@catppuccin/highlightjs@0.2.2/css/catppuccin.variables.css");
 
   @media (prefers-color-scheme: light) {

--- a/styles/mdbook/catppuccin.user.css
+++ b/styles/mdbook/catppuccin.user.css
@@ -134,8 +134,8 @@
       background: @mantle;
     }
     blockquote blockquote {
-      border-top: 0.1em solid @surface2;
-      border-bottom: 0.1em solid @surface2;
+      border-top-color: @surface2;
+      border-bottom-color: @surface2;
     }
     hr {
       color: @surface2;

--- a/styles/mdbook/preview.webp
+++ b/styles/mdbook/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d71e4166b06fb217e84dfdd4196c0834e4ee21aad2bcc17d36cb59abe7b5de0f
+size 165684


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for mdBook 🎉

Themes websites using mdBook. Currently added the domain for the Rust books: https://doc.rust-lang.org/cargo/index.html, https://doc.rust-lang.org/book/title-page.html.

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - `catppuccin.user.css` - all the CSS for the userstyle, based on the
    template.
  - `preview.webp` - composite image of all four individual flavor screenshots stitched together,
    generated via [Catwalk](https://github.com/catppuccin/toolbox/tree/main/catwalk#readme).
