### PR TITLE
fix(crates.io): yanked badges

### DIFF
--- a/styles/crates.io/catppuccin.user.css
+++ b/styles/crates.io/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name crates.io Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/crates.io
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/crates.io
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/crates.io/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acrates.io
 @description Soothing pastel theme for crates.io

--- a/styles/crates.io/catppuccin.user.css
+++ b/styles/crates.io/catppuccin.user.css
@@ -281,6 +281,11 @@
       background-color: @surface0;
       box-shadow: none;
     }
+
+    [class*="_yanked-badge_"] {
+      background-color: @red;
+      color: @crust;
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes the following yanked badge:

![Screenshot 2024-05-25 at 00 02 59 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/8717d870-3e6a-4fc7-aef5-fbd651901520)

Can be seen on crate pages like https://crates.io/crates/url_validator/0.1.3.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
