### PR TITLE
feat(homepage): Reverting certain changes

### DIFF
--- a/styles/homepage/catppuccin.user.css
+++ b/styles/homepage/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name homepage Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/homepage
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/homepage
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/homepage/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahomepage
 @description Soothing pastel theme for homepage
@@ -74,11 +74,11 @@
 
     :is(.dark .dark\:bg-theme-800) {
       --tw-bg-opacity: 1;
-      background-color: @mantle; //background Color
+      background-color: @base; //background Color
     }
 
     .dark {
-      --bg-color: @mantle;
+      --bg-color: @base;
       --scrollbar-thumb: @accent-color; //ScrollBar
       --scrollbar-track: @mantle; //Scrollbar base
     }
@@ -114,7 +114,7 @@
     // Services Level Features
 
     :is(.dark .dark\:bg-white\/5) {
-      background-color: @base; //Box Background
+      background-color: @mantle; //Box Background
     }
     :is(.dark .dark\:shadow-theme-900\/20) {
       --tw-shadow-color: @mantle; //Box Shadows
@@ -168,6 +168,10 @@
 
     :is(.dark .dark\:hover\:text-theme-300:hover) {
       --tw-text-opacity: 1;
+      color: darken(
+        @accent-color,
+        10%
+      ); //Section Names + Container Description Hover Color
     }
     :is(.dark .dark\:text-theme-200) {
       --tw-text-opacity: 1;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes certain issues from [PR #915](https://github.com/catppuccin/userstyles/pull/915).
Base background colour revert to slightly lighter colour(base), in accordance with catppuccin userstyle guide.
Base box colour revert to slightly darker colour (mantle), in accordance with catppuccin userstyle guide.
Reverted hover colours to accent colour, else accent colour is completely absent from the styling.

Invite @BPplays (original PR author) for any comments.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
