### PR TITLE
fix(docs.rs): misc

### DIFF
--- a/styles/docs.rs/catppuccin.user.css
+++ b/styles/docs.rs/catppuccin.user.css
@@ -127,8 +127,8 @@
     --copy-path-button-color: @text;
     --codeblock-error-hover-color: @red;
     --codeblock-error-color: fade(@red, 70%);
-    --codeblock-ignore-hover-color: red;
-    --codeblock-ignore-color: red;
+    --codeblock-ignore-hover-color: @red;
+    --codeblock-ignore-color: fade(@red, 70%);
     --warning-border-color: red;
     --type-link-color: @sky;
     --trait-link-color: @mauve;

--- a/styles/docs.rs/catppuccin.user.css
+++ b/styles/docs.rs/catppuccin.user.css
@@ -197,7 +197,7 @@
     --crate-search-hover-border: red;
     --src-sidebar-background-selected: @surface0;
     --src-sidebar-background-hover: @surface1;
-    --table-alt-row-background-color: red;
+    --table-alt-row-background-color: @mantle;
     --codeblock-link-background: red;
     --scrape-example-toggle-line-background: red;
     --scrape-example-toggle-line-hover-background: red;

--- a/styles/docs.rs/catppuccin.user.css
+++ b/styles/docs.rs/catppuccin.user.css
@@ -121,7 +121,7 @@
     --border-color: @surface0;
     --button-background-color: @mantle;
     --right-side-color: @surface2;
-    --code-attribute-color: red;
+    --code-attribute-color: @yellow;
     --toggles-color: @subtext1;
     --search-input-focused-border-color: @accent-color;
     --copy-path-button-color: @text;

--- a/styles/docs.rs/catppuccin.user.css
+++ b/styles/docs.rs/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name docs.rs Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/docs.rs
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/docs.rs
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/docs.rs/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Adocs.rs
 @description Soothing pastel theme for docs.rs


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes another one of these:

![Screenshot 2024-05-25 at 11 26 04 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/d435fc08-2d44-444f-83d1-6c1ccec26fa6)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
