### PR TITLE
fix(proton): light color scheme for message iframe

### DIFF
--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Proton Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/proton
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/proton
-@version 0.1.6
+@version 0.1.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/proton/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aproton
 @description Soothing pastel theme for Proton
@@ -235,6 +235,10 @@
       box-shadow: none;
       background-color: var(--navigation-current-item-background-color);
       color: var(--email-item-unread-text-color);
+    }
+
+    .message-content:not(.plain) .message-iframe iframe {
+      color-scheme: light;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes #828 by setting `color-scheme: light;` for the iframe containing the message.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
