### PR TITLE
fix(docs.rs): background of links in source viewer

### DIFF
--- a/styles/docs.rs/catppuccin.user.css
+++ b/styles/docs.rs/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name docs.rs Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/docs.rs
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/docs.rs
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/docs.rs/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Adocs.rs
 @description Soothing pastel theme for docs.rs
@@ -198,7 +198,7 @@
     --src-sidebar-background-selected: @surface0;
     --src-sidebar-background-hover: @surface1;
     --table-alt-row-background-color: @mantle;
-    --codeblock-link-background: red;
+    --codeblock-link-background: fade(@surface0, 50%);
     --scrape-example-toggle-line-background: red;
     --scrape-example-toggle-line-hover-background: red;
     --scrape-example-code-line-highlight: fade(@accent-color, 40%);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes these kind of links in the source code:
![Screenshot 2024-05-28 at 13 17 26 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/114b1a01-3a6f-4054-9aa8-48d4d2188f55)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
