### PR TITLE
feat(docs.rs): apply to doc.rust-lang.org

### DIFF
--- a/styles/docs.rs/catppuccin.user.css
+++ b/styles/docs.rs/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name docs.rs Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/docs.rs
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/docs.rs
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/docs.rs/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Adocs.rs
 @description Soothing pastel theme for docs.rs
@@ -15,7 +15,7 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document domain('docs.rs') {
+@-moz-document regexp('^https?://(docs\\.rs|doc\\.rust-lang\\.org).*') {
   @media (prefers-color-scheme: light) {
     :root:not([data-docs-rs-theme]) {
       #catppuccin(@lightFlavor, @accentColor);

--- a/styles/docs.rs/catppuccin.user.css
+++ b/styles/docs.rs/catppuccin.user.css
@@ -15,7 +15,7 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document regexp('^https?://(docs\\.rs|doc\\.rust-lang\\.org).*') {
+@-moz-document domain('docs.rs'), domain('doc.rust-lang.org') {
   @media (prefers-color-scheme: light) {
     :root:not([data-docs-rs-theme]) {
       #catppuccin(@lightFlavor, @accentColor);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Apply the docs.rs userstyle to https://doc.rust-lang.org (aka docs.rs/std)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
