### PR TITLE
feat(mdbook): apply to rust-book.cs.brown.edu

### DIFF
--- a/styles/mdbook/catppuccin.user.css
+++ b/styles/mdbook/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name mdBook Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mdbook
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mdbook
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mdbook/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amdbook
 @description Soothing pastel theme for mdBook
@@ -15,7 +15,7 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document url-prefix('https://rust-lang.github.io/mdBook/'), domain('doc.rust-lang.org')
+@-moz-document url-prefix('https://rust-lang.github.io/mdBook/'), domain('doc.rust-lang.org'), domain('rust-book.cs.brown.edu')
 {
   @import url("https://unpkg.com/@catppuccin/highlightjs@0.2.2/css/catppuccin.variables.css");
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Apply the mdbook userstyle to https://rust-book.cs.brown.edu

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
