### PR TITLE
fix(hackage): color haddock menus

### DIFF
--- a/styles/hackage/catppuccin.user.css
+++ b/styles/hackage/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hackage Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hackage
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hackage
-@version 0.1.1
+@version 0.1.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hackage/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahackage
 @description Soothing pastel theme for Hackage
@@ -255,6 +255,77 @@
     }
 
     /*
+     * Quick jump
+     */
+
+    #search p.error {
+      color: @red;
+    }
+
+    #search-form,
+    #search-results {
+      box-shadow: 2px 2px 6px fade(@mantle, 20%);
+    }
+
+    #search-form {
+      input {
+        border-color: @accent-color;
+      }
+    }
+
+    #search-results {
+      border-color: @accent-color;
+
+      & > ul > li {
+        border-bottom-color: @overlay0;
+      }
+    }
+
+    .search-module > ul > li > a[href].active-link {
+      background-color: @surface2;
+    }
+
+    .search-result ul.subs::after {
+      color: @subtext1;
+    }
+
+    .more-results,
+    .more-results::before {
+      color: @subtext0;
+    }
+
+    .keyboard-shortcuts th {
+      color: @accent-color;
+    }
+
+    .key {
+      background-color: @mantle;
+      color: @text;
+      border-color: @mantle;
+    }
+
+    /*
+     * Dropdown
+     */
+
+    .dropdown-menu {
+      background-color: @surface0;
+      border-color: @surface0;
+
+      button {
+        background-color: @accent-color;
+        color: @mantle;
+        border-color: @surface2;
+
+        &:hover,
+        &:active {
+          background-color: @accent-color;
+          color: @mantle;
+        }
+      }
+    }
+
+    /*
      * Tables
      */
 
@@ -416,6 +487,10 @@
       }
     }
 
+    input[type="submit"] {
+      color: @text;
+    }
+
     input[type="range"]:hover,
     input[type="submit"]:hover {
       background-color: @crust;
@@ -500,10 +575,75 @@
       border-color: @overlay0;
     }
 
+    /*
+     * MathJax
+     */
+
     #MathJax_Message {
       background-color: @mantle;
       border-color: @surface1;
       color: @text;
+    }
+
+    #MathJax_About,
+    #MathJax_Help,
+    .MathJax_Menu {
+      background-color: @surface0;
+      color: @text;
+      border-color: @accent-color;
+      box-shadow: 0px 10px 20px @mantle;
+      -webkit-box-shadow: 0px 10px 20px @mantle;
+      -moz-box-shadow: 0px 10px 20px @mantle;
+    }
+
+    #MathJax_About > span,
+    #MathJax_HelpContent {
+      background-color: @surface1 !important;
+      color: @subtext1 !important;
+      border-color: @overlay0 !important;
+    }
+
+    .MathJax_MenuArrow {
+      color: @subtext1;
+    }
+
+    .MathJax_MenuRule {
+      border-top-color: @overlay0;
+    }
+
+    .MathJax_MenuActive {
+      background-color: @surface1;
+      color: @text;
+    }
+
+    .MathJax_MenuDisabled {
+      color: @overlay2;
+    }
+
+    .MathJax_MenuDisabled:focus,
+    .MathJax_MenuLabel:focus {
+      background-color: @surface1;
+    }
+
+    #MathJax_AboutClose,
+    #MathJax_HelpClose {
+      border-color: @surface2;
+      color: @subtext0;
+      span {
+        background-color: @surface2;
+      }
+
+      &:hover {
+        color: @text !important;
+        border-color: @overlay0 !important;
+        span {
+          background-color: @overlay0 !important;
+        }
+      }
+    }
+
+    span.mathjax img when not (@lookup = latte) {
+      filter: invert(100%);
     }
 
     /*

--- a/styles/hackage/catppuccin.user.css
+++ b/styles/hackage/catppuccin.user.css
@@ -591,9 +591,9 @@
       background-color: @surface0;
       color: @text;
       border-color: @accent-color;
-      box-shadow: 0px 10px 20px @mantle;
-      -webkit-box-shadow: 0px 10px 20px @mantle;
-      -moz-box-shadow: 0px 10px 20px @mantle;
+      box-shadow: 0 10px 20px @mantle;
+      -webkit-box-shadow: 0 10px 20px @mantle;
+      -moz-box-shadow: 0 10px 20px @mantle;
     }
 
     #MathJax_About > span,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

* Fixed the quick jump and dropdown (Instances) menus in Haddock documentations.
* Colored the MathJax settings and applied invert to the image-rendered math for dark themes.
* Colored the text of submit buttons in the advanced search page.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
