### PR TITLE
fix(hyperpipe): color the play button

### DIFF
--- a/styles/hyperpipe/catppuccin.user.css
+++ b/styles/hyperpipe/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hyperpipe Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hyperpipe
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hyperpipe
-@version 0.1.1
+@version 0.1.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hyperpipe/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahyperpipe
 @description Soothing pastel theme for Hyperpipe
@@ -102,6 +102,7 @@
     --color-border-hover: @overlay0 !important;
     --color-shadow: @crust !important;
     --color-blur: fade(@mantle, 45%) !important;
+    --color-gradient: linear-gradient(45deg, @accent-color, fade(@accent-color, 45%));
     --color-scrollbar: @accent-color !important;
     --color-heading: @text !important;
     --color-text: @text !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

* Colored the button gradient on albums and playlist.

![Screenshot of the said button, with blue accent.](https://github.com/catppuccin/userstyles/assets/45771313/df97a074-a530-48fa-9042-6974f4951c5b)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
