### PR TITLE
fix(mastodon): active icon button color

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Mastodon Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version 1.3.0
+@version 1.3.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amastodon
 @description Soothing pastel theme for Mastodon

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -182,7 +182,7 @@ domain("toot.wales") {
     .follow_requests-unlocked_explanation a,
     .column-back-button,
     .text-icon-button,
-    .icon-button.active,
+    .icon-button.star-icon.active,
     .public-layout .public-account-bio .account__header__fields a,
     .column-header__back-button,
     .navigation-bar strong,
@@ -192,6 +192,10 @@ domain("toot.wales") {
     .reactions-bar__item.active .reactions-bar__item__count,
     .column-header.active .column-header__icon {
       color: @accent-color;
+    }
+
+    .icon-button.active {
+      color: @mantle;
     }
 
     .display-name strong {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
closes #933 lol
![image](https://github.com/catppuccin/userstyles/assets/29279972/44ba81d5-7d49-4ef3-b7b2-18a46f54764a)
![image](https://github.com/catppuccin/userstyles/assets/29279972/ce5f049d-8786-4b8c-9622-8b82c058a5ac)

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
