### PR TITLE
fix(mastodon): active icon button color + confirmation prompt

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -194,7 +194,7 @@ domain("toot.wales") {
       color: @accent-color;
     }
 
-    .icon-button.active {
+    .icon-button.active.inverted {
       color: @mantle;
     }
 
@@ -212,6 +212,14 @@ domain("toot.wales") {
     .emoji-mart-anchor-selected,
     .reply-indicator__content a {
       color: @accent-color !important;
+    }
+
+    .confirmation-modal {
+      background-color: @base;
+      color: @text;
+    }
+    .confirmation-modal__action-bar {
+      background-color: @mantle;
     }
 
     .privacy-dropdown__option {

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Mastodon Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version 1.3.1
+@version 1.3.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amastodon
 @description Soothing pastel theme for Mastodon


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
realized that confirmation was not styled + fixes a regression caused by my last PR

<table>
<tr>
 <td>
before
 <td>
after
<tr>
 <td>
<img width="300" alt="meow" src="https://github.com/catppuccin/userstyles/assets/29279972/f5ab22fd-3d5d-4f9e-a77b-c11635a768b1">
 <td>
<img width="343" alt="image" src="https://github.com/catppuccin/userstyles/assets/29279972/9f976869-dfb6-42f7-b85e-31e81598b089">
</table>

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
