### PR TITLE
fix(picrew): fix unthemed buttons

### DIFF
--- a/styles/picrew/catppuccin.user.css
+++ b/styles/picrew/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Picrew Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/picrew
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/picrew
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/picrew/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apicrew
 @description Soothing pastel theme for Picrew
@@ -1019,10 +1019,14 @@
     .imagemaker_controller {
       background-color: @mantle !important;
     }
-    /* move image element (buttons) (inner image maker) */
-    .control_position_wrapper .ctrlbtn_position_inner::before {
+    /* rotate image element (inner image maker) */
+    .ctrlbtn-rotate_left,
+    .ctrlbtn-rotate_right {
       background: @surface0 !important;
+      color: @accent-color !important;
     }
+    /* move image element (buttons) (inner image maker) */
+    .control_position_wrapper .ctrlbtn_position_inner::before,
     .control_position_wrapper .ctrlbtn_position_inner::after {
       background: @surface0 !important;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

fixes a couple of unthemed buttons in the image maker

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
