### PR TITLE
feat(mdbook): appply accent-color to links and sidebar text

### DIFF
--- a/styles/mdbook/catppuccin.user.css
+++ b/styles/mdbook/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name mdBook Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mdbook
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mdbook
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mdbook/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amdbook
 @description Soothing pastel theme for mdBook
@@ -104,12 +104,12 @@
     --sidebar-bg: @mantle;
     --sidebar-fg: @text;
     --sidebar-non-existant: @overlay0;
-    --sidebar-active: @blue;
+    --sidebar-active: @accent-color;
     --sidebar-spacer: @overlay0;
     --scrollbar: @overlay0;
     --icons: @overlay0;
     --icons-hover: @overlay1;
-    --links: @blue;
+    --links: @accent-color;
     --inline-code-color: @peach;
     --theme-popup-bg: @mantle;
     --theme-popup-border: @overlay0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

As things are now, the accent color is almost never used throughout MDbook. This fixes that by changing the link and active sidebar text to use the accent-color instead of always appearing blue.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
