### PR TITLE
fix(wikipedia): Legibility of text color in tracklist tables

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.17
+@version 0.0.18
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -987,6 +987,15 @@
       > tr:nth-child(1),
     .navbox-abovebelow {
       background-color: @surface1 !important;
+    }
+
+    .mw-parser-output .tracklist > tbody {
+      color: inherit;
+
+      > .tracklist-total-length * {
+        background-color: @overlay1;
+        color: @base;
+      }
     }
 
     .mw-content-ltr


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
The `<tbody>` child of the tracklist table (`.tracklist`) now inherits the parent text color. 

The last row (`.tracklist-total-length`) is in inverted colors (it was already inverted, I've just changed the background to `@overlay1`.)

Closes #792.

Here's some screenshots of the [Future, Present Past](https://en.wikipedia.org/wiki/Future_Present_Past) track listing using mauve accents.

- Latte:
![latte](https://github.com/catppuccin/userstyles/assets/60618151/40ce6674-b767-49ec-9beb-58842ab55a19)

- Frappe:
![frappe](https://github.com/catppuccin/userstyles/assets/60618151/ad3c70fc-d886-446c-bc7d-1bb44b3eb5f2)

- Macchiato:
![macchiato](https://github.com/catppuccin/userstyles/assets/60618151/6054b59c-a2bb-4425-a623-f2600cbbf189)

- Mocha
![mocha](https://github.com/catppuccin/userstyles/assets/60618151/4830afda-c557-4620-b103-13ecf405998a)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
