### PR TITLE
fix(wikipedia): .noarticletext div background-color

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.18
+@version 0.0.19
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -1005,6 +1005,15 @@
       > td:nth-child(2) {
       border-color: @surface2 !important;
       background-color: @surface0 !important;
+    }
+
+    .noarticletext,
+    #noarticletext {
+      background-color: @base !important;
+    }
+
+    #sisterproject {
+      background-color: @mantle !important;
     }
 
     [style="color:#02a64f;line-height:initial"] {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes issues with background-color on the `<div class="noarticletext">` tag and tags with `id=\#sisterproject` in some languages.

Closes #670.
Some screenshots are included in my comment on that issue.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
