### PR TITLE
build(CODEOWNERS): protect sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,3 +81,7 @@
 /styles/wikiwand @Tnixc
 /styles/youtube @isabelroses @uncenter
 /styles/nextjs @Dandraghas
+
+.github/CODEOWNERS @catppuccin/userstyles-staff
+/scripts/ @catppuccin/userstyles-staff
+/template/ @catppuccin/userstyles-staff

--- a/scripts/generate/main.ts
+++ b/scripts/generate/main.ts
@@ -52,15 +52,25 @@ await syncIssueLabels(userstylesData.userstyles);
 /**
  * Keep `.github/CODEOWNERS` in sync with the userstyle metadata.
  */
-await updateFile(
-  join(REPO_ROOT, ".github/CODEOWNERS"),
-  Object.entries(userstylesData.userstyles)
-    .filter(([_, { "current-maintainers": currentMaintainers }]) => currentMaintainers.length > 0)
+const CODEOWNERS_FILE = ".github/CODEOWNERS";
+const maintainersCodeOwners = () => {
+  return Object.entries(userstylesData.userstyles)
+    .filter(([_, { "current-maintainers": currentMaintainers }]) =>
+      currentMaintainers.length > 0
+    )
     .map(([slug, { "current-maintainers": currentMaintainers }]) => {
       const codeOwners = currentMaintainers
         .map((maintainer) => `@${maintainer.url.split("/").pop()}`)
         .join(" ");
       return `/styles/${slug} ${codeOwners}`;
     })
-    .join("\n"),
+    .join("\n");
+};
+const userstylesStaffCodeOwners = () => {
+  const paths = [CODEOWNERS_FILE, "/scripts/", "/template/"];
+  return paths.map((path) => `${path} @catppuccin/userstyles-staff`).join("\n");
+};
+await updateFile(
+  join(REPO_ROOT, CODEOWNERS_FILE),
+  `${maintainersCodeOwners()}\n\n${userstylesStaffCodeOwners()}`,
 );


### PR DESCRIPTION
This commit ensures that explicit approval
from catppuccin/userstyles-staff is required
for paths that are responsible for managing
the repository.
