### PR TITLE
fix(stack-overflow): notification toasts

### DIFF
--- a/styles/stack-overflow/catppuccin.user.css
+++ b/styles/stack-overflow/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stack Overflow Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stack-overflow
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stack-overflow
-@version 0.1.0
+@version 0.1.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stack-overflow/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astack-overflow
 @description Soothing pastel theme for Stack Overflow
@@ -182,6 +182,7 @@ domain('superuser.com'), domain('mathoverflow.net'), domain('askubuntu.com'), do
       --purple-200: fade(@mauve, 40%);
       --purple-400: fade(@mauve, 60%);
 
+      --green-100: @green;
       --green-400: @green;
       --green-500: @green;
 
@@ -302,6 +303,13 @@ domain('superuser.com'), domain('mathoverflow.net'), domain('askubuntu.com'), do
     .s-badge {
       color: @crust;
       background-color: @mauve;
+    }
+
+    .s-notice {
+      &,
+      .s-notice--btn {
+        color: @mantle !important;
+      }
     }
 
     .badge,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![Screenshot 2024-06-08 at 12 21 57 (Arc)](https://github.com/catppuccin/userstyles/assets/47499684/dd523718-8581-49fe-a8d7-1032ee59b43e)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
