### PR TITLE
fix(template): typo

### DIFF
--- a/template/catppuccin.user.css
+++ b/template/catppuccin.user.css
@@ -34,7 +34,7 @@
   /* If the website you are theming *does* have a light/dark mode toggle,
      you can conditionally enable light/dark flavors by targeting whatever
      attribute that website uses to indicate the theme. *The example below gives you an idea of what
-     to look for. The website you are themeing may use a class-based approach (e.g. :root.theme-dark),
+     to look for. The website you are theming may use a class-based approach (e.g. :root.theme-dark),
      or any of the myriad of other methods like this.*
      Use the below example CSS to start if this is the case.
      For an actual example of this, see https://github.com/catppuccin/userstyles/blob/39288b593278e5efa48007d5fc001292cf910672/styles/youtube/catppuccin.user.css#L21-L30.


### PR DESCRIPTION
In the template, "theming" is spelled like "themeing" (with an extra e). this change fixes that