### PR TITLE
fix(duckduckgo): assorted elements

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.2.3
+@version 0.2.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -165,6 +165,14 @@
     --sds-color-background-container-01: @surface0 !important;
     --sds-color-border-accent-01: @accent-color !important;
     --theme-dc-color-container-message: @surface0 !important;
+    --sds-color-palette-gray-85: @surface1 !important;
+    --sds-color-palette-white: @crust !important;
+    --sds-color-background-accent-01: @accent-color !important;
+    --theme-col-txt-card-body-light: @text !important;
+    --theme-col-bg-page-alt-2: @surface0 !important;
+    --theme-dc-color-llama-main: @pink !important;
+    --theme-dc-color-mixtral-main: @peach !important;
+    --theme-dc-color-anchor-sleep: @subtext0 !important;
 
     .footer,
     .footer--mobile,
@@ -194,16 +202,16 @@
     }
 
     /* privacy reminders */
-    .privacy-reminder__text {
+    .wXKLp5dS9jGvo097pfaG {
       color: @green !important;
     }
-    .privacy-reminder__icon-circle {
+    .IuA6a2PUTR9Lck6m0WlP {
       @svg: escape(
         '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-4.572-1.562a.675.675 0 1 0-1.006-.9L7.123 9.224 5.597 7.36a.675.675 0 0 0-1.044.855l2.025 2.475a.675.675 0 0 0 1.025.023z" fill="@{green}"/></svg>'
       );
       background-image: url("data:image/svg+xml,@{svg}") !important;
     }
-    .privacy-reminder__icon-shield {
+    .XxDCpwElzOhQaLmCxJ8z {
       @svg: escape(
         '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="17" viewBox="0 0 16 17" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M6.452.99a3 3 0 0 1 .655-.482c.242-.13.563-.259.894-.258.329 0 .65.128.891.258.251.135.488.311.659.485.683.696 1.162.933 1.836 1.142.645.2 1.409.242 2.45.11a2.03 2.03 0 0 1 1.471.378c.42.315.686.794.69 1.324.034 3.86-.53 6.343-1.723 8.126-1.26 1.886-3.14 2.838-5.113 3.838l-.238.12a2.06 2.06 0 0 1-1.848 0l-.176-.089-.062-.031c-1.973-1-3.852-1.952-5.113-3.838C.532 10.29-.032 7.807 0 3.947c.005-.53.271-1.008.69-1.323.416-.313.95-.445 1.469-.38 1.049.133 1.816.082 2.46-.124.677-.216 1.159-.452 1.832-1.13m5.03 5.419a.686.686 0 0 0-1.021-.915L7.108 9.24 5.56 7.346a.686.686 0 0 0-1.061.868l2.057 2.515a.686.686 0 0 0 1.042.023z" fill="@{green}"/></svg>'
       );


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
this includes the always private icons + text, and their new ai chat models among other things

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
