### PR TITLE
fix(wikipedia): selflink anchors

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.19
+@version 0.0.20
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -576,6 +576,10 @@
     .vector-menu-tabs .mw-list-item.new a,
     .mw-plusminus-neg {
       color: @red;
+    }
+    
+    a.mw-selflink {
+      color: @text;
     }
 
     #searchInput {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This gives the correct coloring for selflinks on Wikipedia.

Before, when on the Wikipedia page for Family BASIC:

![image](https://github.com/catppuccin/userstyles/assets/55464333/498a9df1-2957-4c26-a9ce-ba3fe9a38d50)

After:

![image](https://github.com/catppuccin/userstyles/assets/55464333/bc0b4ca8-0605-42ca-9e3f-c54ac50d9c8e)

This matches default Wikipedia:

![image](https://github.com/catppuccin/userstyles/assets/55464333/18a1cf4a-3547-49e0-9b96-f366f7564787)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `caatppuccin.user.css` file.
