### PR TITLE
fix(wikipedia): broken background on some external links

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.19
+@version 0.0.20
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -1304,11 +1304,15 @@
       background-image: url("data:image/svg+xml,@{svg}") !important;
     }
 
-    .mw-parser-output a.external[class="external text"][rel="nofollow"] {
+    .mw-parser-output a.external {
       @svg: escape(
         '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="@{accent-color}" d="M6 1h5v5L8.86 3.85 4.7 8 4 7.3l4.15-4.16zM2 3h2v1H2v6h6V8h1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1"/></svg>'
       );
       background-image: url("data:image/svg+xml,@{svg}") !important;
+    }
+    
+    .plainlinks a.external {
+      background: none !important;
     }
 
     #mw-indicator-mw-helplink a {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes #922.

![image](https://github.com/catppuccin/userstyles/assets/55464333/cab5b0c9-c0af-4a74-809c-05fb074db151)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
