### PR TITLE
build: use `npm:` instead of `esm.sh`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
     "@actions/core": "npm:@actions/core@1.10.1",
     "@octokit/rest": "npm:@octokit/rest@20.0.2",
     "ajv": "npm:ajv@8.12.0",
-    "type-fest/": "https://esm.sh/v135/type-fest@4.8.1/",
+    "type-fest/": "npm:type-fest@4.8.1",
     "handlebars": "npm:handlebars@4.7.8",
     "less": "npm:less@4.2.0",
     "usercss-meta": "npm:usercss-meta@0.12.0"

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
     "@actions/core": "npm:@actions/core@1.10.1",
     "@octokit/rest": "npm:@octokit/rest@20.0.2",
     "ajv": "npm:ajv@8.12.0",
-    "type-fest/": "npm:type-fest@4.8.1",
+    "type-fest": "npm:type-fest@4.8.1",
     "handlebars": "npm:handlebars@4.7.8",
     "less": "npm:less@4.2.0",
     "usercss-meta": "npm:usercss-meta@0.12.0"

--- a/deno.lock
+++ b/deno.lock
@@ -16,6 +16,7 @@
       "npm:stylelint-config-recommended": "npm:stylelint-config-recommended@14.0.0_stylelint@16.2.1__@csstools+css-tokenizer@2.2.3__@csstools+css-parser-algorithms@2.6.0___@csstools+css-tokenizer@2.2.3__postcss-selector-parser@6.0.15__postcss@8.4.35",
       "npm:stylelint-config-standard": "npm:stylelint-config-standard@36.0.0_stylelint@16.2.1__@csstools+css-tokenizer@2.2.3__@csstools+css-parser-algorithms@2.6.0___@csstools+css-tokenizer@2.2.3__postcss-selector-parser@6.0.15__postcss@8.4.35",
       "npm:svgo": "npm:svgo@3.2.0",
+      "npm:type-fest@4.8.1": "npm:type-fest@4.8.1",
       "npm:usercss-meta@0.12.0": "npm:usercss-meta@0.12.0"
     },
     "npm": {
@@ -1390,6 +1391,10 @@
         "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
         "dependencies": {}
       },
+      "type-fest@4.8.1": {
+        "integrity": "sha512-ShaaYnjf+0etG8W/FumARKMjjIToy/haCaTjN2dvcewOSoNqCQzdgG7m2JVOlM5qndGTHjkvsrWZs+k/2Z7E0Q==",
+        "dependencies": {}
+      },
       "type@1.2.0": {
         "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
         "dependencies": {}
@@ -1651,6 +1656,7 @@
       "npm:ajv@8.12.0",
       "npm:handlebars@4.7.8",
       "npm:less@4.2.0",
+      "npm:type-fest@4.8.1",
       "npm:usercss-meta@0.12.0"
     ]
   }


### PR DESCRIPTION
Renovate is having some trouble parsing this as it's looking for it in the npm registry. Changing it to the `npm:` specifier should hopefully fix this.

When the deno-lib is brought into userstyles, we can look towards reverting this change to put more dependencies into the cache.
