### PR TITLE
build: regenerate deno lockfile

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,14 @@
     "type-fest": "npm:type-fest@4.8.1",
     "handlebars": "npm:handlebars@4.7.8",
     "less": "npm:less@4.2.0",
-    "usercss-meta": "npm:usercss-meta@0.12.0"
+    "usercss-meta": "npm:usercss-meta@0.12.0",
+    "json-schema-to-typescript": "npm:json-schema-to-typescript@13.1.2",
+    "postcss-less": "npm:postcss-less@6.0.0",
+    "stylelint": "npm:stylelint@16.6.1",
+    "stylelint-config-standard": "npm:stylelint-config-standard@36.0.0",
+    "stylelint-config-recommended": "npm:stylelint-config-recommended@14.0.0",
+    "postcss-value-parser": "npm:postcss-value-parser@4.2.0",
+    "svgo": "npm:svgo@3.2.0"
   },
   "tasks": {
     "ci:generate": "deno run -A ./scripts/generate/main.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -3,19 +3,16 @@
   "packages": {
     "specifiers": {
       "npm:@actions/core@1.10.1": "npm:@actions/core@1.10.1",
-      "npm:@octokit/rest@20.0.2": "npm:@octokit/rest@20.0.2_@octokit+core@5.1.0",
-      "npm:@types/less": "npm:@types/less@3.0.6",
+      "npm:@octokit/rest@20.0.2": "npm:@octokit/rest@20.0.2_@octokit+core@5.2.0",
       "npm:ajv@8.12.0": "npm:ajv@8.12.0",
       "npm:handlebars@4.7.8": "npm:handlebars@4.7.8",
-      "npm:json-schema-to-typescript": "npm:json-schema-to-typescript@13.1.2_glob@7.2.3",
+      "npm:json-schema-to-typescript@13.1.2": "npm:json-schema-to-typescript@13.1.2_glob@7.2.3",
       "npm:less@4.2.0": "npm:less@4.2.0",
-      "npm:postcss-less": "npm:postcss-less@6.0.0_postcss@8.4.35",
-      "npm:postcss-value-parser": "npm:postcss-value-parser@4.2.0",
+      "npm:postcss-less@6.0.0": "npm:postcss-less@6.0.0_postcss@8.4.38",
       "npm:prettier@3.2.4": "npm:prettier@3.2.4",
-      "npm:stylelint": "npm:stylelint@16.2.1_@csstools+css-tokenizer@2.2.3_@csstools+css-parser-algorithms@2.6.0__@csstools+css-tokenizer@2.2.3_postcss-selector-parser@6.0.15_postcss@8.4.35",
-      "npm:stylelint-config-recommended": "npm:stylelint-config-recommended@14.0.0_stylelint@16.2.1__@csstools+css-tokenizer@2.2.3__@csstools+css-parser-algorithms@2.6.0___@csstools+css-tokenizer@2.2.3__postcss-selector-parser@6.0.15__postcss@8.4.35",
-      "npm:stylelint-config-standard": "npm:stylelint-config-standard@36.0.0_stylelint@16.2.1__@csstools+css-tokenizer@2.2.3__@csstools+css-parser-algorithms@2.6.0___@csstools+css-tokenizer@2.2.3__postcss-selector-parser@6.0.15__postcss@8.4.35",
-      "npm:svgo": "npm:svgo@3.2.0",
+      "npm:stylelint-config-recommended@14.0.0": "npm:stylelint-config-recommended@14.0.0_stylelint@16.6.1__@csstools+css-tokenizer@2.3.1__@csstools+css-parser-algorithms@2.6.3___@csstools+css-tokenizer@2.3.1__postcss-selector-parser@6.1.0__postcss@8.4.38",
+      "npm:stylelint-config-standard@36.0.0": "npm:stylelint-config-standard@36.0.0_stylelint@16.6.1__@csstools+css-tokenizer@2.3.1__@csstools+css-parser-algorithms@2.6.3___@csstools+css-tokenizer@2.3.1__postcss-selector-parser@6.1.0__postcss@8.4.38",
+      "npm:stylelint@16.6.1": "npm:stylelint@16.6.1_@csstools+css-tokenizer@2.3.1_@csstools+css-parser-algorithms@2.6.3__@csstools+css-tokenizer@2.3.1_postcss-selector-parser@6.1.0_postcss@8.4.38",
       "npm:type-fest@4.8.1": "npm:type-fest@4.8.1",
       "npm:usercss-meta@0.12.0": "npm:usercss-meta@0.12.0"
     },
@@ -23,34 +20,35 @@
       "@actions/core@1.10.1": {
         "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
         "dependencies": {
-          "@actions/http-client": "@actions/http-client@2.2.0",
+          "@actions/http-client": "@actions/http-client@2.2.1",
           "uuid": "uuid@8.3.2"
         }
       },
-      "@actions/http-client@2.2.0": {
-        "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+      "@actions/http-client@2.2.1": {
+        "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
         "dependencies": {
           "tunnel": "tunnel@0.0.6",
-          "undici": "undici@5.28.3"
+          "undici": "undici@5.28.4"
         }
       },
-      "@babel/code-frame@7.23.5": {
-        "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "@babel/code-frame@7.24.7": {
+        "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
         "dependencies": {
-          "@babel/highlight": "@babel/highlight@7.23.4",
-          "chalk": "chalk@2.4.2"
+          "@babel/highlight": "@babel/highlight@7.24.7",
+          "picocolors": "picocolors@1.0.1"
         }
       },
-      "@babel/helper-validator-identifier@7.22.20": {
-        "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "@babel/helper-validator-identifier@7.24.7": {
+        "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
         "dependencies": {}
       },
-      "@babel/highlight@7.23.4": {
-        "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "@babel/highlight@7.24.7": {
+        "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
         "dependencies": {
-          "@babel/helper-validator-identifier": "@babel/helper-validator-identifier@7.22.20",
+          "@babel/helper-validator-identifier": "@babel/helper-validator-identifier@7.24.7",
           "chalk": "chalk@2.4.2",
-          "js-tokens": "js-tokens@4.0.0"
+          "js-tokens": "js-tokens@4.0.0",
+          "picocolors": "picocolors@1.0.1"
         }
       },
       "@bcherny/json-schema-ref-parser@10.0.5-fork": {
@@ -62,43 +60,36 @@
           "js-yaml": "js-yaml@4.1.0"
         }
       },
-      "@csstools/css-parser-algorithms@2.6.0_@csstools+css-tokenizer@2.2.3": {
-        "integrity": "sha512-YfEHq0eRH98ffb5/EsrrDspVWAuph6gDggAE74ZtjecsmyyWpW768hOyiONa8zwWGbIWYfa2Xp4tRTrpQQ00CQ==",
+      "@csstools/css-parser-algorithms@2.6.3_@csstools+css-tokenizer@2.3.1": {
+        "integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
         "dependencies": {
-          "@csstools/css-tokenizer": "@csstools/css-tokenizer@2.2.3"
+          "@csstools/css-tokenizer": "@csstools/css-tokenizer@2.3.1"
         }
       },
-      "@csstools/css-tokenizer@2.2.3": {
-        "integrity": "sha512-pp//EvZ9dUmGuGtG1p+n17gTHEOqu9jO+FiCUjNN3BDmyhdA2Jq9QsVeR7K8/2QCK17HSsioPlTW9ZkzoWb3Lg==",
+      "@csstools/css-tokenizer@2.3.1": {
+        "integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g==",
         "dependencies": {}
       },
-      "@csstools/media-query-list-parser@2.1.8_@csstools+css-parser-algorithms@2.6.0__@csstools+css-tokenizer@2.2.3_@csstools+css-tokenizer@2.2.3": {
-        "integrity": "sha512-DiD3vG5ciNzeuTEoh74S+JMjQDs50R3zlxHnBnfd04YYfA/kh2KiBCGhzqLxlJcNq+7yNQ3stuZZYLX6wK/U2g==",
+      "@csstools/media-query-list-parser@2.1.11_@csstools+css-parser-algorithms@2.6.3__@csstools+css-tokenizer@2.3.1_@csstools+css-tokenizer@2.3.1": {
+        "integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
         "dependencies": {
-          "@csstools/css-parser-algorithms": "@csstools/css-parser-algorithms@2.6.0_@csstools+css-tokenizer@2.2.3",
-          "@csstools/css-tokenizer": "@csstools/css-tokenizer@2.2.3"
+          "@csstools/css-parser-algorithms": "@csstools/css-parser-algorithms@2.6.3_@csstools+css-tokenizer@2.3.1",
+          "@csstools/css-tokenizer": "@csstools/css-tokenizer@2.3.1"
         }
       },
-      "@csstools/selector-specificity@3.0.2_postcss-selector-parser@6.0.15": {
-        "integrity": "sha512-RpHaZ1h9LE7aALeQXmXrJkRG84ZxIsctEN2biEUmFyKpzFM3zZ35eUMcIzZFsw/2olQE6v69+esEqU2f1MKycg==",
+      "@csstools/selector-specificity@3.1.1_postcss-selector-parser@6.1.0": {
+        "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
         "dependencies": {
-          "postcss-selector-parser": "postcss-selector-parser@6.0.15"
+          "postcss-selector-parser": "postcss-selector-parser@6.1.0"
         }
+      },
+      "@dual-bundle/import-meta-resolve@4.1.0": {
+        "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+        "dependencies": {}
       },
       "@fastify/busboy@2.1.1": {
         "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
         "dependencies": {}
-      },
-      "@isaacs/cliui@8.0.2": {
-        "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-        "dependencies": {
-          "string-width": "string-width@5.1.2",
-          "string-width-cjs": "string-width@4.2.3",
-          "strip-ansi": "strip-ansi@7.1.0",
-          "strip-ansi-cjs": "strip-ansi@6.0.1",
-          "wrap-ansi": "wrap-ansi@8.1.0",
-          "wrap-ansi-cjs": "wrap-ansi@7.0.0"
-        }
       },
       "@jsdevtools/ono@7.1.3": {
         "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
@@ -126,30 +117,30 @@
         "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
         "dependencies": {}
       },
-      "@octokit/core@5.1.0": {
-        "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+      "@octokit/core@5.2.0": {
+        "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
         "dependencies": {
           "@octokit/auth-token": "@octokit/auth-token@4.0.0",
-          "@octokit/graphql": "@octokit/graphql@7.0.2",
-          "@octokit/request": "@octokit/request@8.2.0",
-          "@octokit/request-error": "@octokit/request-error@5.0.1",
-          "@octokit/types": "@octokit/types@12.6.0",
+          "@octokit/graphql": "@octokit/graphql@7.1.0",
+          "@octokit/request": "@octokit/request@8.4.0",
+          "@octokit/request-error": "@octokit/request-error@5.1.0",
+          "@octokit/types": "@octokit/types@13.5.0",
           "before-after-hook": "before-after-hook@2.2.3",
           "universal-user-agent": "universal-user-agent@6.0.1"
         }
       },
-      "@octokit/endpoint@9.0.4": {
-        "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+      "@octokit/endpoint@9.0.5": {
+        "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
         "dependencies": {
-          "@octokit/types": "@octokit/types@12.6.0",
+          "@octokit/types": "@octokit/types@13.5.0",
           "universal-user-agent": "universal-user-agent@6.0.1"
         }
       },
-      "@octokit/graphql@7.0.2": {
-        "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+      "@octokit/graphql@7.1.0": {
+        "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
         "dependencies": {
-          "@octokit/request": "@octokit/request@8.2.0",
-          "@octokit/types": "@octokit/types@12.6.0",
+          "@octokit/request": "@octokit/request@8.4.0",
+          "@octokit/types": "@octokit/types@13.5.0",
           "universal-user-agent": "universal-user-agent@6.0.1"
         }
       },
@@ -157,50 +148,54 @@
         "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
         "dependencies": {}
       },
-      "@octokit/plugin-paginate-rest@9.2.0_@octokit+core@5.1.0": {
-        "integrity": "sha512-NKi0bJEZqOSbBLMv9kdAcuocpe05Q2xAXNLTGi0HN2GSMFJHNZuSoPNa0tcQFTOFCKe+ZaYBZ3lpXh1yxgUDCA==",
+      "@octokit/openapi-types@22.2.0": {
+        "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+        "dependencies": {}
+      },
+      "@octokit/plugin-paginate-rest@9.2.1_@octokit+core@5.2.0": {
+        "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
         "dependencies": {
-          "@octokit/core": "@octokit/core@5.1.0",
+          "@octokit/core": "@octokit/core@5.2.0",
           "@octokit/types": "@octokit/types@12.6.0"
         }
       },
-      "@octokit/plugin-request-log@4.0.0_@octokit+core@5.1.0": {
-        "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+      "@octokit/plugin-request-log@4.0.1_@octokit+core@5.2.0": {
+        "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
         "dependencies": {
-          "@octokit/core": "@octokit/core@5.1.0"
+          "@octokit/core": "@octokit/core@5.2.0"
         }
       },
-      "@octokit/plugin-rest-endpoint-methods@10.4.0_@octokit+core@5.1.0": {
-        "integrity": "sha512-INw5rGXWlbv/p/VvQL63dhlXr38qYTHkQ5bANi9xofrF9OraqmjHsIGyenmjmul1JVRHpUlw5heFOj1UZLEolA==",
+      "@octokit/plugin-rest-endpoint-methods@10.4.1_@octokit+core@5.2.0": {
+        "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
         "dependencies": {
-          "@octokit/core": "@octokit/core@5.1.0",
+          "@octokit/core": "@octokit/core@5.2.0",
           "@octokit/types": "@octokit/types@12.6.0"
         }
       },
-      "@octokit/request-error@5.0.1": {
-        "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "@octokit/request-error@5.1.0": {
+        "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
         "dependencies": {
-          "@octokit/types": "@octokit/types@12.6.0",
+          "@octokit/types": "@octokit/types@13.5.0",
           "deprecation": "deprecation@2.3.1",
           "once": "once@1.4.0"
         }
       },
-      "@octokit/request@8.2.0": {
-        "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+      "@octokit/request@8.4.0": {
+        "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
         "dependencies": {
-          "@octokit/endpoint": "@octokit/endpoint@9.0.4",
-          "@octokit/request-error": "@octokit/request-error@5.0.1",
-          "@octokit/types": "@octokit/types@12.6.0",
+          "@octokit/endpoint": "@octokit/endpoint@9.0.5",
+          "@octokit/request-error": "@octokit/request-error@5.1.0",
+          "@octokit/types": "@octokit/types@13.5.0",
           "universal-user-agent": "universal-user-agent@6.0.1"
         }
       },
-      "@octokit/rest@20.0.2_@octokit+core@5.1.0": {
+      "@octokit/rest@20.0.2_@octokit+core@5.2.0": {
         "integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
         "dependencies": {
-          "@octokit/core": "@octokit/core@5.1.0",
-          "@octokit/plugin-paginate-rest": "@octokit/plugin-paginate-rest@9.2.0_@octokit+core@5.1.0",
-          "@octokit/plugin-request-log": "@octokit/plugin-request-log@4.0.0_@octokit+core@5.1.0",
-          "@octokit/plugin-rest-endpoint-methods": "@octokit/plugin-rest-endpoint-methods@10.4.0_@octokit+core@5.1.0"
+          "@octokit/core": "@octokit/core@5.2.0",
+          "@octokit/plugin-paginate-rest": "@octokit/plugin-paginate-rest@9.2.1_@octokit+core@5.2.0",
+          "@octokit/plugin-request-log": "@octokit/plugin-request-log@4.0.1_@octokit+core@5.2.0",
+          "@octokit/plugin-rest-endpoint-methods": "@octokit/plugin-rest-endpoint-methods@10.4.1_@octokit+core@5.2.0"
         }
       },
       "@octokit/types@12.6.0": {
@@ -209,13 +204,11 @@
           "@octokit/openapi-types": "@octokit/openapi-types@20.0.0"
         }
       },
-      "@pkgjs/parseargs@0.11.0": {
-        "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-        "dependencies": {}
-      },
-      "@trysound/sax@0.2.0": {
-        "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-        "dependencies": {}
+      "@octokit/types@13.5.0": {
+        "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+        "dependencies": {
+          "@octokit/openapi-types": "@octokit/openapi-types@22.2.0"
+        }
       },
       "@types/glob@7.2.0": {
         "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
@@ -228,12 +221,8 @@
         "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
         "dependencies": {}
       },
-      "@types/less@3.0.6": {
-        "integrity": "sha512-PecSzorDGdabF57OBeQO/xFbAkYWo88g4Xvnsx7LRwqLC17I7OoKtA3bQB9uXkY6UkMWCOsA8HSVpaoitscdXw==",
-        "dependencies": {}
-      },
-      "@types/lodash@4.14.202": {
-        "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "@types/lodash@4.17.5": {
+        "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
         "dependencies": {}
       },
       "@types/minimatch@5.1.2": {
@@ -277,10 +266,6 @@
           "color-convert": "color-convert@2.0.1"
         }
       },
-      "ansi-styles@6.2.1": {
-        "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-        "dependencies": {}
-      },
       "any-promise@1.3.0": {
         "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
         "dependencies": {}
@@ -309,10 +294,6 @@
         "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
         "dependencies": {}
       },
-      "boolbase@1.0.0": {
-        "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-        "dependencies": {}
-      },
       "brace-expansion@1.1.11": {
         "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
         "dependencies": {
@@ -320,16 +301,10 @@
           "concat-map": "concat-map@0.0.1"
         }
       },
-      "brace-expansion@2.0.1": {
-        "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "braces@3.0.3": {
+        "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
         "dependencies": {
-          "balanced-match": "balanced-match@1.0.2"
-        }
-      },
-      "braces@3.0.2": {
-        "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-        "dependencies": {
-          "fill-range": "fill-range@7.0.1"
+          "fill-range": "fill-range@7.1.1"
         }
       },
       "call-me-maybe@1.0.2": {
@@ -348,14 +323,14 @@
           "supports-color": "supports-color@5.5.0"
         }
       },
-      "cli-color@2.0.3": {
-        "integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+      "cli-color@2.0.4": {
+        "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
         "dependencies": {
-          "d": "d@1.0.1",
+          "d": "d@1.0.2",
           "es5-ext": "es5-ext@0.10.64",
           "es6-iterator": "es6-iterator@2.0.3",
-          "memoizee": "memoizee@0.4.15",
-          "timers-ext": "timers-ext@0.1.7"
+          "memoizee": "memoizee@0.4.17",
+          "timers-ext": "timers-ext@0.1.8"
         }
       },
       "color-convert@1.9.3": {
@@ -382,10 +357,6 @@
         "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
         "dependencies": {}
       },
-      "commander@7.2.0": {
-        "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-        "dependencies": {}
-      },
       "concat-map@0.0.1": {
         "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
         "dependencies": {}
@@ -405,65 +376,30 @@
           "parse-json": "parse-json@5.2.0"
         }
       },
-      "cross-spawn@7.0.3": {
-        "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-        "dependencies": {
-          "path-key": "path-key@3.1.1",
-          "shebang-command": "shebang-command@2.0.0",
-          "which": "which@2.0.2"
-        }
-      },
-      "css-functions-list@3.2.1": {
-        "integrity": "sha512-Nj5YcaGgBtuUmn1D7oHqPW0c9iui7xsTsj5lIX8ZgevdfhmjFfKB3r8moHJtNJnctnYXJyYX5I1pp90HM4TPgQ==",
+      "css-functions-list@3.2.2": {
+        "integrity": "sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ==",
         "dependencies": {}
-      },
-      "css-select@5.1.0": {
-        "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-        "dependencies": {
-          "boolbase": "boolbase@1.0.0",
-          "css-what": "css-what@6.1.0",
-          "domhandler": "domhandler@5.0.3",
-          "domutils": "domutils@3.1.0",
-          "nth-check": "nth-check@2.1.1"
-        }
-      },
-      "css-tree@2.2.1": {
-        "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-        "dependencies": {
-          "mdn-data": "mdn-data@2.0.28",
-          "source-map-js": "source-map-js@1.0.2"
-        }
       },
       "css-tree@2.3.1": {
         "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
         "dependencies": {
           "mdn-data": "mdn-data@2.0.30",
-          "source-map-js": "source-map-js@1.0.2"
+          "source-map-js": "source-map-js@1.2.0"
         }
-      },
-      "css-what@6.1.0": {
-        "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-        "dependencies": {}
       },
       "cssesc@3.0.0": {
         "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
         "dependencies": {}
       },
-      "csso@5.0.5": {
-        "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-        "dependencies": {
-          "css-tree": "css-tree@2.2.1"
-        }
-      },
-      "d@1.0.1": {
-        "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "d@1.0.2": {
+        "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
         "dependencies": {
           "es5-ext": "es5-ext@0.10.64",
-          "type": "type@1.2.0"
+          "type": "type@2.7.3"
         }
       },
-      "debug@4.3.4": {
-        "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "debug@4.3.5": {
+        "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
         "dependencies": {
           "ms": "ms@2.1.2"
         }
@@ -478,46 +414,8 @@
           "path-type": "path-type@4.0.0"
         }
       },
-      "dom-serializer@2.0.0": {
-        "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-        "dependencies": {
-          "domelementtype": "domelementtype@2.3.0",
-          "domhandler": "domhandler@5.0.3",
-          "entities": "entities@4.5.0"
-        }
-      },
-      "domelementtype@2.3.0": {
-        "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-        "dependencies": {}
-      },
-      "domhandler@5.0.3": {
-        "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-        "dependencies": {
-          "domelementtype": "domelementtype@2.3.0"
-        }
-      },
-      "domutils@3.1.0": {
-        "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-        "dependencies": {
-          "dom-serializer": "dom-serializer@2.0.0",
-          "domelementtype": "domelementtype@2.3.0",
-          "domhandler": "domhandler@5.0.3"
-        }
-      },
-      "eastasianwidth@0.2.0": {
-        "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-        "dependencies": {}
-      },
       "emoji-regex@8.0.0": {
         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-        "dependencies": {}
-      },
-      "emoji-regex@9.2.2": {
-        "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-        "dependencies": {}
-      },
-      "entities@4.5.0": {
-        "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
         "dependencies": {}
       },
       "env-paths@2.2.1": {
@@ -540,7 +438,7 @@
         "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
         "dependencies": {
           "es6-iterator": "es6-iterator@2.0.3",
-          "es6-symbol": "es6-symbol@3.1.3",
+          "es6-symbol": "es6-symbol@3.1.4",
           "esniff": "esniff@2.0.1",
           "next-tick": "next-tick@1.1.0"
         }
@@ -548,25 +446,25 @@
       "es6-iterator@2.0.3": {
         "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
         "dependencies": {
-          "d": "d@1.0.1",
+          "d": "d@1.0.2",
           "es5-ext": "es5-ext@0.10.64",
-          "es6-symbol": "es6-symbol@3.1.3"
+          "es6-symbol": "es6-symbol@3.1.4"
         }
       },
-      "es6-symbol@3.1.3": {
-        "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "es6-symbol@3.1.4": {
+        "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
         "dependencies": {
-          "d": "d@1.0.1",
+          "d": "d@1.0.2",
           "ext": "ext@1.7.0"
         }
       },
       "es6-weak-map@2.0.3": {
         "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
         "dependencies": {
-          "d": "d@1.0.1",
+          "d": "d@1.0.2",
           "es5-ext": "es5-ext@0.10.64",
           "es6-iterator": "es6-iterator@2.0.3",
-          "es6-symbol": "es6-symbol@3.1.3"
+          "es6-symbol": "es6-symbol@3.1.4"
         }
       },
       "escape-string-regexp@1.0.5": {
@@ -576,23 +474,23 @@
       "esniff@2.0.1": {
         "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
         "dependencies": {
-          "d": "d@1.0.1",
+          "d": "d@1.0.2",
           "es5-ext": "es5-ext@0.10.64",
           "event-emitter": "event-emitter@0.3.5",
-          "type": "type@2.7.2"
+          "type": "type@2.7.3"
         }
       },
       "event-emitter@0.3.5": {
         "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
         "dependencies": {
-          "d": "d@1.0.1",
+          "d": "d@1.0.2",
           "es5-ext": "es5-ext@0.10.64"
         }
       },
       "ext@1.7.0": {
         "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
         "dependencies": {
-          "type": "type@2.7.2"
+          "type": "type@2.7.3"
         }
       },
       "fast-deep-equal@3.1.3": {
@@ -606,7 +504,7 @@
           "@nodelib/fs.walk": "@nodelib/fs.walk@1.2.8",
           "glob-parent": "glob-parent@5.1.2",
           "merge2": "merge2@1.4.1",
-          "micromatch": "micromatch@4.0.5"
+          "micromatch": "micromatch@4.0.7"
         }
       },
       "fastest-levenshtein@1.0.16": {
@@ -619,36 +517,28 @@
           "reusify": "reusify@1.0.4"
         }
       },
-      "file-entry-cache@8.0.0": {
-        "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "file-entry-cache@9.0.0": {
+        "integrity": "sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==",
         "dependencies": {
-          "flat-cache": "flat-cache@4.0.0"
+          "flat-cache": "flat-cache@5.0.0"
         }
       },
-      "fill-range@7.0.1": {
-        "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "fill-range@7.1.1": {
+        "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
         "dependencies": {
           "to-regex-range": "to-regex-range@5.0.1"
         }
       },
-      "flat-cache@4.0.0": {
-        "integrity": "sha512-EryKbCE/wxpxKniQlyas6PY1I9vwtF3uCBweX+N8KYTCn3Y12RTGtQAJ/bd5pl7kxUAc8v/R3Ake/N17OZiFqA==",
+      "flat-cache@5.0.0": {
+        "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
         "dependencies": {
           "flatted": "flatted@3.3.1",
-          "keyv": "keyv@4.5.4",
-          "rimraf": "rimraf@5.0.5"
+          "keyv": "keyv@4.5.4"
         }
       },
       "flatted@3.3.1": {
         "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
         "dependencies": {}
-      },
-      "foreground-child@3.1.1": {
-        "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-        "dependencies": {
-          "cross-spawn": "cross-spawn@7.0.3",
-          "signal-exit": "signal-exit@4.1.0"
-        }
       },
       "fs.realpath@1.0.0": {
         "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
@@ -669,16 +559,6 @@
         "dependencies": {
           "@types/glob": "@types/glob@7.2.0",
           "glob": "glob@7.2.3"
-        }
-      },
-      "glob@10.3.10": {
-        "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-        "dependencies": {
-          "foreground-child": "foreground-child@3.1.1",
-          "jackspeak": "jackspeak@2.3.6",
-          "minimatch": "minimatch@9.0.3",
-          "minipass": "minipass@7.0.4",
-          "path-scurry": "path-scurry@1.10.1"
         }
       },
       "glob@7.2.3": {
@@ -731,7 +611,7 @@
           "minimist": "minimist@1.2.8",
           "neo-async": "neo-async@2.6.2",
           "source-map": "source-map@0.6.1",
-          "uglify-js": "uglify-js@3.17.4",
+          "uglify-js": "uglify-js@3.18.0",
           "wordwrap": "wordwrap@1.0.0"
         }
       },
@@ -825,13 +705,6 @@
         "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
         "dependencies": {}
       },
-      "jackspeak@2.3.6": {
-        "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-        "dependencies": {
-          "@isaacs/cliui": "@isaacs/cliui@8.0.2",
-          "@pkgjs/parseargs": "@pkgjs/parseargs@0.11.0"
-        }
-      },
       "js-tokens@4.0.0": {
         "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
         "dependencies": {}
@@ -855,9 +728,9 @@
         "dependencies": {
           "@bcherny/json-schema-ref-parser": "@bcherny/json-schema-ref-parser@10.0.5-fork",
           "@types/json-schema": "@types/json-schema@7.0.15",
-          "@types/lodash": "@types/lodash@4.14.202",
+          "@types/lodash": "@types/lodash@4.17.5",
           "@types/prettier": "@types/prettier@2.7.3",
-          "cli-color": "cli-color@2.0.3",
+          "cli-color": "cli-color@2.0.4",
           "get-stdin": "get-stdin@8.0.0",
           "glob": "glob@7.2.3",
           "glob-promise": "glob-promise@4.2.2_glob@7.2.3",
@@ -883,8 +756,8 @@
         "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
         "dependencies": {}
       },
-      "known-css-properties@0.29.0": {
-        "integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==",
+      "known-css-properties@0.31.0": {
+        "integrity": "sha512-sBPIUGTNF0czz0mwGGUoKKJC8Q7On1GPbCSFPfyEsfHb2DyBG0Y4QtV+EVWpINSaiGKZblDNuF5AezxSgOhesQ==",
         "dependencies": {}
       },
       "less@4.2.0": {
@@ -899,7 +772,7 @@
           "needle": "needle@3.3.1",
           "parse-node-version": "parse-node-version@1.0.1",
           "source-map": "source-map@0.6.1",
-          "tslib": "tslib@2.6.2"
+          "tslib": "tslib@2.6.3"
         }
       },
       "lines-and-columns@1.2.4": {
@@ -912,10 +785,6 @@
       },
       "lodash@4.17.21": {
         "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-        "dependencies": {}
-      },
-      "lru-cache@10.2.0": {
-        "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
         "dependencies": {}
       },
       "lru-queue@0.1.0": {
@@ -935,25 +804,21 @@
         "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
         "dependencies": {}
       },
-      "mdn-data@2.0.28": {
-        "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-        "dependencies": {}
-      },
       "mdn-data@2.0.30": {
         "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
         "dependencies": {}
       },
-      "memoizee@0.4.15": {
-        "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "memoizee@0.4.17": {
+        "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
         "dependencies": {
-          "d": "d@1.0.1",
+          "d": "d@1.0.2",
           "es5-ext": "es5-ext@0.10.64",
           "es6-weak-map": "es6-weak-map@2.0.3",
           "event-emitter": "event-emitter@0.3.5",
           "is-promise": "is-promise@2.2.2",
           "lru-queue": "lru-queue@0.1.0",
           "next-tick": "next-tick@1.1.0",
-          "timers-ext": "timers-ext@0.1.7"
+          "timers-ext": "timers-ext@0.1.8"
         }
       },
       "meow@13.2.0": {
@@ -964,10 +829,10 @@
         "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
         "dependencies": {}
       },
-      "micromatch@4.0.5": {
-        "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "micromatch@4.0.7": {
+        "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
         "dependencies": {
-          "braces": "braces@3.0.2",
+          "braces": "braces@3.0.3",
           "picomatch": "picomatch@2.3.1"
         }
       },
@@ -981,18 +846,8 @@
           "brace-expansion": "brace-expansion@1.1.11"
         }
       },
-      "minimatch@9.0.3": {
-        "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-        "dependencies": {
-          "brace-expansion": "brace-expansion@2.0.1"
-        }
-      },
       "minimist@1.2.8": {
         "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-        "dependencies": {}
-      },
-      "minipass@7.0.4": {
-        "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
         "dependencies": {}
       },
       "mkdirp@1.0.4": {
@@ -1019,7 +874,7 @@
         "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
         "dependencies": {
           "iconv-lite": "iconv-lite@0.6.3",
-          "sax": "sax@1.3.0"
+          "sax": "sax@1.4.1"
         }
       },
       "neo-async@2.6.2": {
@@ -1033,12 +888,6 @@
       "normalize-path@3.0.0": {
         "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
         "dependencies": {}
-      },
-      "nth-check@2.1.1": {
-        "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-        "dependencies": {
-          "boolbase": "boolbase@1.0.0"
-        }
       },
       "object-assign@4.1.1": {
         "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
@@ -1059,7 +908,7 @@
       "parse-json@5.2.0": {
         "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
         "dependencies": {
-          "@babel/code-frame": "@babel/code-frame@7.23.5",
+          "@babel/code-frame": "@babel/code-frame@7.24.7",
           "error-ex": "error-ex@1.3.2",
           "json-parse-even-better-errors": "json-parse-even-better-errors@2.3.1",
           "lines-and-columns": "lines-and-columns@1.2.4"
@@ -1073,23 +922,12 @@
         "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
         "dependencies": {}
       },
-      "path-key@3.1.1": {
-        "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-        "dependencies": {}
-      },
-      "path-scurry@1.10.1": {
-        "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
-        "dependencies": {
-          "lru-cache": "lru-cache@10.2.0",
-          "minipass": "minipass@7.0.4"
-        }
-      },
       "path-type@4.0.0": {
         "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
         "dependencies": {}
       },
-      "picocolors@1.0.0": {
-        "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "picocolors@1.0.1": {
+        "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
         "dependencies": {}
       },
       "picomatch@2.3.1": {
@@ -1100,24 +938,24 @@
         "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
         "dependencies": {}
       },
-      "postcss-less@6.0.0_postcss@8.4.35": {
+      "postcss-less@6.0.0_postcss@8.4.38": {
         "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
         "dependencies": {
-          "postcss": "postcss@8.4.35"
+          "postcss": "postcss@8.4.38"
         }
       },
       "postcss-resolve-nested-selector@0.1.1": {
         "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
         "dependencies": {}
       },
-      "postcss-safe-parser@7.0.0_postcss@8.4.35": {
+      "postcss-safe-parser@7.0.0_postcss@8.4.38": {
         "integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
         "dependencies": {
-          "postcss": "postcss@8.4.35"
+          "postcss": "postcss@8.4.38"
         }
       },
-      "postcss-selector-parser@6.0.15": {
-        "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+      "postcss-selector-parser@6.1.0": {
+        "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
         "dependencies": {
           "cssesc": "cssesc@3.0.0",
           "util-deprecate": "util-deprecate@1.0.2"
@@ -1127,12 +965,12 @@
         "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
         "dependencies": {}
       },
-      "postcss@8.4.35": {
-        "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "postcss@8.4.38": {
+        "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
         "dependencies": {
           "nanoid": "nanoid@3.3.7",
-          "picocolors": "picocolors@1.0.0",
-          "source-map-js": "source-map-js@1.0.2"
+          "picocolors": "picocolors@1.0.1",
+          "source-map-js": "source-map-js@1.2.0"
         }
       },
       "prettier@2.8.8": {
@@ -1171,12 +1009,6 @@
         "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
         "dependencies": {}
       },
-      "rimraf@5.0.5": {
-        "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
-        "dependencies": {
-          "glob": "glob@10.3.10"
-        }
-      },
       "run-parallel@1.2.0": {
         "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
         "dependencies": {
@@ -1187,22 +1019,12 @@
         "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
         "dependencies": {}
       },
-      "sax@1.3.0": {
-        "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "sax@1.4.1": {
+        "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
         "dependencies": {}
       },
       "semver@5.7.2": {
         "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-        "dependencies": {}
-      },
-      "shebang-command@2.0.0": {
-        "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-        "dependencies": {
-          "shebang-regex": "shebang-regex@3.0.0"
-        }
-      },
-      "shebang-regex@3.0.0": {
-        "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
         "dependencies": {}
       },
       "signal-exit@4.1.0": {
@@ -1221,8 +1043,8 @@
           "is-fullwidth-code-point": "is-fullwidth-code-point@3.0.0"
         }
       },
-      "source-map-js@1.0.2": {
-        "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "source-map-js@1.2.0": {
+        "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
         "dependencies": {}
       },
       "source-map@0.6.1": {
@@ -1237,14 +1059,6 @@
           "strip-ansi": "strip-ansi@6.0.1"
         }
       },
-      "string-width@5.1.2": {
-        "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-        "dependencies": {
-          "eastasianwidth": "eastasianwidth@0.2.0",
-          "emoji-regex": "emoji-regex@9.2.2",
-          "strip-ansi": "strip-ansi@7.1.0"
-        }
-      },
       "strip-ansi@6.0.1": {
         "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
         "dependencies": {
@@ -1257,35 +1071,36 @@
           "ansi-regex": "ansi-regex@6.0.1"
         }
       },
-      "stylelint-config-recommended@14.0.0_stylelint@16.2.1__@csstools+css-tokenizer@2.2.3__@csstools+css-parser-algorithms@2.6.0___@csstools+css-tokenizer@2.2.3__postcss-selector-parser@6.0.15__postcss@8.4.35": {
+      "stylelint-config-recommended@14.0.0_stylelint@16.6.1__@csstools+css-tokenizer@2.3.1__@csstools+css-parser-algorithms@2.6.3___@csstools+css-tokenizer@2.3.1__postcss-selector-parser@6.1.0__postcss@8.4.38": {
         "integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
         "dependencies": {
-          "stylelint": "stylelint@16.2.1_@csstools+css-tokenizer@2.2.3_@csstools+css-parser-algorithms@2.6.0__@csstools+css-tokenizer@2.2.3_postcss-selector-parser@6.0.15_postcss@8.4.35"
+          "stylelint": "stylelint@16.6.1_@csstools+css-tokenizer@2.3.1_@csstools+css-parser-algorithms@2.6.3__@csstools+css-tokenizer@2.3.1_postcss-selector-parser@6.1.0_postcss@8.4.38"
         }
       },
-      "stylelint-config-standard@36.0.0_stylelint@16.2.1__@csstools+css-tokenizer@2.2.3__@csstools+css-parser-algorithms@2.6.0___@csstools+css-tokenizer@2.2.3__postcss-selector-parser@6.0.15__postcss@8.4.35": {
+      "stylelint-config-standard@36.0.0_stylelint@16.6.1__@csstools+css-tokenizer@2.3.1__@csstools+css-parser-algorithms@2.6.3___@csstools+css-tokenizer@2.3.1__postcss-selector-parser@6.1.0__postcss@8.4.38": {
         "integrity": "sha512-3Kjyq4d62bYFp/Aq8PMKDwlgUyPU4nacXsjDLWJdNPRUgpuxALu1KnlAHIj36cdtxViVhXexZij65yM0uNIHug==",
         "dependencies": {
-          "stylelint": "stylelint@16.2.1_@csstools+css-tokenizer@2.2.3_@csstools+css-parser-algorithms@2.6.0__@csstools+css-tokenizer@2.2.3_postcss-selector-parser@6.0.15_postcss@8.4.35",
-          "stylelint-config-recommended": "stylelint-config-recommended@14.0.0_stylelint@16.2.1__@csstools+css-tokenizer@2.2.3__@csstools+css-parser-algorithms@2.6.0___@csstools+css-tokenizer@2.2.3__postcss-selector-parser@6.0.15__postcss@8.4.35"
+          "stylelint": "stylelint@16.6.1_@csstools+css-tokenizer@2.3.1_@csstools+css-parser-algorithms@2.6.3__@csstools+css-tokenizer@2.3.1_postcss-selector-parser@6.1.0_postcss@8.4.38",
+          "stylelint-config-recommended": "stylelint-config-recommended@14.0.0_stylelint@16.6.1__@csstools+css-tokenizer@2.3.1__@csstools+css-parser-algorithms@2.6.3___@csstools+css-tokenizer@2.3.1__postcss-selector-parser@6.1.0__postcss@8.4.38"
         }
       },
-      "stylelint@16.2.1_@csstools+css-tokenizer@2.2.3_@csstools+css-parser-algorithms@2.6.0__@csstools+css-tokenizer@2.2.3_postcss-selector-parser@6.0.15_postcss@8.4.35": {
-        "integrity": "sha512-SfIMGFK+4n7XVAyv50CpVfcGYWG4v41y6xG7PqOgQSY8M/PgdK0SQbjWFblxjJZlN9jNq879mB4BCZHJRIJ1hA==",
+      "stylelint@16.6.1_@csstools+css-tokenizer@2.3.1_@csstools+css-parser-algorithms@2.6.3__@csstools+css-tokenizer@2.3.1_postcss-selector-parser@6.1.0_postcss@8.4.38": {
+        "integrity": "sha512-yNgz2PqWLkhH2hw6X9AweV9YvoafbAD5ZsFdKN9BvSDVwGvPh+AUIrn7lYwy1S7IHmtFin75LLfX1m0D2tHu8Q==",
         "dependencies": {
-          "@csstools/css-parser-algorithms": "@csstools/css-parser-algorithms@2.6.0_@csstools+css-tokenizer@2.2.3",
-          "@csstools/css-tokenizer": "@csstools/css-tokenizer@2.2.3",
-          "@csstools/media-query-list-parser": "@csstools/media-query-list-parser@2.1.8_@csstools+css-parser-algorithms@2.6.0__@csstools+css-tokenizer@2.2.3_@csstools+css-tokenizer@2.2.3",
-          "@csstools/selector-specificity": "@csstools/selector-specificity@3.0.2_postcss-selector-parser@6.0.15",
+          "@csstools/css-parser-algorithms": "@csstools/css-parser-algorithms@2.6.3_@csstools+css-tokenizer@2.3.1",
+          "@csstools/css-tokenizer": "@csstools/css-tokenizer@2.3.1",
+          "@csstools/media-query-list-parser": "@csstools/media-query-list-parser@2.1.11_@csstools+css-parser-algorithms@2.6.3__@csstools+css-tokenizer@2.3.1_@csstools+css-tokenizer@2.3.1",
+          "@csstools/selector-specificity": "@csstools/selector-specificity@3.1.1_postcss-selector-parser@6.1.0",
+          "@dual-bundle/import-meta-resolve": "@dual-bundle/import-meta-resolve@4.1.0",
           "balanced-match": "balanced-match@2.0.0",
           "colord": "colord@2.9.3",
           "cosmiconfig": "cosmiconfig@9.0.0",
-          "css-functions-list": "css-functions-list@3.2.1",
+          "css-functions-list": "css-functions-list@3.2.2",
           "css-tree": "css-tree@2.3.1",
-          "debug": "debug@4.3.4",
+          "debug": "debug@4.3.5",
           "fast-glob": "fast-glob@3.3.2",
           "fastest-levenshtein": "fastest-levenshtein@1.0.16",
-          "file-entry-cache": "file-entry-cache@8.0.0",
+          "file-entry-cache": "file-entry-cache@9.0.0",
           "global-modules": "global-modules@2.0.0",
           "globby": "globby@11.1.0",
           "globjoin": "globjoin@0.1.4",
@@ -1293,23 +1108,23 @@
           "ignore": "ignore@5.3.1",
           "imurmurhash": "imurmurhash@0.1.4",
           "is-plain-object": "is-plain-object@5.0.0",
-          "known-css-properties": "known-css-properties@0.29.0",
+          "known-css-properties": "known-css-properties@0.31.0",
           "mathml-tag-names": "mathml-tag-names@2.1.3",
           "meow": "meow@13.2.0",
-          "micromatch": "micromatch@4.0.5",
+          "micromatch": "micromatch@4.0.7",
           "normalize-path": "normalize-path@3.0.0",
-          "picocolors": "picocolors@1.0.0",
-          "postcss": "postcss@8.4.35",
+          "picocolors": "picocolors@1.0.1",
+          "postcss": "postcss@8.4.38",
           "postcss-resolve-nested-selector": "postcss-resolve-nested-selector@0.1.1",
-          "postcss-safe-parser": "postcss-safe-parser@7.0.0_postcss@8.4.35",
-          "postcss-selector-parser": "postcss-selector-parser@6.0.15",
+          "postcss-safe-parser": "postcss-safe-parser@7.0.0_postcss@8.4.38",
+          "postcss-selector-parser": "postcss-selector-parser@6.1.0",
           "postcss-value-parser": "postcss-value-parser@4.2.0",
           "resolve-from": "resolve-from@5.0.0",
           "string-width": "string-width@4.2.3",
           "strip-ansi": "strip-ansi@7.1.0",
           "supports-hyperlinks": "supports-hyperlinks@3.0.0",
           "svg-tags": "svg-tags@1.0.0",
-          "table": "table@6.8.1",
+          "table": "table@6.8.2",
           "write-file-atomic": "write-file-atomic@5.0.1"
         }
       },
@@ -1336,20 +1151,8 @@
         "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
         "dependencies": {}
       },
-      "svgo@3.2.0": {
-        "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
-        "dependencies": {
-          "@trysound/sax": "@trysound/sax@0.2.0",
-          "commander": "commander@7.2.0",
-          "css-select": "css-select@5.1.0",
-          "css-tree": "css-tree@2.3.1",
-          "css-what": "css-what@6.1.0",
-          "csso": "csso@5.0.5",
-          "picocolors": "picocolors@1.0.0"
-        }
-      },
-      "table@6.8.1": {
-        "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "table@6.8.2": {
+        "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
         "dependencies": {
           "ajv": "ajv@8.12.0",
           "lodash.truncate": "lodash.truncate@4.4.2",
@@ -1370,8 +1173,8 @@
           "any-promise": "any-promise@1.3.0"
         }
       },
-      "timers-ext@0.1.7": {
-        "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "timers-ext@0.1.8": {
+        "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
         "dependencies": {
           "es5-ext": "es5-ext@0.10.64",
           "next-tick": "next-tick@1.1.0"
@@ -1383,8 +1186,8 @@
           "is-number": "is-number@7.0.0"
         }
       },
-      "tslib@2.6.2": {
-        "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "tslib@2.6.3": {
+        "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
         "dependencies": {}
       },
       "tunnel@0.0.6": {
@@ -1395,20 +1198,16 @@
         "integrity": "sha512-ShaaYnjf+0etG8W/FumARKMjjIToy/haCaTjN2dvcewOSoNqCQzdgG7m2JVOlM5qndGTHjkvsrWZs+k/2Z7E0Q==",
         "dependencies": {}
       },
-      "type@1.2.0": {
-        "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "type@2.7.3": {
+        "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
         "dependencies": {}
       },
-      "type@2.7.2": {
-        "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+      "uglify-js@3.18.0": {
+        "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
         "dependencies": {}
       },
-      "uglify-js@3.17.4": {
-        "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-        "dependencies": {}
-      },
-      "undici@5.28.3": {
-        "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "undici@5.28.4": {
+        "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
         "dependencies": {
           "@fastify/busboy": "@fastify/busboy@2.1.1"
         }
@@ -1441,31 +1240,9 @@
           "isexe": "isexe@2.0.0"
         }
       },
-      "which@2.0.2": {
-        "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-        "dependencies": {
-          "isexe": "isexe@2.0.0"
-        }
-      },
       "wordwrap@1.0.0": {
         "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
         "dependencies": {}
-      },
-      "wrap-ansi@7.0.0": {
-        "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-        "dependencies": {
-          "ansi-styles": "ansi-styles@4.3.0",
-          "string-width": "string-width@4.2.3",
-          "strip-ansi": "strip-ansi@6.0.1"
-        }
-      },
-      "wrap-ansi@8.1.0": {
-        "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-        "dependencies": {
-          "ansi-styles": "ansi-styles@6.2.1",
-          "string-width": "string-width@5.1.2",
-          "strip-ansi": "strip-ansi@7.1.0"
-        }
       },
       "wrappy@1.0.2": {
         "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
@@ -1641,11 +1418,6 @@
     "https://deno.land/std@0.206.0/yaml/schema/mod.ts": "4472e827bab5025e92bc2eb2eeefa70ecbefc64b2799b765c69af84822efef32",
     "https://deno.land/std@0.206.0/yaml/stringify.ts": "fffc09c65c68d3d63f8159e8cbaa3f489bc20a8e55b4fbb61a8c2e9f914d1d02",
     "https://deno.land/std@0.206.0/yaml/type.ts": "65553da3da3c029b6589c6e4903f0afbea6768be8fca61580711457151f2b30f",
-    "https://esm.sh/type-fest@4.8.1": "fabf6997a3adf11e45d11e3c4d58d0634ab98f9d72f3116f3694123818ccd457",
-    "https://esm.sh/v135/type-fest@4.8.1/denonext/source/simplify.d.js": "a3a0888441b04e1ab9ac5db803dc2bba5509a78f916ca78e583d26b47f429e5f",
-    "https://esm.sh/v135/type-fest@4.8.1/denonext/source/union-to-intersection.d.js": "4dda98575465ccb71439587d666e602980113bf8d01bb42067ca6ffeb4fae0e3",
-    "https://esm.sh/v135/type-fest@4.8.1/source/simplify.d": "7359c9f2ef1a0d33486b54d31afe5a266317a370d20fe6947f245f4dca9de376",
-    "https://esm.sh/v135/type-fest@4.8.1/source/union-to-intersection.d": "8a73c629d0507dd707e4cbaa3f745ffbd74b5073191ce522afc2ac0639f748cd",
     "https://raw.githubusercontent.com/catppuccin/catppuccin/d4f2666c2b04337f0a8632713de0889d9a7d332d/resources/ports.schema.json": "39ce3bcd2dabd033010684df7caa82cc69c25584174eba0922e6435dce53f06a",
     "https://raw.githubusercontent.com/catppuccin/palette/v0.2.0/palette-porcelain.json": "a13a97027e630bdac3a498696b9465f6f947ec6abc2acfee9084e9a951effe4b"
   },
@@ -1655,7 +1427,14 @@
       "npm:@octokit/rest@20.0.2",
       "npm:ajv@8.12.0",
       "npm:handlebars@4.7.8",
+      "npm:json-schema-to-typescript@13.1.2",
       "npm:less@4.2.0",
+      "npm:postcss-less@6.0.0",
+      "npm:postcss-value-parser@4.2.0",
+      "npm:stylelint-config-recommended@14.0.0",
+      "npm:stylelint-config-standard@36.0.0",
+      "npm:stylelint@16.6.1",
+      "npm:svgo@3.2.0",
       "npm:type-fest@4.8.1",
       "npm:usercss-meta@0.12.0"
     ]

--- a/scripts/lint/stylelint-custom/optimizedSvgs.js
+++ b/scripts/lint/stylelint-custom/optimizedSvgs.js
@@ -1,6 +1,6 @@
-import stylelint from "npm:stylelint";
-import valueParser from "npm:postcss-value-parser";
-import { optimize } from "npm:svgo";
+import stylelint from "stylelint";
+import valueParser from "postcss-value-parser";
+import { optimize } from "svgo";
 
 const {
   createPlugin,

--- a/scripts/lint/stylelint.ts
+++ b/scripts/lint/stylelint.ts
@@ -2,10 +2,10 @@ import * as color from "std/fmt/colors.ts";
 import type { WalkEntry } from "std/fs/walk.ts";
 import { relative } from "std/path/mod.ts";
 
-import "npm:postcss-less";
-import stylelint from "npm:stylelint";
-import "npm:stylelint-config-standard";
-import "npm:stylelint-config-recommended";
+import "postcss-less";
+import stylelint from "stylelint";
+import "stylelint-config-standard";
+import "stylelint-config-recommended";
 
 import { REPO_ROOT } from "@/deps.ts";
 import { log } from "@/lint/logger.ts";

--- a/scripts/types/mod.ts
+++ b/scripts/types/mod.ts
@@ -1,7 +1,7 @@
 export * as UserStylesSchema from "@/types/userstyles.d.ts";
 export * as PortsSchema from "catppuccin-repo/resources/types/ports.d.ts";
 
-import { Entries } from "https://esm.sh/type-fest@4.8.1";
+import { Entries } from "type-fest";
 declare global {
   interface ObjectConstructor {
     entries<T extends object>(o: T): Entries<T>;

--- a/scripts/update-types.ts
+++ b/scripts/update-types.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run -A
 // deno-lint-ignore-file no-explicit-any
 import { join } from "std/path/mod.ts";
-import { compile, Options } from "npm:json-schema-to-typescript";
+import { compile, Options } from "json-schema-to-typescript";
 import { REPO_ROOT, userStylesSchema } from "@/deps.ts";
 
 const options = {

--- a/styles/ichi.moe/catppuccin.user.css
+++ b/styles/ichi.moe/catppuccin.user.css
@@ -299,7 +299,7 @@
     }
 
     .f-dropdown::before {
-      border-color: transparent transparent @subtext1 transparent;
+      border-color: transparent transparent @subtext1;
     }
 
     span.query-pick {


### PR DESCRIPTION
Converts any and all direct `npm:` imports to plain imports and stores the alias in the deno.json for clarity. I then regenerated the lockfile, and ran all scripts to make sure all dependencies were added.