### PR TITLE
fix(instagram): direct message fixes

### DIFF
--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.2.4
+@version 0.2.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -763,14 +763,20 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
+    .x11jlvup {
+    --chat-outgoing-message-bubble-background-color: @blue;}
+    .x1n2onr6 {
+    --chat-incoming-message-bubble-background-color: @surface0;}
+
     /* Chat background */
     .xnz67gz {
       background-color: @base;
     }
-    [style*="background-color: rgb(55, 151, 240);"] {
-      background-color: @blue !important;
-      color: @mantle !important;
+    /* messages you've sent */
+    .xyk4ms5 {
+      color: @crust !important;
     }
+/* sidebar */
     .xvbhtw8 {
       background-color: @mantle;
     }
@@ -778,11 +784,6 @@
     .xk50ysn,
     .xi81zsa {
       color: @subtext0 !important;
-    }
-    ._aa5c,
-    ._aa4j,
-    ._abyk {
-      background-color: @crust;
     }
 
     /* New Chat Button */
@@ -795,6 +796,20 @@
       background-color: @surface0;
       color: @text;
     }
+
+    /* notes */
+    .xsnw5ke, .x3zg9eu::after {
+      background-color: @surface0;
+    }
+    .x103n6ev, .xzxgvzf {
+      background-image: linear-gradient(-90deg,fade(@surface0, 30%), fade(@surface0, 100%))
+    }
+
+    /* explicit music icon in notes */
+    .x1cp0k07 {
+      color: @text;
+    }
+
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
themes the new notes feature instagram added as well as fix the direct messages not being themed properly
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
