### PR TITLE
fix(codeberg): inline code block

### DIFF
--- a/styles/codeberg/catppuccin.user.css
+++ b/styles/codeberg/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Codeberg Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/codeberg
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/codeberg
-@version 1.1.2
+@version 1.1.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/codeberg/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acodeberg
 @description Soothing pastel theme for Codeberg
@@ -77,6 +77,10 @@
         border-color: var(--color-light-border);
         color: @crust;
       }
+    }
+
+    .inline-code-block {
+      color: var(--color-label-text);
     }
 
     #codeberg-logo (@color) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

| Before | After |
| --- | --- |
| ![image](https://github.com/catppuccin/userstyles/assets/47499684/a7b8ec8b-3bab-48bd-a463-b4f74886ce47) | ![image](https://github.com/catppuccin/userstyles/assets/47499684/13062853-c088-48a8-8398-08701b994008) |


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
