### PR TITLE
fix(youtube): improve button styling

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.1.0
+@version 4.1.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -601,8 +601,8 @@
         border-color: @surface2;
 
         &:hover {
-          background-color: @accent-color;
-          color: @crust;
+          background-color: fade(@accent-color, 30%);
+          color: @accent-color;
         }
       }
 
@@ -617,6 +617,10 @@
       &.yt-spec-button-shape-next--filled {
         color: @crust;
         background-color: @accent-color;
+          
+          &:hover {
+              background-color: lighten(@accent-color, 5%);
+          }
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Makes buttons like the two here look better by adding a different background on hover and matching the hover background of the outline button more closely to YouTube's own styling:

![image](https://github.com/catppuccin/userstyles/assets/47499684/c38411b6-817b-4830-8f19-bcb2f10fbccd)

![image](https://github.com/catppuccin/userstyles/assets/47499684/7f17e715-5515-491e-ad45-9f9801a62be5)
![image](https://github.com/catppuccin/userstyles/assets/47499684/dc2d5025-10b3-4bc2-86f3-08696aa72bde)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
