### PR TITLE
chore(maintainers): remove `haiksgithub`

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -94,9 +94,6 @@ collaborators:
   - &BlankParticle
     name: BlankParticle
     url: https://github.com/BlankParticle
-  - &haiksgithub
-    name: haiksgithub
-    url: https://github.com/haiksgithub
   - &genshibe
     name: GenShibe
     url: https://github.com/GenShibe
@@ -458,7 +455,7 @@ userstyles:
     readme:
       app-link: "https://instagram.com"
     current-maintainers: [*genshibe]
-    past-maintainers: [*haiksgithub, *isabelroses]
+    past-maintainers: [*isabelroses]
   invidious:
     name: Invidious
     categories: [entertainment, social_networking]


### PR DESCRIPTION
User has deleted their GitHub account.

Initially, I thought about keeping the name
but linking to @ghost for the URL but that
feels a bit odd.

Going forward, we should just remove accounts
that have been deleted and are rendered on GitHub
as @ghost.
