### PR TITLE
fix(lemmy): use `@text` for body text

### DIFF
--- a/styles/lemmy/catppuccin.user.css
+++ b/styles/lemmy/catppuccin.user.css
@@ -119,7 +119,7 @@
     }
 
     body {
-      color: @accent-color;
+      color: @text;
       background-color: @base;
     }
 

--- a/styles/lemmy/catppuccin.user.css
+++ b/styles/lemmy/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Lemmy Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/lemmy
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/lemmy
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/lemmy/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Alemmy
 @description Soothing pastel theme for Lemmy


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
Latte theme with pink (or similarly light) accent choices resulted in illegible body text, such as comments.
This fixes the issue by setting body text to `@text` color instead of @accent-color.

**(before) Latte Pink with `@accent-colored` text as prior:**
<img width="449" alt="image" src="https://github.com/catppuccin/userstyles/assets/12573044/17d5453a-e3e1-4364-a499-d9039c2201fb">

**(after) Resolved with `@text` colored text:**
<img width="551" alt="image" src="https://github.com/catppuccin/userstyles/assets/12573044/e7d3c21b-e0b8-4945-9912-4afcaa778ddb">

**NB:** `@accent-color` is still used across the theme elsewhere.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
