### PR TITLE
fix(go.dev): adjust dark/light application selectors

### DIFF
--- a/styles/go.dev/catppuccin.user.css
+++ b/styles/go.dev/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name go.dev Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/go.dev
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/go.dev
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/go.dev/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ago.dev
 @description Soothing pastel theme for go.dev
@@ -17,12 +17,14 @@
 
 @-moz-document domain('go.dev') {
   @media (prefers-color-scheme: light) {
-    :root[data-theme="auto"] {
+    :root[data-theme="auto"],
+    :root:not([data-theme]) {
       #catppuccin(@lightFlavor, @accentColor);
     }
   }
   @media (prefers-color-scheme: dark) {
-    :root[data-theme="auto"] {
+    :root[data-theme="auto"],
+    :root:not([data-theme]) {
       #catppuccin(@darkFlavor, @accentColor);
     }
   }
@@ -377,12 +379,14 @@
 
 @-moz-document domain('pkg.go.dev') {
   @media (prefers-color-scheme: light) {
-    :root[data-theme="auto"] {
+    :root[data-theme="auto"],
+    :root:not([data-theme]) {
       #catppuccin(@lightFlavor, @accentColor);
     }
   }
   @media (prefers-color-scheme: dark) {
-    :root[data-theme="auto"] {
+    :root[data-theme="auto"],
+    :root:not([data-theme]) {
       #catppuccin(@darkFlavor, @accentColor);
     }
   }
@@ -689,12 +693,14 @@
 @-moz-document url-prefix("https://go.dev/tour")
 {
   @media (prefers-color-scheme: light) {
-    :root[data-theme="auto"] {
+    :root[data-theme="auto"],
+    :root:not([data-theme]) {
       #catppuccin(@lightFlavor, @accentColor);
     }
   }
   @media (prefers-color-scheme: dark) {
-    :root[data-theme="auto"] {
+    :root[data-theme="auto"],
+    :root:not([data-theme]) {
       #catppuccin(@darkFlavor, @accentColor);
     }
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Sometimes the `data-theme` attribute doesn't exist, like if it is your first time visiting the website. This adjusts the theme application selectors to use `prefers-color-scheme` if there is no attribute set, as if `data-theme="auto"`.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
