### PR TITLE
chore(arch-wiki): move @GenShibe to `past-maintainers`

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -161,7 +161,8 @@ userstyles:
     readme:
       app-link: "https://wiki.archlinux.org/"
       usage: "Make sure to use the default **Light** theme"
-    current-maintainers: [*genshibe]
+    current-maintainers: []
+    past-maintainers: [*genshibe]
   boringproxy:
     name: boringproxy
     categories: [development]


### PR DESCRIPTION
i don't use arch anymore and i don't see myself maintaining this style so yeah
