### PR TITLE
fix(arch-wiki):header and buttons

### DIFF
--- a/styles/arch-wiki/catppuccin.user.css
+++ b/styles/arch-wiki/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Arch Wiki Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/arch-wiki
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/arch-wiki
-@version 0.0.6
+@version 0.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/arch-wiki/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aarch-wiki
 @description Soothing pastel theme for Arch Wiki
@@ -175,7 +175,9 @@
 
     .vector-pinnable-header-toggle-button,
     .vector-pinnable-header-unpin-button {
-      color: @blue;
+      color: @mantle;
+      background-color: @accent-color;
+      border-color: @base;
     }
 
     .wikitable {
@@ -379,6 +381,11 @@
 
     .vector-tab-noicon mw-list-item a {
       color: @blue;
+    }
+
+    .mw-header {
+      background-color: @base !important;
+      color: @text;
     }
 
     .mw-footer li a {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fix for [this issue](https://github.com/catppuccin/userstyles/issues/1040)
A header and some buttons are white and too bright, so I changed some colors.
I also checked other flavors than mocha and they look fine after this fix.
### before
![image](https://github.com/catppuccin/userstyles/assets/112705243/be6e8c5e-a001-4580-b1bb-89dcdf7b1a56)
![image](https://github.com/catppuccin/userstyles/assets/112705243/998d42e0-819c-429f-8785-7388f4328594)

### after
![image](https://github.com/catppuccin/userstyles/assets/112705243/3af2b032-8195-46fe-9c43-379b546ee862)
![image](https://github.com/catppuccin/userstyles/assets/112705243/3cc5aac9-49fd-45f6-99dc-d7c776613f31)

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
