### PR TITLE
fix(google-gemini): misc

### DIFF
--- a/styles/google-gemini/catppuccin.user.css
+++ b/styles/google-gemini/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Gemini Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google-gemini
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-gemini
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-gemini/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-gemini
 @description Soothing pastel theme for Google Gemini
@@ -98,6 +98,7 @@
     --bard-color-primary: @accent-color;
     --bard-color-primary-background: @base;
     --bard-color-primary-opacity-08: fade(@accent-color, 8%);
+    --bard-color-neutral-90: @mantle;
     --bard-color-outline: @overlay2;
     --bard-color-on-primary: darken(@accent-color, 10%);
     --bard-color-on-primary-container: @text;
@@ -172,6 +173,11 @@
     --bard-color-factuality-form-background: @mantle;
     --bard-color-fact-check-button-complete: @surface0;
     --bard-color-fact-check-button-loading: @surface1;
+    --bard-color-tunable-selection-menu-text: @text;
+    --bard-color-tunable-selection-menu-background: @mantle;
+    --bard-color-tunable-selection-textarea-background: @base;
+    --bard-color-tunable-selection-shimmer-non-advanced: @accent-color;
+    --bard-color-action-tooltip-background: darken(@accent-color, 20%);
 
     --mdc-switch-selected-hover-handle-color: lighten(@accent-color, 10%);
     --mdc-switch-selected-focus-handle-color: lighten(@accent-color, 10%);
@@ -210,12 +216,15 @@
     --mat-menu-container-color: @base;
     --mat-menu-item-icon-color: @text;
     --mat-filled-button-state-layer-color: @overlay2;
+    --mat-fab-small-hover-state-layer-opacity: 1;
 
     --gm-outlinedtextfield-outline-color: @subtext0;
     --gm-outlinedtextfield-outline-color--stateful: @accent-color;
     --gm-outlinedtextfield-ink-color: @text;
     --gm3-sys-color-on-secondary-container: @crust;
     --gm3-sys-color-secondary-container: @text;
+
+    --gem-sys-color--surface: @base;
 
     --og-theme-color: @text;
 
@@ -307,6 +316,15 @@
       --mdc-fab-container-color: @accent-color;
       --mat-fab-foreground-color: @crust;
     }
+    .gmat-mdc-button.mat-mdc-mini-fab:not(
+        .mat-mdc-button-disabled
+      ).mat-primary.gmat-mdc-fab-outline {
+      --mat-fab-small-state-layer-color: @surface0;
+    }
+    .mat-mdc-fab:not(.mdc-riple-upgraded):focus::before,
+    .mat-mdc-mini-fab:not(.mdc-riple-upgraded):focus::before {
+      background: @surface2;
+    }
     .mat-mdc-menu-panel {
       background-color: @base !important;
     }
@@ -318,6 +336,9 @@
     }
     .banner-close-button {
       --mat-icon-color: @crust;
+    }
+    & when (@lookup = latte) {
+      --bard-color-action-tooltip-background: lighten(@accent-color, 30%);
     }
     [data-mat-icon-name="search"] svg {
       > path:nth-child(1) {

--- a/styles/google-gemini/catppuccin.user.css
+++ b/styles/google-gemini/catppuccin.user.css
@@ -200,6 +200,9 @@
     --mdc-list-list-item-hover-label-text-color: @text;
     --mdc-filled-button-label-text-color: @text;
     --mdc-circular-progress-active-indicator-color: @accent-color;
+    --mdc-outlined-button-focus-outline-color: @text;
+    --mdc-outlined-button-hover-label-text-color: @subtext1;
+    --mdc-list-list-item-focus-label-text-color: @text;
 
     --mat-app-text-color: @text;
     --mat-text-button-state-layer-color: @overlay2;
@@ -217,6 +220,7 @@
     --mat-menu-item-icon-color: @text;
     --mat-filled-button-state-layer-color: @overlay2;
     --mat-fab-small-hover-state-layer-opacity: 1;
+    --mat-divider-color: @surface0;
 
     --gm-outlinedtextfield-outline-color: @subtext0;
     --gm-outlinedtextfield-outline-color--stateful: @accent-color;
@@ -254,6 +258,25 @@
       & .mdc-notched-outline__trailing {
         border-color: @text !important;
       }
+    }
+    .gmat-mdc-dialog .mat-mdc-dialog-container {
+      .mdc-dialog__content {
+        color: @subtext0;
+      }
+      .mdc-dialog__title {
+        color: @text;
+      }
+    }
+    .gmat-mdc-button.mat-mdc-outlined-button.mat-unthemed {
+      --mdc-outlined-button-outline-color: @overlay0;
+      --mdc-outlined-button-label-text-color: @subtext0;
+    }
+    .gmat-mdc-button.mat-mdc-outlined-button {
+      --mat-outlined-button-state-layer-color: @overlay2;
+    }
+    .gmat-mdc-button.mat-mdc-outlined-button:not(.mat-mdc-button-disabled, [disabled], :disabled).mdc-ripple-upgraded--background-focused,
+    .gmat-mdc-button.mat-mdc-outlined-button:not(.mat-mdc-button-disabled, [disabled], :disabled, .mdc-ripple-upgraded):focus {
+      color: @text;
     }
     .gmat-mdc-chip {
       --mdc-chip-label-text-color: @subtext0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Gemini updated and header color broke, this pr fixes it.
and also other fixes.
 - Header
 - Mini fab hover/focus
 - Action tooltip
 - Tunable menu
 - Recitation button
 - Buttons focus text color
 - Outline button
 - Divider color
 - Dialog container

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
