### PR TITLE
fix(pinterest): misc

### DIFF
--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -190,6 +190,11 @@
       }
     }
 
+    // Pin hover icons (and other icons)
+    .Uvi.gUZ.U9O.kVc {
+      color: @text;
+    }
+
     /* Header & Search */
 
     div[data-test-id="header-Header"] div.P_h span.xnr {
@@ -354,7 +359,7 @@
 
     // "Saved to __" popup text
     .tBJ.dyH.iFc.j1A.X8m.zDA.swG {
-      color: @text !important;
+      color: var(--color-text-light) !important;
     }
 
     /* Pin page */
@@ -455,11 +460,6 @@
 
     div[data-test-id="savedInfo"] a h3 {
       color: var(--color-text-light) !important;
-    }
-
-    // Profile icons
-    .Uvi.gUZ.U9O.kVc {
-      color: @text;
     }
 
     a[aria-label="More ideas"] {

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -180,10 +180,10 @@
       background-color: @base !important;
     }
 
-    // profile popup
+    // "Accounts and more options" popup
     div#HeaderAccountOptionsFlyout {
       background-color: @mantle;
-      border: none;
+      border-color: transparent;
       // external link icons
       .Hn_.Uvi.gUZ {
         color: var(--color-text-icon-light);
@@ -346,7 +346,7 @@
     // Saved button background
     .akY.KI_.Hsu.USg.CCY.S9z.z_v.BG7.LDc.xD4.fZz.hUC.kJo.gSJ.d24._O1.KS5.mQ8.Tbt.L4E.jKZ {
       background-color: @surface2 !important;
-      border: none
+      border-color: transparent;
     }
 
     // board picker flyout button

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Pinterest Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pinterest
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pinterest
-@version 1.1.3
+@version 1.1.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pinterest/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apinterest
 @description Soothing pastel theme for Pinterest
@@ -180,10 +180,25 @@
       background-color: @base !important;
     }
 
+    // profile popup
+    div#HeaderAccountOptionsFlyout {
+      background-color: @mantle;
+      border: none;
+      // external link icons
+      .Hn_.Uvi.gUZ {
+        color: var(--color-text-icon-light);
+      }
+    }
+
     /* Header & Search */
 
     div[data-test-id="header-Header"] div.P_h span.xnr {
       color: @text !important;
+    }
+
+    // make top bar match
+    div[data-test-id="header-background"] {
+      background-color: @base;
     }
 
     div[data-test-id="one-bar-pill"] {
@@ -201,8 +216,9 @@
     }
 
     div#searchBoxContainer {
-      div[style="height: 48px; background-color: rgb(225, 225, 225);"] {
-        background-color: darken(@mantle, 2.5%) !important;
+      // search bar
+      div.Jea.fev.zI7.iyn.Hsu {
+        background-color: @mantle !important;
       }
 
       div[style="padding: 0px 0px 0px 16px; height: 100%; border-radius: 24px; box-shadow: rgba(0, 132, 255, 0.5) 0px 0px 0px 4px;"],
@@ -219,6 +235,13 @@
       }
     }
 
+    // make selected search suggestions darker
+    div[aria-selected="true"][data-test-id="search-suggestion"] {
+      .C9q.Jea.KS5.Lfz.TMJ.XiG.Zr3.zI7.iyn.Hsu {
+        background-color: @surface0
+      }
+    }
+
     /* Home */
 
     div.moreIdeasBoardRepCarousel
@@ -230,6 +253,22 @@
     div.moreIdeasBoardRepCarousel & ~ div.MIw.QLY.zI7.iyn.Hsu {
       background: none !important;
     }
+
+    // Home page icons
+    .Uvi.gUZ.U9O.kVc {
+      color: var(--color-text-icon-light);
+    }
+
+    // remove bar
+    .fZz.imm.zI7.iyn.Hsu {
+      background-color: @base;
+    }
+
+    // "created" and "saved" button backgrounds
+    .DUt.XiG._wN.hA-.wYR.zI7.iyn.Hsu {
+      background-color: transparent !important;
+    }
+
 
     /* Pins */
 
@@ -283,6 +322,45 @@
       color: @mantle !important;
     }
 
+    .tBJ.dyH.iFc.sAJ.B1n.zDA.IZT.H2s.CKL {
+      color: @text !important;
+    }
+
+    // back of send and ... buttons on pins
+    .x8f.INd._O1.KS5.mQ8.NSs {
+      background-color: @crust !important;
+    }
+
+    // Save button background
+    .akY.KI_.Hsu.USg.CCY.S9z.z_v.BG7.LDc.xD4.fZz.hUC.adn.Rk4.d24._O1.KS5.mQ8.Tbt.L4E.jKZ {
+      background-color: @accent-color !important;
+      //color: @text !important;
+    }
+
+    // Save button text
+    .tBJ.dyH.iFc.sAJ.B1n.tg7.IZT.H2s {
+      color: var(--color-text-dark) !important;
+    }
+
+    // Saved button background
+    .akY.KI_.Hsu.USg.CCY.S9z.z_v.BG7.LDc.xD4.fZz.hUC.kJo.gSJ.d24._O1.KS5.mQ8.Tbt.L4E.jKZ {
+      background-color: @surface2 !important;
+      border: none
+    }
+
+    // board picker flyout button
+    button[aria-label="save button"] {
+      .RCK.Hsu.USg.adn.CCY.NTm.KhY.S9z.Vxj.aZc.Zr3.hA-.Il7.hNT.BG7.hDj._O1.KS5.mQ8.Tbt.L4E {
+        background-color: @accent-color;
+        color: @accent-color;
+      }
+    }
+
+    // "Saved to __" popup text
+    .tBJ.dyH.iFc.j1A.X8m.zDA.swG {
+      color: @text !important;
+    }
+
     /* Pin page */
 
     div[data-test-id="inline-comment-composer-container"] {
@@ -331,6 +409,20 @@
       background-color: transparent;
       color: @subtext1;
       caret-color: @text;
+    }
+
+    div[data-test-id="react-button"] {
+      .Jea.KS5.mQ8.zI7.iyn.Hsu {
+        //background-color: @accent-color;
+        color: @accent-color;
+      }
+    }
+
+    // remove "More to explore" bar
+    div[data-test-id="related-modules-header"] {
+      .Jea.KS5.LCN.X6t.hUC.imm.jzS.mQ8.zI7.iyn.Hsu {
+        background-color: transparent;
+      }
     }
 
     /* Video and story pins */
@@ -504,6 +596,11 @@
 
     div[role="tablist"] button[aria-selected="true"] {
       background-color: @crust !important;
+    }
+
+    input[type="text"],
+    input[type="search"] {
+      color: @text;
     }
 
     /* Login */

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -254,11 +254,6 @@
       background: none !important;
     }
 
-    // Home page icons
-    .Uvi.gUZ.U9O.kVc {
-      color: var(--color-text-icon-light);
-    }
-
     // remove bar
     .fZz.imm.zI7.iyn.Hsu {
       background-color: @base;
@@ -322,8 +317,9 @@
       color: @mantle !important;
     }
 
+    // board name to save to preview / dropdown
     .tBJ.dyH.iFc.sAJ.B1n.zDA.IZT.H2s.CKL {
-      color: @text !important;
+      color: var(--color-text-light) !important;
     }
 
     // back of send and ... buttons on pins
@@ -339,7 +335,7 @@
 
     // Save button text
     .tBJ.dyH.iFc.sAJ.B1n.tg7.IZT.H2s {
-      color: var(--color-text-dark) !important;
+      color: var(--color-text-light) !important;
     }
 
     // Saved button background
@@ -459,6 +455,23 @@
 
     div[data-test-id="savedInfo"] a h3 {
       color: var(--color-text-light) !important;
+    }
+
+    // Profile icons
+    .Uvi.gUZ.U9O.kVc {
+      color: @text;
+    }
+
+    a[aria-label="More ideas"] {
+      .TzN {
+        background-color: @surface0;
+      }
+    }
+
+    a[aria-label="Organize"] {
+      .TzN {
+        background-color: @surface0;
+      }
     }
 
     /* Settings */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes readability in dark mode themes, as well as other fixes:
- Search bar color
- Top bar color matches base
- Change save button from red to accent color
- "More ideas" and "Organize" hover states
- Hide background of "created" and "saved" buttons on profile
- Remove bar behind "created" and "saved" buttons on profile
- "Account and more options" popup looks better in dark mode
- other miscellaneous fixes

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
