### PR TITLE
fix(twitch): chat mention backgrounds

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -236,6 +236,7 @@
       --color-text-tooltip: @base !important;
       --color-background-tooltip: @text !important;
       --color-hinted-grey-2: @surface0;
+      --color-hinted-grey-15: @text;
       --color-background-overlay-alt: @mantle;
       --color-background-button-overlay-primary-hover: @subtext1;
       --color-background-button-overlay-text-hover: @crust;

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.3.0
+@version 1.3.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes mentions in chat, which through a roundabout set of vars ends up using this var.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
