### PR TITLE
fix(porkbun): success buttons

### DIFF
--- a/styles/porkbun/catppuccin.user.css
+++ b/styles/porkbun/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Porkbun Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/porkbun
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/porkbun
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/porkbun/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aporkbun
 @description Soothing pastel theme for Porkbun

--- a/styles/porkbun/catppuccin.user.css
+++ b/styles/porkbun/catppuccin.user.css
@@ -193,6 +193,17 @@
       color: @crust;
     }
 
+    .btn-success {
+      background-color: @green;
+      border-color: @green;
+      color: @crust;
+    }
+
+    .btn-success-light {
+      background-color: @green;
+      color: @crust;
+    }
+
     .btn-porkbun-white-borderless,
     .btn-porkbun-white:hover,
     .btn-porkbun-white:focus {
@@ -205,11 +216,6 @@
       .text-muted {
         color: @surface0;
       }
-    }
-
-    .btn-success-light {
-      background-color: @green;
-      color: @crust;
     }
 
     /* Inputs */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes these green success buttons and organizes the CSS a bit.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
