### PR TITLE
fix(google): unthemed background

### DIFF
--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -1946,6 +1946,9 @@
         background: @surface0 !important;
         color: @subtext0 !important;
       }
+      .CvDJxb {
+        background-color: @base !important;
+      }
       .aFCkf {
         background: @surface0 !important;
         color: @blue !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes a unthemed background on google

![image](https://github.com/catppuccin/userstyles/assets/147266582/5b5c277f-5da0-4de6-9383-7c461bea605d)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
