### PR TITLE
fix(stack-overflow): jobs page

### DIFF
--- a/styles/stack-overflow/catppuccin.user.css
+++ b/styles/stack-overflow/catppuccin.user.css
@@ -413,6 +413,11 @@ domain('superuser.com'), domain('mathoverflow.net'), domain('askubuntu.com'), do
       }
     }
 
+    .sunset-background {
+       background-color: @base !important;
+       color: @text !important;
+    }
+
     .disabled-link {
       color: @overlay2;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the unthemed jobs page

![image](https://github.com/catppuccin/userstyles/assets/147266582/e1ea29a7-6d26-409f-943c-4ebe88ee1176)

![image](https://github.com/catppuccin/userstyles/assets/147266582/43da773e-2764-4372-91c2-eb6c940d8b5b)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
