### PR TITLE
fix(lemmy): unthemed warning/info boxes

### DIFF
--- a/styles/lemmy/catppuccin.user.css
+++ b/styles/lemmy/catppuccin.user.css
@@ -239,6 +239,11 @@
       color: @text !important;
       background-color: rgba(#rgbify(@mantle) [], 1) !important;
     }
+    .alert-info, .alert-warning {
+      background-color: @mantle !important;
+      border-color: @mantle !important;
+      color: @text !important;
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/catppuccin/userstyles/assets/147266582/4acca4da-e928-4cb8-a420-97340cb9b9ae)
![image](https://github.com/catppuccin/userstyles/assets/147266582/9e38aa5e-71c2-48f0-9e9e-285e857200ae)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
