### PR TITLE
fix(chess.com): wrap variables in body selector

### DIFF
--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -20,7 +20,7 @@
     #catppuccin(@lightFlavor, @accentColor);
   }
 
-  .dark-mode {
+  .dark-mode body {
     #catppuccin(@darkFlavor, @accentColor);
   }
 
@@ -84,7 +84,7 @@
     @wq: #piece("w/wq") [];
     @wr: #piece("w/wr") [];
 
-    .dark-mode body {
+    body {
       --theme-background-color: @base !important;
       --globalBackground: @mantle !important;
       --globalBackgroundOpaque: @mantle !important;

--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -116,7 +116,7 @@
     --globalColorWin: @green !important;
     --globalColorDraw: @accent-color !important;
     --globalColorLoss: @red !important;
-  
+
     /* index page */
     .promo-title,
     .index-title {

--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -84,40 +84,39 @@
     @wq: #piece("w/wq") [];
     @wr: #piece("w/wr") [];
 
-    body {
-      --theme-background-color: @base !important;
-      --globalBackground: @mantle !important;
-      --globalBackgroundOpaque: @mantle !important;
-      --globalSecondaryBackground: @crust !important;
-      --globalTertiaryBackground: @surface0 !important;
-      --globalAccentBackground: @accent-color !important;
-      --globalSecondaryAccentBackground: darken(@accent-color, 20%) !important;
-      --globalSiteBackground: @base !important;
-      --subtleButtonBackground: hsla(0, 0%, 100%, 0.16);
-      --globalBorder: @surface0 !important;
-      --globalGray: hsla(0, 0%, 100%, 0.08);
-      --globalGraySoft: hsla(0, 0%, 100%, 0.08);
-      --globalColorThemeFull: @text !important;
-      --globalColorThemeHigh: @text;
-      --globalColorThemeMid: @overlay2 !important;
-      --globalColorThemeLow: @overlay0 !important;
-      --globalColorThemeLower: @base !important;
-      --globalColorThemeLink: @sapphire !important;
-      --globalColorThemeBlueToWhite: #fff;
-      --globalColorThemeBlueToMid: hsla(0, 0%, 100%, 0.72);
-      --globalColorThemeBlueToMidHover: hsla(0, 0%, 100%, 0.85);
-      --globalColorThemeBlueToHigh: hsla(0, 0%, 100%, 0.85);
-      --globalColorThemeBlueToHighHover: #fff;
-      --globalColorThemeHighToMid: hsla(0, 0%, 100%, 0.72);
-      --globalColorThemeFullToMid: hsla(0, 0%, 100%, 0.72);
-      --globalColorNeutral50: rgba(0, 0, 0, 0.1);
-      --globalColorNeutral100: rgba(0, 0, 0, 0.2);
-      --globalColorNeutral200: rgba(0, 0, 0, 0.4);
-      --globalOverlayBackground: @base !important;
-      --globalColorWin: @green !important;
-      --globalColorDraw: @accent-color !important;
-      --globalColorLoss: @red !important;
-    }
+    --theme-background-color: @base !important;
+    --globalBackground: @mantle !important;
+    --globalBackgroundOpaque: @mantle !important;
+    --globalSecondaryBackground: @crust !important;
+    --globalTertiaryBackground: @surface0 !important;
+    --globalAccentBackground: @accent-color !important;
+    --globalSecondaryAccentBackground: darken(@accent-color, 20%) !important;
+    --globalSiteBackground: @base !important;
+    --subtleButtonBackground: hsla(0, 0%, 100%, 0.16);
+    --globalBorder: @surface0 !important;
+    --globalGray: hsla(0, 0%, 100%, 0.08);
+    --globalGraySoft: hsla(0, 0%, 100%, 0.08);
+    --globalColorThemeFull: @text !important;
+    --globalColorThemeHigh: @text;
+    --globalColorThemeMid: @overlay2 !important;
+    --globalColorThemeLow: @overlay0 !important;
+    --globalColorThemeLower: @base !important;
+    --globalColorThemeLink: @sapphire !important;
+    --globalColorThemeBlueToWhite: #fff;
+    --globalColorThemeBlueToMid: hsla(0, 0%, 100%, 0.72);
+    --globalColorThemeBlueToMidHover: hsla(0, 0%, 100%, 0.85);
+    --globalColorThemeBlueToHigh: hsla(0, 0%, 100%, 0.85);
+    --globalColorThemeBlueToHighHover: #fff;
+    --globalColorThemeHighToMid: hsla(0, 0%, 100%, 0.72);
+    --globalColorThemeFullToMid: hsla(0, 0%, 100%, 0.72);
+    --globalColorNeutral50: rgba(0, 0, 0, 0.1);
+    --globalColorNeutral100: rgba(0, 0, 0, 0.2);
+    --globalColorNeutral200: rgba(0, 0, 0, 0.4);
+    --globalOverlayBackground: @base !important;
+    --globalColorWin: @green !important;
+    --globalColorDraw: @accent-color !important;
+    --globalColorLoss: @red !important;
+  
     /* index page */
     .promo-title,
     .index-title {

--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -84,39 +84,40 @@
     @wq: #piece("w/wq") [];
     @wr: #piece("w/wr") [];
 
-    --theme-background-color: @base !important;
-    --globalBackground: @mantle !important;
-    --globalBackgroundOpaque: @mantle !important;
-    --globalSecondaryBackground: @crust !important;
-    --globalTertiaryBackground: @surface0 !important;
-    --globalAccentBackground: @accent-color !important;
-    --globalSecondaryAccentBackground: darken(@accent-color, 20%) !important;
-    --globalSiteBackground: @base !important;
-    --subtleButtonBackground: hsla(0, 0%, 100%, 0.16);
-    --globalBorder: @surface0 !important;
-    --globalGray: hsla(0, 0%, 100%, 0.08);
-    --globalGraySoft: hsla(0, 0%, 100%, 0.08);
-    --globalColorThemeFull: @text !important;
-    --globalColorThemeHigh: @text;
-    --globalColorThemeMid: @overlay2 !important;
-    --globalColorThemeLow: @overlay0 !important;
-    --globalColorThemeLower: @base !important;
-    --globalColorThemeLink: @sapphire !important;
-    --globalColorThemeBlueToWhite: #fff;
-    --globalColorThemeBlueToMid: hsla(0, 0%, 100%, 0.72);
-    --globalColorThemeBlueToMidHover: hsla(0, 0%, 100%, 0.85);
-    --globalColorThemeBlueToHigh: hsla(0, 0%, 100%, 0.85);
-    --globalColorThemeBlueToHighHover: #fff;
-    --globalColorThemeHighToMid: hsla(0, 0%, 100%, 0.72);
-    --globalColorThemeFullToMid: hsla(0, 0%, 100%, 0.72);
-    --globalColorNeutral50: rgba(0, 0, 0, 0.1);
-    --globalColorNeutral100: rgba(0, 0, 0, 0.2);
-    --globalColorNeutral200: rgba(0, 0, 0, 0.4);
-    --globalOverlayBackground: @base !important;
-    --globalColorWin: @green !important;
-    --globalColorDraw: @accent-color !important;
-    --globalColorLoss: @red !important;
-
+    body {
+      --theme-background-color: @base !important;
+      --globalBackground: @mantle !important;
+      --globalBackgroundOpaque: @mantle !important;
+      --globalSecondaryBackground: @crust !important;
+      --globalTertiaryBackground: @surface0 !important;
+      --globalAccentBackground: @accent-color !important;
+      --globalSecondaryAccentBackground: darken(@accent-color, 20%) !important;
+      --globalSiteBackground: @base !important;
+      --subtleButtonBackground: hsla(0, 0%, 100%, 0.16);
+      --globalBorder: @surface0 !important;
+      --globalGray: hsla(0, 0%, 100%, 0.08);
+      --globalGraySoft: hsla(0, 0%, 100%, 0.08);
+      --globalColorThemeFull: @text !important;
+      --globalColorThemeHigh: @text;
+      --globalColorThemeMid: @overlay2 !important;
+      --globalColorThemeLow: @overlay0 !important;
+      --globalColorThemeLower: @base !important;
+      --globalColorThemeLink: @sapphire !important;
+      --globalColorThemeBlueToWhite: #fff;
+      --globalColorThemeBlueToMid: hsla(0, 0%, 100%, 0.72);
+      --globalColorThemeBlueToMidHover: hsla(0, 0%, 100%, 0.85);
+      --globalColorThemeBlueToHigh: hsla(0, 0%, 100%, 0.85);
+      --globalColorThemeBlueToHighHover: #fff;
+      --globalColorThemeHighToMid: hsla(0, 0%, 100%, 0.72);
+      --globalColorThemeFullToMid: hsla(0, 0%, 100%, 0.72);
+      --globalColorNeutral50: rgba(0, 0, 0, 0.1);
+      --globalColorNeutral100: rgba(0, 0, 0, 0.2);
+      --globalColorNeutral200: rgba(0, 0, 0, 0.4);
+      --globalOverlayBackground: @base !important;
+      --globalColorWin: @green !important;
+      --globalColorDraw: @accent-color !important;
+      --globalColorLoss: @red !important;
+    }
     /* index page */
     .promo-title,
     .index-title {

--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -84,7 +84,7 @@
     @wq: #piece("w/wq") [];
     @wr: #piece("w/wr") [];
 
-    body {
+    .dark-mode body {
       --theme-background-color: @base !important;
       --globalBackground: @mantle !important;
       --globalBackgroundOpaque: @mantle !important;

--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Chess.com Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chess.com
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chess.com
-@version 0.1.4
+@version 0.1.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chess.com/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achess.com
 @description Soothing pastel theme for Chess.com


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/catppuccin/userstyles/assets/147266582/7cc81a52-7228-4cd6-a447-91298116d8cd)
![image](https://github.com/catppuccin/userstyles/assets/147266582/35a82299-0f9d-41bd-a240-94c18679972b)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
