### PR TITLE
fix(advent-of-code): unthemed text and hover

### DIFF
--- a/styles/advent-of-code/catppuccin.user.css
+++ b/styles/advent-of-code/catppuccin.user.css
@@ -221,6 +221,18 @@
           text-shadow: 0 0 5px @yellow;
         }
 
+        .stats-both {
+           color: @yellow
+        }
+        
+        .stats-firstonly {
+           color: @overlay0
+        }
+          
+        a:hover {
+           background-color: @mantle !important;
+        }
+        
         input[type="text"],
         textarea,
         code::before {

--- a/styles/advent-of-code/catppuccin.user.css
+++ b/styles/advent-of-code/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Advent Of Code Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/advent-of-code
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/advent-of-code
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/advent-of-code/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aadvent-of-code
 @description Soothing pastel theme for Advent Of Code


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![Screenshot from 2024-07-09 17-23-18](https://github.com/catppuccin/userstyles/assets/147266582/c7dd3e45-5d25-49b4-a8e9-b61639c4c789)
![Screenshot from 2024-07-09 17-24-02](https://github.com/catppuccin/userstyles/assets/147266582/08f70874-90b7-4974-a6c6-dba4787fb9c7)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
