### PR TITLE
fix(go.dev): use ``@surface0`` instead of ``@text`` for the logo background

### DIFF
--- a/styles/go.dev/catppuccin.user.css
+++ b/styles/go.dev/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name go.dev Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/go.dev
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/go.dev
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/go.dev/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ago.dev
 @description Soothing pastel theme for go.dev

--- a/styles/go.dev/catppuccin.user.css
+++ b/styles/go.dev/catppuccin.user.css
@@ -88,7 +88,7 @@
     --color-background-card-footer: @crust;
     --color-background-code: @surface0; // Code Snippets
     --color-background-inverted: @crust;
-    --color-background-logo: @text;
+    --color-background-logo: @mantle;
     --color-background-playground-input: @mantle;
     --color-brand-primary: @accent-color; // Affects most Go-Color Elements
     --color-button: @accent-color;

--- a/styles/go.dev/catppuccin.user.css
+++ b/styles/go.dev/catppuccin.user.css
@@ -88,7 +88,7 @@
     --color-background-card-footer: @crust;
     --color-background-code: @surface0; // Code Snippets
     --color-background-inverted: @crust;
-    --color-background-logo: @mantle;
+    --color-background-logo: @surface0;
     --color-background-playground-input: @mantle;
     --color-brand-primary: @accent-color; // Affects most Go-Color Elements
     --color-button: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/catppuccin/userstyles/assets/147266582/3f112a0e-68f3-446d-a499-427b8633a8ee)
note that below is an old screenshot
![image](https://github.com/catppuccin/userstyles/assets/147266582/e71705cd-fdfa-442c-bc30-722ce6f2bb2c)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
