### PR TITLE
fix(go.dev): info banner

### DIFF
--- a/styles/go.dev/catppuccin.user.css
+++ b/styles/go.dev/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name go.dev Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/go.dev
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/go.dev
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/go.dev/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ago.dev
 @description Soothing pastel theme for go.dev
@@ -87,6 +87,7 @@
     --color-background-banner: @mantle;
     --color-background-card-footer: @crust;
     --color-background-code: @surface0; // Code Snippets
+    --color-background-info: @surface1;
     --color-background-inverted: @crust;
     --color-background-logo: @text;
     --color-background-playground-input: @mantle;
@@ -488,6 +489,14 @@
       .go-Select {
         background-image: url("data:image/svg+xml,@{svg}");
       }
+    }
+    // Info Icon
+    .go-Main-banner .go-Message .go-Icon {
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="@{text}"><path d="M0 0h24v24H0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"/></svg>'
+      );
+      content: url("data:image/svg+xml,@{svg}");
+      filter: none;
     }
     // Pkg.go Subheader
     .go-Main-header {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes miscolored info banners in `pkg.go.dev`

![image](https://github.com/user-attachments/assets/083f2036-715b-47dc-9740-6fb4ba56afd9)

![image](https://github.com/user-attachments/assets/d0fcf707-0c7a-44d7-9c09-1eefdf69c47a)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
