### PR TITLE
fix(codeberg): secondary menu, inline code

### DIFF
--- a/styles/codeberg/catppuccin.user.css
+++ b/styles/codeberg/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Codeberg Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/codeberg
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/codeberg
-@version 1.1.3
+@version 1.1.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/codeberg/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acodeberg
 @description Soothing pastel theme for Codeberg
@@ -64,7 +64,8 @@
     --color-footer-text: @text;
 
     .ui.secondary.menu .dropdown.item:hover,
-    .ui.secondary.menu a.item:hover {
+    .ui.secondary.menu a.item:hover,
+    .ui.secondary.menu a.active.item:hover {
       background-color: var(--color-nav-hover-bg);
       color: var(--color-black);
     }
@@ -102,6 +103,10 @@
       a:hover {
         color: @blue !important;
       }
+    }
+
+    .inline-code-block {
+        background-color: var(--color-markup-code-inline);
     }
   }
 

--- a/styles/codeberg/catppuccin.user.css
+++ b/styles/codeberg/catppuccin.user.css
@@ -104,10 +104,6 @@
         color: @blue !important;
       }
     }
-
-    .inline-code-block {
-        background-color: var(--color-markup-code-inline);
-    }
   }
 
   @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Items in secondary menu colors are reversed when they are hovered but not for active(selected) one.
Inline code blocks use accent colors and it makes them hard to read.

Here are screenshots(no secondary menu one because I couldn't figure out how to screenshot while hovering items)
### before
![image](https://github.com/user-attachments/assets/05b6981c-6800-47e2-813b-9337f7bd2981)

![image](https://github.com/user-attachments/assets/60948d3c-0795-4387-8f47-f9e489a1a0be)

### after
![image](https://github.com/user-attachments/assets/479fa127-aab6-4d11-b218-f3f195b07c4a)

![image](https://github.com/user-attachments/assets/4637d83c-a224-4784-9ee7-6165fa7c8c83)

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
