### PR TITLE
fix(duckduckgo): partially unthemed popup

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.2.4
+@version 0.2.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -295,6 +295,12 @@
 
     .module__toggle--more::after {
       background: linear-gradient(rgba(40, 40, 40, 0), @surface0);
+    }
+
+    /* popup */
+    .atb-new .badge-link__checkbox.badge-link__checkbox_checked {
+        background: @mantle;
+        color: @text;
     }
 
     /* button on hover */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title

![image](https://github.com/user-attachments/assets/34f25160-3f34-4378-b287-ed16b7b925c6)
![image](https://github.com/user-attachments/assets/f7165e8e-4e39-4f46-afb1-bfeff96a3356)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
