### PR TITLE
fix(duckduckgo): home page and other minor stuff

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -858,6 +858,7 @@
 
     select,
     h1,
+    input,
     h2,
     h4,
     h5,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.2.4
+@version 0.2.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -16,11 +16,11 @@
 ==/UserStyle== */
 
 @-moz-document domain(duckduckgo.com) {
-  :root:not(.dark-bg) {
+  :root {
     #catppuccin(@lightFlavor, @accentColor);
   }
 
-  :root.dark-bg {
+  :root {
     #catppuccin(@darkFlavor, @accentColor);
   }
 
@@ -65,7 +65,9 @@
         color: @subtext0 !important;
       }
     }
-
+    
+    --color-gray100: @base !important;
+    --color-gray85: @mantle !important;
     --sds-color-text-02: @text !important;
     --theme-col-txt-page-separator: @text!important;
     --theme-col-page-separator: @text !important;
@@ -110,10 +112,10 @@
     --theme-badge-fg--green: @crust !important;
     --theme-browser-comparison-table-check-bg: @green !important;
     --theme-browser-comparison-table-cross-bg: @red !important;
-    --theme-searchbox-bg: @surface0 !important;
-    --theme-searchbox-bg--hover: @surface0 !important;
-    --theme-searchbox-bg--active: @surface0 !important;
-    --theme-searchbox-bg--focused: @surface0 !important;
+    --theme-searchbox-bg: @mantle !important;
+    --theme-searchbox-bg--hover: @mantle !important;
+    --theme-searchbox-bg--active: @mantle !important;
+    --theme-searchbox-bg--focused: @mantle !important;
     --theme-border-color-legacy-home-searchbox: @surface2 !important;
     --theme-button-link-text: @blue !important;
     --theme-browser-comparison-table-badge-text: @text !important;
@@ -173,7 +175,19 @@
     --theme-dc-color-llama-main: @pink !important;
     --theme-dc-color-mixtral-main: @peach !important;
     --theme-dc-color-anchor-sleep: @subtext0 !important;
+    --theme-button-primary-bg: @accent-color !important;
+    --theme-col-bg-header: @mantle !important;
 
+    .searchbox_combobox__V4gS9.searchbox_isHomepage__C57Qt, .searchbox_suggestions__umkQH {
+        background-color: @mantle !important;
+        border-color: @mantle !important;
+    }
+
+    .atb-new .badge-link__checkbox.badge-link__checkbox_checked {
+        background: @mantle;
+        color: @text;
+    }
+    
     .footer,
     .footer--mobile,
     .modal--dropdown--settings,
@@ -739,7 +753,6 @@
     .feedback-btn__icon-wrap .set-bookmarklet__input .btn,
     .btn.btn--secondary,
     .btn.is-disabled,
-    input,
     textarea,
     .frm__input,
     .frm__text,
@@ -844,7 +857,6 @@
       background-color: @surface0 !important;
     }
 
-    input,
     select,
     h1,
     h2,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -16,15 +16,12 @@
 ==/UserStyle== */
 
 @-moz-document domain(duckduckgo.com) {
-  @media (prefers-color-scheme: light) {
-    :root {
-      #catppuccin(@lightFlavor, @accentColor);
-    }
+  :root:not(.dark-bg) {
+    #catppuccin(@lightFlavor, @accentColor);
   }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      #catppuccin(@darkFlavor, @accentColor);
-    }
+
+  :root.dark-bg {
+    #catppuccin(@darkFlavor, @accentColor);
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -16,12 +16,15 @@
 ==/UserStyle== */
 
 @-moz-document domain(duckduckgo.com) {
-  :root {
-    #catppuccin(@lightFlavor, @accentColor);
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
-
-  :root {
-    #catppuccin(@darkFlavor, @accentColor);
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {
@@ -105,9 +108,8 @@
     --theme-col-txt-button-secondary: @accent-color !important;
     --theme-bg-legacy-home: @base !important;
     --theme-bg-cta-cards: @surface0 !important;
-    --theme-button-primary-bg: @blue !important;
-    --theme-button-primary-bg--hover: @blue !important;
-    --theme-button-primary-bg--active: @blue !important;
+    --theme-button-primary-bg--hover: @accent-color !important;
+    --theme-button-primary-bg--active: @accent-color !important;
     --theme-button-primary-text: @crust !important;
     --theme-badge-fg--green: @crust !important;
     --theme-browser-comparison-table-check-bg: @green !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title

also merges #1072 too
![image](https://github.com/user-attachments/assets/0d81a4c8-0924-4679-a54a-84b5947a0aaf)
![image](https://github.com/user-attachments/assets/04bb2489-e70e-440b-9f04-95a6eb6164e0)
![image](https://github.com/user-attachments/assets/284c181f-c862-457e-85a0-b9b3e18c9e6c)
![image](https://github.com/user-attachments/assets/75a8b926-1568-4c8b-985d-c05df425261f)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
