### PR TITLE
fix(whatsapp-web): filter groups

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.css
+++ b/styles/whatsapp-web/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name WhatsApp Web Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/whatsapp-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/whatsapp-web
-@version 0.0.9
+@version 0.0.10
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/whatsapp-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awhatsapp-web
 @description Soothing pastel theme for WhatsApp Web
@@ -93,6 +93,20 @@
     --intro-border: @accent-color !important;
     /* general background */
     --app-background: @base !important;
+
+     /*FILTER GROUP*
+    /*filter background*/
+    --filters-container-background: var(--base);
+    /* active filter text */
+    --filters-item-active-color: var(--mauve);      
+    /* active filter background */
+    --filters-item-active-background: var(--mantle);       
+    /* inactive filter background */
+    --filters-item-background: var(--surface0);
+    /* inactive filter text */
+    --filters-item-color: var(--text);
+    /* inactive filter background on hover*/
+    --filters-item-background-hover: var(--surface1);
 
     /* CHAT LIST */
     /* nav bar background */


### PR DESCRIPTION
## 🔧 Fixed filter group theme. 🔧

Fixes unthemed filter group above chat list.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
