### PR TITLE
fix(youtube): profile card

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.1.1
+@version 4.1.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -963,6 +963,24 @@
         color: @text;
       }
     }
+
+    /* Profiles */
+    .yt-profile-card-view-model-wiz {
+      background-color: @mantle;
+    }
+    .yt-profile-identity-info-view-model-wiz__channel-name,
+    .yt-profile-info-view-model-wiz__section-title,
+    .yt-comment-interaction-view-model-wiz__video-title,
+    .yt-shared-subscription-view-model-wiz__channel-name {
+      color: @text;
+    }
+    .yt-profile-identity-info-view-model-wiz__badge,
+    .yt-profile-identity-info-view-model-wiz__metadata-handle,
+    .yt-profile-identity-info-view-model-wiz__metadata-content,
+    .yt-profile-info-view-model-wiz__section-subtitle,
+    .yt-comment-interaction-view-model-wiz__comment-content {
+        color: @subtext0;
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Profile cards are not themed.
|before|after|
|-|-|
|![image](https://github.com/user-attachments/assets/c0c2ef3f-2e7d-42cd-9659-97c2e98d6ffa)|![image](https://github.com/user-attachments/assets/1913e248-38a6-40ba-8e93-997bfe9e1186)|
|![image](https://github.com/user-attachments/assets/99fc7db4-33ef-44f3-be17-7e84b6b14214)|![image](https://github.com/user-attachments/assets/96ee4ce0-c18b-4f71-bcd1-828b0001c89c)|

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
