### PR TITLE
fix(modrinth): unthemed logo

### DIFF
--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Modrinth Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/modrinth
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/modrinth
-@version 1.2.2
+@version 1.2.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/modrinth/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amodrinth
 @description Soothing pastel theme for Modrinth
@@ -109,6 +109,14 @@
     --color-warning-banner-bg: fade(@red, 10%);
     --color-warning-banner-text: @text;
 
+    g {
+        path {
+            fill: @accent-color !important;
+        }
+  
+       mix-blend-mode: none;
+    }
+    
     [tabindex="0"]:focus-visible,
     a:focus-visible,
     button:focus-visible {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/b438ff44-d4d1-4757-bee3-4d8960d1a755)
![image](https://github.com/user-attachments/assets/45cc2380-60fa-4edf-bd4c-12aec0c3cbf3)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
