### PR TITLE
fix(modrinth): unthemed frontpage elements

### DIFF
--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Modrinth Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/modrinth
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/modrinth
-@version 1.2.3
+@version 1.2.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/modrinth/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amodrinth
 @description Soothing pastel theme for Modrinth

--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -108,9 +108,25 @@
     --color-warning-banner-side: @red;
     --color-warning-banner-bg: fade(@red, 10%);
     --color-warning-banner-text: @text;
+    --landing-green-label: @accent-color;
+    --landing-green-label-bg: fade(@accent-color, 10%);
+    --landing-blue-label: @blue;
+    --landing-blue-label-bg: fade(@blue, 10%);
 
+    // homepage
+    .blob-demonstration,
+    .blob-demonstration::after {
+      background: linear-gradient(
+        0deg,
+        fade(@accent-color, 20%),
+        fade(@base, 10%)
+      ) !important;
+    }
     .logo-banner path {
       fill: @accent-color !important;
+    }
+    .logo-banner > svg > g > rect {
+      display: none;
     }
 
     [tabindex="0"]:focus-visible,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed labels in the front page, unthemed gradient in the demonstration cards and the green logo in the bottom of the page
![image](https://github.com/user-attachments/assets/cda26cf3-323e-435a-b2eb-9925c699baf2)
![image](https://github.com/user-attachments/assets/5e0334dd-4c4d-416b-bfb0-0255528e716d)
![image](https://github.com/user-attachments/assets/b817418a-c4ca-4c20-ab5d-657397fc7e47)
![image](https://github.com/user-attachments/assets/479fd38e-9880-4422-8364-dcd01573ace2)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
