### PR TITLE
fix(pypi): unthemed text

### DIFF
--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name PyPI Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pypi
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pypi
-@version 0.0.6
+@version 0.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pypi/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apypi
 @description Soothing pastel theme for PyPI

--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -135,6 +135,10 @@
       background-image: linear-gradient(90deg, @surface0, @surface0) !important;
     }
 
+    .project-description blockquote {
+      color: @text !important;
+    }
+  
     .banner,
     .footer {
       background-color: @mantle !important;

--- a/styles/pypi/catppuccin.user.css
+++ b/styles/pypi/catppuccin.user.css
@@ -136,7 +136,7 @@
     }
 
     .project-description blockquote {
-      color: @text !important;
+      color: @subtext0 !important;
     }
   
     .banner,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/7e78ae29-8c3d-4bbd-bd5e-c454f9b0727f)
![image](https://github.com/user-attachments/assets/ab560378-3c3e-44fa-83aa-6d3fc6357e9f)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
