### PR TITLE
docs: update catwalk links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/userstyle-creation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/userstyle-creation.md
@@ -29,4 +29,4 @@ Feel free to leave this section empty if you don't have anything more to say.
   - `catppuccin.user.css` - all the CSS for the userstyle, based on the
     template.
   - `preview.webp` - composite image of all four individual flavor screenshots stitched together,
-    generated via [Catwalk](https://github.com/catppuccin/toolbox/tree/main/catwalk#readme).
+    generated via [Catwalk](https://github.com/catppuccin/catwalk).

--- a/docs/userstyle-creation.md
+++ b/docs/userstyle-creation.md
@@ -46,7 +46,7 @@ To create a userstyle, follow the instructions below. If you run into any diffic
 7. Create your image preview.
    - Take a screenshot of the themed website in each flavor, and then convert all four images [to WebP](./tips-and-tricks.md#how-do-i-convert-preview-images-to-webp) (e.g. `mocha.webp`,
      `macchiato.webp`, `frappe.webp` & `latte.webp`).
-   - Use [Catwalk](https://github.com/catppuccin/toolbox#catwalk) to generate a
+   - Use [Catwalk](https://github.com/catppuccin/catwalk) to generate a
      composite or grid image of all the images. **This must be saved as
      `styles/<name-of-website>/preview.webp`.**
 8. Raise a [pull request](https://github.com/catppuccin/userstyles/compare),


### PR DESCRIPTION
update the catwalk link in the docs and the pr template

> This tool has moved to a separate repository to reduce the increasing complexity of managing a monorepo. To find code, documentation, and releases starting with and after [v1.3.1](https://github.com/catppuccin/catwalk/releases/tag/v1.3.1), visit [catppuccin/catwalk](https://github.com/catppuccin/catwalk).

\- [catppuccin/toolbox](https://github.com/catppuccin/toolbox/tree/main/catwalk)