### PR TITLE
fix(modrinth): theme 2nth table row 

### DIFF
--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -128,6 +128,10 @@
     .logo-banner > svg > g > rect {
       display: none;
     }
+    // 2nth table row
+    .markdown-body table tr:nth-child(2n) {
+      background: @mantle;
+    }
 
     [tabindex="0"]:focus-visible,
     a:focus-visible,

--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Modrinth Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/modrinth
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/modrinth
-@version 1.2.4
+@version 1.2.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/modrinth/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amodrinth
 @description Soothing pastel theme for Modrinth


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed 2nth table rows
screenshots (from [Simple Voice Chat](https://modrinth.com/plugin/simple-voice-chat)):
before:
![image](https://github.com/user-attachments/assets/7b47d8e2-aaaa-46c2-8942-2499e24f13e2)
after:
![image](https://github.com/user-attachments/assets/73d5da88-a14c-400f-b357-2aae1fd6c9a2)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
