### PR TITLE
fix(modrinth): unthemed variables

### DIFF
--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Modrinth Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/modrinth
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/modrinth
-@version 1.2.5
+@version 1.2.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/modrinth/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amodrinth
 @description Soothing pastel theme for Modrinth

--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -73,6 +73,7 @@
     --color-bg: @crust;
     --color-ad-raised: @surface2;
     --color-ad: @surface1;
+    --color-ad-highlight: @teal ;
     --color-brand: @accent-color;
     --color-brand-green: @green;
     --color-button-bg-active: @overlay0;
@@ -94,6 +95,7 @@
     --color-purple: @mauve;
     --color-special-purple: @mauve;
     --color-red: @red;
+    --color-gray: @subtext0;
     --color-special-gray: @subtext0;
     --color-green: @green;
     --color-text: @subtext1;
@@ -104,6 +106,7 @@
     --color-table-alternate-row: @crust;
     --color-table-border: @overlay0;
     --color-contrast: @text;
+    --color-accent-contrast: @mantle;
     --color-brand-shadow: @accent-color;
     --color-warning-banner-side: @red;
     --color-warning-banner-bg: fade(@red, 10%);
@@ -127,10 +130,6 @@
     }
     .logo-banner > svg > g > rect {
       display: none;
-    }
-    // 2nth table row
-    .markdown-body table tr:nth-child(2n) {
-      background: @mantle;
     }
 
     [tabindex="0"]:focus-visible,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

themes `--color-ad-highlight` (links in highlighted ads), `--color-gray` (the line under markdown headers), `--color-accent-contrast` (markdown tables 2nth row)
also removed the "2nth table row" section since it got replaced by `--color-accent-contrast`

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
