### PR TITLE
fix(pronouns.page): social buttons

### DIFF
--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -108,6 +108,11 @@
       --bs-btn-disabled-border-color: @accent-color;
     }
 
+    .btn-square {
+      background-color: @accent-color !important;
+      color: @crust !important;
+    }
+
     .btn-outline-primary {
       color: @text;
 

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -110,7 +110,6 @@
 
     .btn-square {
       background-color: @accent-color !important;
-      color: @crust !important;
     }
 
     .btn-outline-primary {

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Pronouns.page Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pronouns.page
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pronouns.page
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pronouns.page/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apronouns.page
 @description Soothing pastel theme for Pronouns.page

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -108,10 +108,6 @@
       --bs-btn-disabled-border-color: @accent-color;
     }
 
-    .btn-square {
-      background-color: @accent-color !important;
-    }
-
     .btn-outline-primary {
       color: @text;
 
@@ -210,6 +206,10 @@
     }
     .btn-outline-dark {
       color: @text;
+    }
+
+    .btn-square {
+      background-color: @accent-color !important;
     }
 
     /* Inputs */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/c23d0ac6-753c-4fad-916a-c3a6296b9558)
![image](https://github.com/user-attachments/assets/bffd00cd-1b2e-4608-a0e5-4de9a756ef3e)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
