### PR TITLE
fix(tuta): logo

### DIFF
--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -114,6 +114,7 @@
       background-color: @surface1 !important;
     }
 
+    /* logo */
     path[style*="fill: #00d2a7;"] {
       fill: @accent-color !important;
     }

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Tuta Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/tuta
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/tuta
-@version 0.0.8
+@version 0.0.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/tuta/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atuta
 @description Soothing pastel theme for Tuta

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -114,6 +114,14 @@
       background-color: @surface1 !important;
     }
 
+    path[style*="fill: #00d2a7;"] {
+      fill: @accent-color !important;
+    }
+    
+    path[style*="fill: #c5c7c7;"] {
+      fill: @text !important;
+    }
+
     .row-selected {
       border-color: @accent-color !important;
       color: @accent-color !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the logo
![image](https://github.com/user-attachments/assets/9902e656-495f-4aed-b7f9-7eb9f16b6013)
![image](https://github.com/user-attachments/assets/abc8b898-dbc0-41ae-b83c-5633ea566f68)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
