### PR TITLE
fix(cinny): footer

### DIFF
--- a/styles/cinny/catppuccin.user.css
+++ b/styles/cinny/catppuccin.user.css
@@ -242,6 +242,19 @@
       background-color: @accent-color;
       color: @base;
     }
+    
+    /* Footer */
+    .footer {
+      .text-s1, .text-h2, a {
+          color: @text;
+      }
+      
+      .footer__creator, .footer__menu-container .text-b3 {
+          color: @subtext0;
+      }
+        
+      background-color: @base;
+    }
   }
 
   :root,

--- a/styles/cinny/catppuccin.user.css
+++ b/styles/cinny/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Cinny Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/cinny
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/cinny
-@version 2.3.0
+@version 2.3.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/cinny/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acinny
 @description Soothing pastel theme for Cinny


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/1255ca16-140f-4a02-8208-720e2888e1ef)
![image](https://github.com/user-attachments/assets/0907866d-f85d-4e49-bb8f-e70bb123d87b)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
