### PR TITLE
fix(youtube): color icons and progress bars

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -384,6 +384,10 @@
       color: @accent-color !important;
     }
 
+    .yt-page-navigation-progress {
+      background: @accent-color !important;
+    }
+
     /* Selected chapter */
     ytd-macro-markers-list-item-renderer {
       --ytd-macro-markers-list-item-background-color: @surface0 !important;

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.1.6
+@version 4.1.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -489,7 +489,9 @@
 
     [fill="red"],
     [fill="#F00"],
-    [fill="#FF0000"] {
+    [fill="#FF0000"],
+    [fill="#f03"],
+    [fill="#FF0033"] {
       fill: @accent-color !important;
     }
 
@@ -825,8 +827,9 @@
     .html5-video-player {
       color: @white;
 
-      .ytp-swatch-background-color {
-        background-color: @accent-color !important;
+      .ytp-swatch-background-color,
+      .ytp-play-progress {
+        background: @accent-color !important;
       }
 
       .ytp-svg-fill,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #1137. Colors the YouTube and Shorts icons, and the video and loading progress bars in some clients.

![YouTube icon before the commit, the default red.](https://github.com/user-attachments/assets/c67071f7-48f2-4eb0-a1a6-f38d1fb93c0b)
![YouTube icon after the commit, Catppuccin Mocha blue.](https://github.com/user-attachments/assets/ee9c270f-9269-4a66-97a5-13b7068cedbb)

![Video progress bar before the commit, the default red gradient.](https://github.com/user-attachments/assets/b8a59080-a4dd-4ff5-8c32-f30d9885d064)
![Video progress bar after the commit, Catppuccin Mocha blue.](https://github.com/user-attachments/assets/f5401145-60b8-4849-a8a5-69c7198c202f)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
