### PR TITLE
fix(spotify-web): unthemed border on playlist details

### DIFF
--- a/styles/spotify-web/catppuccin.user.css
+++ b/styles/spotify-web/catppuccin.user.css
@@ -166,6 +166,11 @@
     .pHrwZOFBdT8FNXnmcPPI {
       background: @crust !important;
     }
+
+    .ePPpO_NuGDUxVRTw7y6W {
+      border-color: @surface0;
+    }
+    
     // Some animated bar icon
     .uWvwXlS0Da1bWsRX6KOw,
     .n5XwsUqagSoVk8oMiw1x {

--- a/styles/spotify-web/catppuccin.user.css
+++ b/styles/spotify-web/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Spotify Web Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/spotify-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/spotify-web
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/spotify-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aspotify-web
 @description Soothing pastel theme for Spotify Web

--- a/styles/spotify-web/catppuccin.user.css
+++ b/styles/spotify-web/catppuccin.user.css
@@ -167,6 +167,7 @@
       background: @crust !important;
     }
 
+    /* some borders */
     .ePPpO_NuGDUxVRTw7y6W {
       border-color: @surface0;
     }

--- a/styles/spotify-web/catppuccin.user.css
+++ b/styles/spotify-web/catppuccin.user.css
@@ -167,7 +167,7 @@
       background: @crust !important;
     }
 
-    /* some borders */
+    /* some borders on the playlist details */
     .ePPpO_NuGDUxVRTw7y6W {
       border-color: @surface0;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/5036e01d-c64f-427a-81be-ed8b1a38b93f)
![image](https://github.com/user-attachments/assets/fde48858-becb-4f59-9d7f-4b61733eb901)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
