### PR TITLE
fix(npm): misc syntax highlighting

### DIFF
--- a/styles/npm/catppuccin.user.css
+++ b/styles/npm/catppuccin.user.css
@@ -135,15 +135,6 @@
       color: @base;
     }
 
-    /* Syntax highlighting text */
-    span[style*="color: rgb(223, 80, 0);"] {
-      color: @peach !important;
-    }
-    
-    span[style*="color: rgb(99, 163, 92);"] {
-      color: @green !important;
-    }
-
     /* Border colors */
     .b--black-10,
     .b--black-20 {
@@ -612,6 +603,13 @@
         [style="color: rgb(111, 66, 193);"] {
           color: var(--color-prettylights-syntax-entity) !important;
         }
+        [style*="color: rgb(223, 80, 0);"] {
+          color: @peach !important;
+        }
+        [style*="color: rgb(99, 163, 92);"] {
+          color: @green !important;
+        }
+        
         .hljs-subst,
         .hljs-built_in {
           color: var(

--- a/styles/npm/catppuccin.user.css
+++ b/styles/npm/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name npm Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/npm
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/npm
-@version 0.0.7
+@version 0.0.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/npm/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anpm
 @description Soothing pastel theme for npm
@@ -133,6 +133,15 @@
     /* Inverse text */
     .white {
       color: @base;
+    }
+
+    /* Syntax highlighting text */
+    span[style*="color: rgb(223, 80, 0);"] {
+      color: @peach !important;
+    }
+    
+    span[style*="color: rgb(99, 163, 92);"] {
+      color: @green !important;
     }
 
     /* Border colors */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/165c210f-1d53-41df-9b61-3c650810a3b8)
![image](https://github.com/user-attachments/assets/0877ee2a-40b4-4b88-85f5-2f7ae6dd57cd)
sorry if my PRs are a bit bearable to review

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
