### PR TITLE
fix(go.dev): unthemed border

### DIFF
--- a/styles/go.dev/catppuccin.user.css
+++ b/styles/go.dev/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name go.dev Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/go.dev
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/go.dev
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/go.dev/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ago.dev
 @description Soothing pastel theme for go.dev
@@ -107,7 +107,8 @@
     --pink: @red;
     --turq-dark: @accent-color;
     --white: @text;
-
+    --border-code: 0.0625rem @surface0 solid;
+    
     .btn {
       background: @accent-color;
       color: @crust;

--- a/styles/go.dev/catppuccin.user.css
+++ b/styles/go.dev/catppuccin.user.css
@@ -107,7 +107,7 @@
     --pink: @red;
     --turq-dark: @accent-color;
     --white: @text;
-    --border-code: 0.0625rem @surface0 solid;
+    --border-code: 0.0625rem @surface2 solid;
     
     .btn {
       background: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/a9521a3f-53ac-4f30-a7b5-20cfc78d6918)
![image](https://github.com/user-attachments/assets/06637b2e-00b3-4bbb-b06b-25ac058f93c1)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
