### PR TITLE
fix(lint): use errors instead of warnings, refactor log impl

### DIFF
--- a/scripts/lint/file-checker.ts
+++ b/scripts/lint/file-checker.ts
@@ -37,7 +37,7 @@ export const checkForMissingFiles = async () => {
       .write();
   } else {
     missingFiles.map((f) => {
-      log(color.red(`Missing file:`) + ` ${f}`, { file: f }, "error");
+      log.error(color.red(`Missing file:`) + ` ${f}`, { file: f });
     });
   }
 

--- a/scripts/lint/logger.ts
+++ b/scripts/lint/logger.ts
@@ -65,21 +65,37 @@ const prettyPrint = (
   );
 };
 
-export const log = (
-  message: string,
-  props: LoggerProps,
-  severity: "error" | "warning" = "warning",
-) => {
-  if (Deno.env.has("CI")) {
-    switch (severity) {
-      case "error":
-        core.error(message, props);
-        break;
-      case "warning":
-        core.warning(message, props);
-        break;
+export const log = {
+  log: (
+    message: string,
+    props: LoggerProps,
+    severity: "error" | "warning",
+  ) => {
+    if (Deno.env.has("CI")) {
+      switch (severity) {
+        case "error":
+          core.error(message, props);
+          break;
+        case "warning":
+          core.warning(message, props);
+          break;
+      }
+    } else {
+      prettyPrint(message, props, severity);
     }
-  } else {
-    prettyPrint(message, props, severity);
-  }
+  },
+
+  warn: function (
+    message: string,
+    props: LoggerProps,
+  ) {
+    this.log(message, props, "warning");
+  },
+
+  error: function (
+    message: string,
+    props: LoggerProps,
+  ) {
+    this.log(message, props, "error");
+  },
 };

--- a/scripts/lint/main.ts
+++ b/scripts/lint/main.ts
@@ -49,10 +49,9 @@ for await (const entry of stylesheets) {
   less.render(content, { lint: true, globalVars: globalVars }).catch(
     (err: Less.RenderError) => {
       failed = true;
-      log(
+      log.error(
         err.message,
         { file, startLine: err.line, endLine: err.line, content },
-        "error",
       );
     },
   );

--- a/scripts/lint/metadata.ts
+++ b/scripts/lint/metadata.ts
@@ -36,7 +36,7 @@ export const verifyMetadata = async (
       e.index -= line.length + 1;
       if (e.index < 0) break;
     }
-    log(e.message, { file, startLine, content });
+    log.error(e.message, { file, startLine, content });
   });
 
   for (const [key, expected] of Object.entries(assert)) {
@@ -58,11 +58,11 @@ export const verifyMetadata = async (
           color.red(String(current)),
         );
 
-      log(message, {
+      log.error(message, {
         file,
         startLine: line !== 0 ? line : undefined,
         content,
-      }, "warning");
+      });
     }
   }
 
@@ -84,7 +84,7 @@ export const verifyMetadata = async (
         .findLastIndex((line: string) => line.includes("==/UserStyle== */")) +
         1;
 
-      log(
+      log.error(
         sprintf(
           "Metadata variable `%s` should exist",
           color.bold(variable),
@@ -94,7 +94,6 @@ export const verifyMetadata = async (
           startLine: line !== 0 ? line : undefined,
           content,
         },
-        "warning",
       );
     } else if (expected.trim() !== lines[current - 1].trim()) {
       const message = sprintf(
@@ -103,11 +102,11 @@ export const verifyMetadata = async (
         (/\[[^\]]+\]/.exec(expected) as RegExpExecArray)[0],
       );
 
-      log(message, {
+      log.error(message, {
         file,
         startLine: current,
         content,
-      }, "warning");
+      });
 
       if (fix) {
         content = content.replace(lines[current - 1], expected);
@@ -135,9 +134,9 @@ const assertions = (userstyle: string, userstyles: Userstyles) => {
   const prefix = "https://github.com/catppuccin/userstyles";
 
   if (!userstyles[userstyle]) {
-    log("Metadata section for this userstyle has not been added", {
+    log.error("Metadata section for this userstyle has not been added", {
       file: "scripts/userstyles.yml",
-    }, "error");
+    });
     Deno.exit(1);
   }
 

--- a/scripts/lint/stylelint.ts
+++ b/scripts/lint/stylelint.ts
@@ -29,7 +29,7 @@ export const lint = (
             color.dim(`(${warning.rule})`),
           ) ?? "unspecified stylelint error";
 
-          log(message, {
+          log.log(message, {
             file: relative(REPO_ROOT, entry.path),
             startLine: warning.line,
             endLine: warning.endLine,

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -67,14 +67,13 @@ export const getUserstylesData = (): Userstyles => {
       const groups =
         /(?<message>.*) at line (?<line>\d+), column (?<column>\d+):[\S\s]*/
           .exec(err.message)?.groups;
-      log(
+      log.error(
         groups!.message,
         {
           file: "scripts/userstyles.yml",
           startLine: Number(groups!.line),
           content: content,
         },
-        "error",
       );
     } else {
       console.log(err);


### PR DESCRIPTION
Was reviewing a PR (#1160) and found it odd that the metadata differences were reported as warnings rather than errors, as we should not be merging a PR in such a state. This PR refactors the logging implementation to make logging warnings vs errors clearer, and switches the metadata logging to be all errors instead of warnings.