### PR TITLE
fix(github): unthemed mentions

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.6.10
+@version      1.6.11
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -495,6 +495,7 @@
       0px 32px 64px 0px #010409;
     --shadow-floating-legacy: 0px 6px 12px -3px @crust, 0px 6px 18px 0px @crust;
     --outline-focus: @blue solid 2px;
+    --bgColor-attention-muted: @surface0;
 
     .turbo-progress-bar {
       background-color: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/deab5d27-aeeb-470b-bd0c-05b071d0d0ce)
![image](https://github.com/user-attachments/assets/f82b00b4-334a-44c9-9575-38ed5efa3805)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
