### PR TITLE
fix(youtube): shorts stats values

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -915,7 +915,6 @@
       .YtwFactoidRendererLabel {
         color: @subtext0;
       }
-
       .YtwFactoidRendererValue {
         color: @text;
       }

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.0
+@version 4.2.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -914,6 +914,10 @@
 
       .YtwFactoidRendererLabel {
         color: @subtext0;
+      }
+
+      .YtwFactoidRendererValue {
+        color: @text;
       }
 
       ytd-reel-video-renderer:not([is-watch-while-mode]) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/1a6df3f9-28a9-4cb9-8d01-0bf5e8433c93)
![image](https://github.com/user-attachments/assets/19ca0f36-8620-45c1-b663-c56b16b64146)

if your wondering where this is, just go to any short's description and you should find this
## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
