### PR TITLE
fix(tuta): borders, calendars, login page, text, etc

### DIFF
--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -136,6 +136,7 @@
     .calendar-long-events-header,
     .calendar-column-border,
     .nav-bar-spacer,
+    .dialog-header,
     [style*="border-color: rgb(17, 17, 17);"], 
     [style*="border-bottom: 1px solid rgb(54, 54, 54);"], 
     [style*="border-right: 1px solid rgb(54, 54, 54);"] {
@@ -192,6 +193,11 @@
 
     .calendar-hour:hover {
       background-color: @surface0 !important;
+    }
+
+    /* checkboxes */
+    input[type*="checkbox"][style*="background-color: rgb(0, 210, 167);"] {
+        background-color: @accent-color !important;
     }
 
     .row-selected {

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Tuta Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/tuta
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/tuta
-@version 0.1.0
+@version 0.0.10
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/tuta/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atuta
 @description Soothing pastel theme for Tuta

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -124,28 +124,52 @@
     }
 
     /* search bar */
-    input, .search-bar {
+    .search-bar {
       background-color: @mantle !important;
       color: @text !important;
     }
 
     /* borders */
-    .border-radius, .dialog-buttons, [style*="border-color: rgb(17, 17, 17);"] {
-       border-color: @surface0 !important;
+    .border-radius, .dialog-buttons, [style*="border-color: rgb(17, 17, 17);"], [style*="border-bottom: 1px solid rgb(54, 54, 54);"] {
+      border-color: @surface0 !important;
+    }
+
+    div[style*="border-bottom: 2px solid rgb(0, 210, 167)"] {
+      border-color: @accent-color !important;
     }
     
     hr {
-       background-color: @surface0 !important;
+      background-color: @surface0 !important;
     }
 
     /* accent text/background */
     .content-accent-fg {
-        color: @accent-color !important;
+      color: @accent-color !important;
     }
       
     .accent-bg {
-        background-color: @accent-color !important;
-        color: @crust !important;
+      background-color: @accent-color !important;
+      color: @crust !important;
+    }
+
+    /* calendar */
+    .calendar-day {
+      background-color: @mantle !important;
+      border-color: @base !important;
+    }
+      
+    .faded-day {
+      color: @subtext0 !important;
+    }
+      
+    .calendar-current-day-circle {
+      background-color: @accent-color !important;
+      color: @crust !important;
+    }
+      
+    [style*="background: rgb(33, 150, 243);"] {
+      background-color: @blue !important;
+      border-color: @blue !important;
     }
 
     .row-selected {

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -129,7 +129,7 @@
       color: @text !important;
     }
     
-    input, label, .content-fg {
+    input, label, span, .content-fg {
       color: @text !important;
     }
 

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -173,6 +173,10 @@
       color: @accent-color !important;
     }
 
+    .checkbox:checked {
+      border-color: @accent-color !important;
+    }
+
     .bg-accent-fg {
       background-color: @accent-color !important;
     }

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -135,6 +135,7 @@
     .calendar-hour, 
     .calendar-long-events-header,
     .calendar-column-border,
+    .nav-bar-spacer,
     [style*="border-color: rgb(17, 17, 17);"], 
     [style*="border-bottom: 1px solid rgb(54, 54, 54);"], 
     [style*="border-right: 1px solid rgb(54, 54, 54);"] {

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -123,6 +123,12 @@
       fill: @text !important;
     }
 
+    /* search bar */
+    input, .search-bar {
+      background-color: @mantle !important;
+      color: @text !important;
+    }
+
     .row-selected {
       border-color: @accent-color !important;
       color: @accent-color !important;

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -130,7 +130,14 @@
     }
 
     /* borders */
-    .border-radius, .dialog-buttons, [style*="border-color: rgb(17, 17, 17);"], [style*="border-bottom: 1px solid rgb(54, 54, 54);"] {
+    .border-radius, 
+    .dialog-buttons,
+    .calendar-hour, 
+    .calendar-long-events-header,
+    .calendar-column-border,
+    [style*="border-color: rgb(17, 17, 17);"], 
+    [style*="border-bottom: 1px solid rgb(54, 54, 54);"], 
+    [style*="border-right: 1px solid rgb(54, 54, 54);"] {
       border-color: @surface0 !important;
     }
 
@@ -167,9 +174,23 @@
       color: @crust !important;
     }
       
+    .calendar-current-day-circle, .calendar-selected-day-circle {
+      background-color: @accent-color !important;
+      color: @crust !important;
+    }
+    
     [style*="background: rgb(33, 150, 243);"] {
       background-color: @blue !important;
       border-color: @blue !important;
+    }
+    
+    [style*="background-color: rgba(0, 210, 167, 0.2);"] {
+      background-color: @accent-color !important;
+      opacity: 0.5;
+    }
+
+    .calendar-hour:hover {
+      background-color: @surface0 !important;
     }
 
     .row-selected {

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Tuta Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/tuta
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/tuta
-@version 0.0.9
+@version 0.1.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/tuta/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atuta
 @description Soothing pastel theme for Tuta
@@ -114,12 +114,12 @@
       background-color: @surface1 !important;
     }
 
-    /* logo */
+    /* logo/icons */
     path[style*="fill: #00d2a7;"] {
       fill: @accent-color !important;
     }
 
-    path[style*="fill: #c5c7c7;"] {
+    svg, path[style*="fill: #c5c7c7;"] {
       fill: @text !important;
     }
 

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -172,6 +172,10 @@
     .content-accent-fg {
       color: @accent-color !important;
     }
+
+    .bg-accent-fg {
+      background-color: @accent-color !important;
+    }
       
     .accent-bg {
       background-color: @accent-color !important;

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -129,6 +129,15 @@
       color: @text !important;
     }
 
+    /* borders */
+    .border-radius, .dialog-buttons, [style*="border-color: rgb(17, 17, 17);"] {
+       border-color: @surface0 !important;
+    }
+    
+    hr {
+       background-color: @surface0 !important;
+    }
+
     .row-selected {
       border-color: @accent-color !important;
       color: @accent-color !important;

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -145,6 +145,7 @@
     .buyOptionBox,
     .segmentControl-border,
     .wizard-breadcrumb-line,
+    .icon-segment-control-item,
     [style*="border-color: rgb(17, 17, 17);"], 
     [style*="border-bottom: 1px solid rgb(54, 54, 54);"], 
     [style*="border-right: 1px solid rgb(54, 54, 54);"] {
@@ -209,6 +210,11 @@
 
     .calendar-hour:hover {
       background-color: @surface0 !important;
+    }
+
+    .icon-segment-control-item[active] {
+      background-color: @surface0 !important;
+      opacity: 0.8 !important;
     }
 
     /* checkboxes */

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -138,6 +138,16 @@
        background-color: @surface0 !important;
     }
 
+    /* accent text/background */
+    .content-accent-fg {
+        color: @accent-color !important;
+    }
+      
+    .accent-bg {
+        background-color: @accent-color !important;
+        color: @crust !important;
+    }
+
     .row-selected {
       border-color: @accent-color !important;
       color: @accent-color !important;

--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -123,9 +123,13 @@
       fill: @text !important;
     }
 
-    /* search bar */
+    /* search bar/filters */
     .search-bar {
       background-color: @mantle !important;
+      color: @text !important;
+    }
+    
+    input, label, .content-fg {
       color: @text !important;
     }
 
@@ -137,13 +141,25 @@
     .calendar-column-border,
     .nav-bar-spacer,
     .dialog-header,
+    .table-header-border tr:first-child,
+    .buyOptionBox,
+    .segmentControl-border,
+    .wizard-breadcrumb-line,
     [style*="border-color: rgb(17, 17, 17);"], 
     [style*="border-bottom: 1px solid rgb(54, 54, 54);"], 
     [style*="border-right: 1px solid rgb(54, 54, 54);"] {
       border-color: @surface0 !important;
     }
 
-    div[style*="border-bottom: 2px solid rgb(0, 210, 167)"] {
+    div[style*="border-bottom: 2px solid rgb(0, 210, 167)"],
+    .buyOptionBox.highlighted,
+    .segmentControl-border-active,
+    .wizard-breadcrumb {
+      border-color: @accent-color !important;
+    }
+    
+    .wizard-breadcrumb-active {
+      color: @accent-color !important;
       border-color: @accent-color !important;
     }
     


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes unthemed borders, calendars, login page, text, accent colors and icons

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
