### PR TITLE
fix(pronouns.page): disabled buttons

### DIFF
--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -212,7 +212,7 @@
       background-color: @accent-color !important;
     }
 
-    button:disabled {
+    .btn:disabled {
        background-color: darken(@accent-color, 5%);
        color: @crust;
     }

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -104,7 +104,7 @@
       --bs-btn-active-bg: @accent-color;
       --bs-btn-active-border-color: @accent-color;
       --bs-btn-disabled-color: @accent-color;
-      --bs-btn-disabled-bg: transparent;
+      --bs-btn-disabled-bg: darken(@accent-color, 5%);
       --bs-btn-disabled-border-color: @accent-color;
     }
 
@@ -210,11 +210,6 @@
 
     .btn-square {
       background-color: @accent-color !important;
-    }
-
-    .btn:disabled {
-       background-color: darken(@accent-color, 5%);
-       color: @crust;
     }
 
     /* Inputs */

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -212,8 +212,8 @@
       background-color: @accent-color !important;
     }
 
-    button[disabled*="disabled"] {
-       background-color: darken(@accent-color, 5);
+    button:disabled {
+       background-color: darken(@accent-color, 5%);
        color: @crust;
     }
 

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Pronouns.page Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pronouns.page
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pronouns.page
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pronouns.page/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apronouns.page
 @description Soothing pastel theme for Pronouns.page
@@ -210,6 +210,11 @@
 
     .btn-square {
       background-color: @accent-color !important;
+    }
+
+    button[disabled*="disabled"] {
+       background-color: darken(@accent-color, 5);
+       color: @crust;
     }
 
     /* Inputs */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/a047f625-6d16-4a17-b9e8-4d7726f22d86)
![image](https://github.com/user-attachments/assets/40f780b8-c58a-438a-83c8-3b3893c535ca)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.