### PR TITLE
fix(google-photos): text, search bar and icons

### DIFF
--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Photos Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google-photos
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-photos
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-photos/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-photos
 @description Soothing pastel theme for Google Photos
@@ -75,6 +75,7 @@
     --pkw-on-surface-variant: @subtext0;
     --pkw-on-surface: @text;
     --gm-colortextbutton-ink-color: @blue;
+    --gm3-sys-color-on-surface-variant: @text;
     .gp1Lgf {
       --gm3-card-outlined-hover-outline-color: @surface2;
       --gm3-card-outlined-container-color: @surface0;
@@ -143,6 +144,10 @@
     }
     .LAL5ie .ZAGvjd {
       color: @text;
+      -webkit-text-fill-color: @text;
+    }
+    .cI2tlc .jBmls {
+       box-shadow: none !important;
     }
     .l9dCke,
     .ggIr1e,
@@ -442,6 +447,15 @@
 
     /* settings page */
     /* main text */
+    h1,
+    .fl9QFd,
+    .CZ5Sfb,
+    .mSbCD,
+    .Ecvatc,
+    .C96I0d,
+    .HiceN,
+    .Qizfvf,
+    .bCPWJc,
     .P0eWkf,
     .rvEjke,
     .IGdgBf,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
i would put a before/after in here but it would take way too much space because of how many unthemed stuff there is, so i decided not to 

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
