### PR TITLE
fix(pronouns.page): search bar focus

### DIFF
--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Pronouns.page Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pronouns.page
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pronouns.page
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pronouns.page/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apronouns.page
 @description Soothing pastel theme for Pronouns.page
@@ -217,6 +217,10 @@
     .form-check-input:checked {
       background-color: @accent-color !important;
       border-color: @accent-color !important;
+    }
+
+    .form-control:focus {
+      box-shadow: 0 0 0 .25rem rgba(@accent-color, 0.5);
     }
 
     .form-control {

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -225,7 +225,7 @@
       border-color: @surface0;
 
       &:focus {
-        box-shadow: 0 0 0 .25rem fade(@accent-color, 5%)
+        box-shadow: 0 0 0 .25rem fade(@accent-color, 50%)
      }
     }
 

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -219,14 +219,14 @@
       border-color: @accent-color !important;
     }
 
-    .form-control:focus {
-      box-shadow: 0 0 0 .25rem rgba(@accent-color, 0.5);
-    }
-
     .form-control {
       color: @text;
       background-color: @mantle;
       border-color: @surface0;
+
+      &:focus {
+        box-shadow: 0 0 0 .25rem fade(@accent-color, 5%)
+     }
     }
 
     .dropdown-menu {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
![image](https://github.com/user-attachments/assets/4ade0c01-4781-46b1-a9db-517ea46dde60)
![image](https://github.com/user-attachments/assets/30b2ce20-7ef4-4bf5-bad1-8f206a7771d2)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
