### PR TITLE
fix(porkbun): form control focus

### DIFF
--- a/styles/porkbun/catppuccin.user.css
+++ b/styles/porkbun/catppuccin.user.css
@@ -248,6 +248,10 @@
       background-color: @mantle;
       color: @text;
       border-color: @surface0;
+
+      &:focus {
+         box-shadow: 0 0 8px fade(@accent-color, 50%);
+      }
     }
 
     select:not([multiple]) {

--- a/styles/porkbun/catppuccin.user.css
+++ b/styles/porkbun/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Porkbun Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/porkbun
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/porkbun
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/porkbun/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aporkbun
 @description Soothing pastel theme for Porkbun


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the unthemed form control focus
![image](https://github.com/user-attachments/assets/e3beefdf-5af6-450b-99c9-1038b80318ed)
![image](https://github.com/user-attachments/assets/abd9416b-fa73-4bdd-9ac8-7a843b0e957f)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
