### PR TITLE
fix(google-photos): text and labels

### DIFF
--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -486,7 +486,8 @@
     .Sn08je,
     .Ja4Wfd,
     .tLNx2,
-    .x1vyqd {
+    .x1vyqd,
+    .CqtWH {
       color: @text;
     }
     /* top bar */
@@ -505,7 +506,9 @@
     .rN6Qmb,
     .eT2rxc,
     .EqBDpe,
-    .cuFkEd {
+    .cuFkEd,
+    .hcClrf,
+    .o7Osof .HhLEze {
       color: @subtext0;
     }
     /* "view" button links */

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -487,7 +487,8 @@
     .Ja4Wfd,
     .tLNx2,
     .x1vyqd,
-    .CqtWH {
+    .CqtWH,
+    .wbspQd {
       color: @text;
     }
     /* top bar */
@@ -500,6 +501,11 @@
     /* upload button */
     .s4MBmb {
       color: @text;
+    }
+    /* automatic album label */
+    .ecTDsc {
+      background-color: @accent-color;
+      color: @crust;
     }
     /* subtext */
     .fYwTV,

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Photos Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google-photos
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-photos
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-photos/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-photos
 @description Soothing pastel theme for Google Photos

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -488,7 +488,8 @@
     .tLNx2,
     .x1vyqd,
     .CqtWH,
-    .wbspQd {
+    .wbspQd,
+    .vUbGoc {
       color: @text;
     }
     /* top bar */
@@ -514,7 +515,8 @@
     .EqBDpe,
     .cuFkEd,
     .hcClrf,
-    .o7Osof .HhLEze {
+    .o7Osof .HhLEze,
+    .k4Or1e {
       color: @subtext0;
     }
     /* "view" button links */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
as said in the title
i was going to fix these on my previous PR on google photos but i forgot to

<details>
<summary>before/after</summary>
<img src="https://github.com/user-attachments/assets/71957168-3a6e-4fac-8ad5-0e11dc19f7c7">
<img src="https://github.com/user-attachments/assets/adc8c06e-906a-4037-823b-3d5fe1da9d96">
<hr>
<img src="https://github.com/user-attachments/assets/3a97dba4-1a2e-44f3-add5-ac9eb1e77e42">
<img src="https://github.com/user-attachments/assets/4bf0f5de-2680-45e0-ada5-879452722fc6">
<hr>
<img src="https://github.com/user-attachments/assets/cd1abb31-e336-47f4-8dd1-e9fc0cd3ba42">
<img src="https://github.com/user-attachments/assets/94020ca5-bd48-46c8-a864-396f2fb52f7c">
</details>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
