### PR TITLE
refactor(perplexity): rewrite

### DIFF
--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -70,35 +70,35 @@
       background-color: @mantle !important;
     }
     .bg-\[red\] {
-      background-color: @red;
+      background-color: @red !important;
     }
 
     .bg-alert {
-      background-color: @peach;
+      background-color: @peach !important;
     }
 
     .bg-backdrop-lightbox\/95 {
-      background-color: @crust;
+      background-color: @crust !important;
     }
 
     .bg-backdrop\/70 {
-      background-color: @mantle;
+      background-color: @mantle !important;
     }
 
     .bg-background {
-      background-color: @base;
+      background-color: @base !important;
     }
 
     .bg-background-300 {
-      background-color: @crust;
+      background-color: @crust !important;
     }
 
     .bg-background-super-alt {
-      background-color: @accent-color;
+      background-color: @accent-color !important;
     }
 
     .bg-backgroundDark {
-      background-color: @surface0;
+      background-color: @surface0 !important;
     }
 
     .bg-black,
@@ -107,30 +107,30 @@
     .bg-black\/50,
     .bg-black\/60,
     .bg-black\/80 {
-      background-color: @crust;
+      background-color: @crust !important;
     }
 
     .bg-borderMain {
-      background-color: @surface1;
+      background-color: @surface1 !important;
     }
 
     .bg-idle,
     .bg-idle\/70 {
-      background-color: @surface0;
+      background-color: @surface0 !important;
     }
 
     .bg-offset,
     .bg-offsetDark,
     .bg-offset\/50 {
-      background-color: @mantle;
+      background-color: @mantle !important;
     }
 
     .bg-offsetPlus {
-      background-color: @surface0;
+      background-color: @surface0 !important;
     }
 
     .bg-offsetPlusDark {
-      background-color: @mantle;
+      background-color: @mantle !important;
     }
 
     .bg-super,
@@ -142,214 +142,214 @@
     .bg-superDark\/100,
     .bg-super\/10,
     .bg-super\/100 {
-      background-color: @accent-color;
+      background-color: @accent-color !important;
     }
 
     .bg-textMain {
-      background-color: @overlay0;
+      background-color: @overlay0 !important;
     }
 
     .bg-textMainDark,
     .bg-textMain\/10 {
-      background-color: @text;
+      background-color: @text !important;
     }
 
     .bg-textOff {
-      background-color: @subtext1;
+      background-color: @subtext1 !important;
     }
 
     .bg-textOffDark,
     .bg-textOff\/50 {
-      background-color: @subtext0;
+      background-color: @subtext0 !important;
     }
 
     .bg-white,
     .bg-white\/30,
     .bg-white\/50,
     .bg-white\/80 {
-      background-color: @text;
+      background-color: @text !important;
     }
 
     .text-background {
-      color: @base;
+      color: @base !important;
     }
 
     .text-black {
-      color: @crust;
+      color: @crust !important;
     }
 
     .text-offset {
-      color: @mantle;
+      color: @mantle !important;
     }
 
     .text-orange-400 {
-      color: @peach;
+      color: @peach !important;
     }
 
     .text-super,
     .text-superAlt,
     .text-superDark,
     .text-superDuper {
-      color: @accent-color;
+      color: @accent-color !important;
     }
 
     .text-textMain {
-      color: @text;
+      color: @text !important;
     }
 
     .text-textMainDark,
     .text-textOff {
-      color: @subtext1;
+      color: @subtext1 !important;
     }
 
     .text-textOff\/50 {
-      color: @subtext0;
+      color: @subtext0 !important;
     }
 
     .text-textOffDark {
-      color: @subtext1;
+      color: @subtext1 !important;
     }
 
     .text-textOffDark\/50 {
-      color: @subtext0;
+      color: @subtext0 !important;
     }
 
     .text-white {
-      color: @crust;
+      color: @crust !important;
     }
 
     .text-default {
-      color: @text;
+      color: @text !important;
     }
 
     .text-zinc-700 {
-      color: @subtext1;
+      color: @subtext1 !important;
     }
 
     .stroke-background {
-      stroke: @surface0;
+      stroke: @surface0 !important;
     }
 
     .stroke-super,
     .stroke-superAlt,
     .stroke-superDark {
-      stroke: @accent-color;
+      stroke: @accent-color !important;
     }
 
     .stroke-textMain {
-      stroke: @text;
+      stroke: @text !important;
     }
 
     .stroke-textMainDark,
     .stroke-textOff {
-      stroke: @subtext1;
+      stroke: @subtext1 !important;
     }
 
     .stroke-textOffDark {
-      stroke: @subtext0;
+      stroke: @subtext0 !important;
     }
 
     .fill-backgroundDark {
-      fill: @base;
+      fill: @base !important;
     }
 
     .fill-super,
     .fill-superAlt,
     .fill-superDark {
-      fill: @accent-color;
+      fill: @accent-color !important;
     }
 
     .fill-textMain,
     .fill-textMainDark {
-      fill: @text;
+      fill: @text !important;
     }
 
     .fill-textOff,
     .fill-textOffDark {
-      fill: @subtext1;
+      fill: @subtext1 !important;
     }
 
     .border-\[black\]\/10 {
-      border-color: rgb(#rgbify(@mantle) / 10);
+      border-color: rgb(#rgbify(@mantle) / 10) !important;
     }
 
     .border-background,
     .border-black\/10,
     .border-black\/5 {
-      border-color: @mantle;
+      border-color: @mantle !important;
     }
 
     .border-borderMain {
-      border-color: @surface1;
+      border-color: @surface1 !important;
     }
 
     .border-borderMain\/10,
     .border-borderMain\/50,
     .border-borderMain\/75 {
-      border-color: @surface0;
+      border-color: @surface0 !important;
     }
 
     .border-borderMainDark {
-      border-color: @base;
+      border-color: @base !important;
     }
 
     .border-offsetPlus {
-      border-color: @mantle;
+      border-color: @mantle !important;
     }
 
     .border-super,
     .border-super\/10,
     .border-super\/100 {
-      border-color: @accent-color;
+      border-color: @accent-color !important;
     }
 
     .border-textMain\/0 {
-      border-color: transparent;
+      border-color: transparent !important;
     }
 
     .border-textMainDark {
-      border-color: @mantle;
+      border-color: @mantle !important;
     }
 
     .border-textOff\/50 {
-      border-color: @subtext0;
+      border-color: @subtext0 !important;
     }
 
     .border-b-offset {
-      border-bottom-color: @subtext0;
+      border-bottom-color: @subtext0 !important;
     }
 
     [class*="hover:!bg-superAlt/20"]:hover {
-      background-color: rgb(#rgbify(@accent-color) / 51);
+      background-color: rgb(#rgbify(@accent-color) / 51) !important;
     }
 
     [class*="hover:bg-offset"]:hover {
-      background-color: @surface0;
+      background-color: @surface0 !important;
     }
 
     [class*="hover:bg-offsetPlus"]:hover {
-      background-color: @surface1;
+      background-color: @surface1 !important;
     }
 
     [class*="hover:bg-super"]:hover {
-      background-color: @accent-color;
+      background-color: @accent-color !important;
     }
 
     [class*="hover:text-super"]:hover,
     [class*="hover:text-superAlt"]:hover {
-      color: @accent-color;
+      color: @accent-color !important;
     }
 
     [class*="hover:text-textMain"]:hover {
-      color: @text;
+      color: @text !important;
     }
 
     [class*="hover:text-textOff"]:hover {
-      color: @subtext0;
+      color: @subtext0 !important;
     }
 
     [class*="hover:text-white"]:hover {
-      color: @text;
+      color: @text !important;
     }
 
     .dark\:divide-borderMainDark\/50:where(
@@ -359,19 +359,19 @@
       > :not([hidden])
       ~ :not([hidden]),
     .divide-borderMain\/50 > :not([hidden]) ~ :not([hidden]) {
-      border-color: @surface1;
+      border-color: @surface1 !important;
     }
 
     .focus\:\!border-backgroundDark:focus {
-      border-color: @mantle!important;
+      border-color: @mantle !important;
     }
 
     .focus\:bg-background:focus {
-      background-color: @base;
+      background-color: @base !important;
     }
 
     .focus\:text-super:focus {
-      color: @accent-color;
+      color: @accent-color !important;
     }
 
     *[class*="ring"] {
@@ -383,7 +383,7 @@
 
     /* citations */
     .citation:hover * {
-      color: @crust;
+      color: @crust !important;
     }
     /* switch knob in settings */
     .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]:before {

--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -129,7 +129,11 @@
       background-color: @surface0 !important;
     }
 
-    .bg-offsetPlusDark {
+    .bg-offsetPlusDark,
+    .dark\:\!bg-offsetPlusDark:where(
+        [data-color-scheme="dark"] .dark\:\!bg-offsetPlusDark,
+        [data-color-scheme="dark"] .dark\:\!bg-offsetPlusDark *
+      ) {
       background-color: @mantle !important;
     }
 
@@ -138,11 +142,13 @@
     .bg-superBG,
     .bg-superBGDark,
     .bg-superDark,
-    .bg-superDark\/10,
     .bg-superDark\/100,
-    .bg-super\/10,
     .bg-super\/100 {
       background-color: @accent-color !important;
+    }
+    .bg-super\/10,
+    .bg-superDark\/10 {
+      background-color: fade(@accent-color, 10%) !important;
     }
 
     .bg-textMain {
@@ -270,7 +276,7 @@
     }
 
     .border-\[black\]\/10 {
-      border-color: rgb(#rgbify(@mantle) / 10) !important;
+      border-color: fade(@mantle, 10%) !important;
     }
 
     .border-background,
@@ -278,7 +284,10 @@
     .border-black\/5 {
       border-color: @mantle !important;
     }
-
+    .dark\:border-borderMainDark:where(
+        [data-color-scheme="dark"] .dark\:border-borderMainDark,
+        [data-color-scheme="dark"] .dark\:border-borderMainDark *
+      ),
     .border-borderMain {
       border-color: @surface1 !important;
     }
@@ -318,9 +327,12 @@
     .border-b-offset {
       border-bottom-color: @subtext0 !important;
     }
+    .group:hover [class*="group-hover:text-superDark"] {
+      color: @accent-color !important;
+    }
 
     [class*="hover:!bg-superAlt/20"]:hover {
-      background-color: rgb(#rgbify(@accent-color) / 51) !important;
+      background-color: @accent-color !important;
     }
 
     [class*="hover:bg-offset"]:hover {
@@ -386,8 +398,27 @@
       color: @crust !important;
     }
     /* switch knob in settings */
-    .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]::before {
+    .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]:before {
       background-color: @accent-color !important;
+    }
+    /* switch in main input */
+    #copilot-toggle > div::before {
+      background-color: @overlay1;
+    }
+
+    /* credits on image view */
+    #__next
+      > div:nth-child(26)
+      > div:nth-child(2)
+      > div
+      > div
+      > div.gap-md.mx-md.py-md.border-borderMainDark.flex.h-\[74px\].items-center.justify-between.border-b-2
+      > div.gap-x-md.flex.items-center
+      > a
+      > div
+      > div
+      > div.line-clamp-1.break-all.transition-all.duration-300.white.font-sans.text-sm.text-white.selection\:bg-super\/50.selection\:text-textMain.dark\:selection\:bg-superDuper\/10.dark\:selection\:text-superDark {
+      color: @text !important;
     }
   }
 }

--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -398,7 +398,7 @@
       color: @crust !important;
     }
     /* switch knob in settings */
-    .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]:before {
+    .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]::before {
       background-color: @accent-color !important;
     }
     /* switch in main input */

--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Perplexity Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/perplexity
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/perplexity
-@version 0.0.4
+@version 0.1.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/perplexity/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aperplexity
 @description Soothing pastel theme for Perplexity
@@ -16,10 +16,11 @@
 ==/UserStyle== */
 
 @-moz-document domain('perplexity.ai') {
-  :root:not(.dark) {
+  :root:not([data-color-scheme="dark"]) {
     #catppuccin(@lightFlavor, @accentColor);
   }
-  :root.dark {
+  :root,
+  :root:not([data-color-scheme="light"]) {
     #catppuccin(@darkFlavor, @accentColor);
   }
 
@@ -66,197 +67,327 @@
     }
 
     body {
+      background-color: @mantle !important;
+    }
+    .bg-\[red\] {
+      background-color: @red;
+    }
+
+    .bg-alert {
+      background-color: @peach;
+    }
+
+    .bg-backdrop-lightbox\/95 {
+      background-color: @crust;
+    }
+
+    .bg-backdrop\/70 {
       background-color: @mantle;
+    }
+
+    .bg-background {
+      background-color: @base;
+    }
+
+    .bg-background-300 {
+      background-color: @crust;
+    }
+
+    .bg-background-super-alt {
+      background-color: @accent-color;
+    }
+
+    .bg-backgroundDark {
+      background-color: @surface0;
+    }
+
+    .bg-black,
+    .bg-black\/30,
+    .bg-black\/40,
+    .bg-black\/50,
+    .bg-black\/60,
+    .bg-black\/80 {
+      background-color: @crust;
+    }
+
+    .bg-borderMain {
+      background-color: @surface1;
+    }
+
+    .bg-idle,
+    .bg-idle\/70 {
+      background-color: @surface0;
     }
 
     .bg-offset,
     .bg-offsetDark,
-    :is(:where(.dark) .dark\:\!bg-offsetDark) {
-      background-color: @mantle !important;
-    }
-    .bg-offset:hover,
-    :is(:where(.dark) .md\:dark\:hover\:bg-offsetDark:hover) {
-      background-color: @mantle !important;
+    .bg-offset\/50 {
+      background-color: @mantle;
     }
 
-    :is(:where(.dark) .dark\:md\:hover\:bg-offsetPlusDark:hover) {
-      background-color: @crust !important;
-    }
-
-    .text-textMainDark,
-    :is(:where(.dark) .dark\:text-textMainDark) {
-      color: @text;
-    }
-
-    :is(:where(.dark) .dark\:bg-offsetDark) {
-      background: @surface0;
-    }
-
-    :is(:where(.dark) .dark\:bg-backgroundDark) {
-      background-color: @base;
-    }
-
-    // buttons + toggle circle
-    :is(:where(.dark) .dark\:bg-offsetPlusDark) {
-      background: @surface1;
-    }
-
-    // off button
-    :is(:where(.dark) .dark\:bg-idleDark) {
-      background: @surface1;
-    }
-
-    // borders
-    :is(:where(.dark) .dark\:border-borderMainDark) {
-      border-color: @surface1 !important;
-    }
-
-    // ring border
-    :is(:where(.dark) .dark\:ring-borderMainDark) {
-      --tw-ring-color: rgb(#rgbify(@crust) []/var(--tw-ring-opacity));
-    }
-
-    .border-borderMainDark\/80,
-    .divide-borderMain\/60 {
-      border-color: @surface1;
-    }
-
-    // Input box
-    textarea {
-      caret-color: @accent-color;
-    }
-
-    // Paths in the "search images/videos/ generate image" boxes, and box hover state
-    #ppl-message-scroll-target
-      > div
-      > div:nth-child(2)
-      > div:nth-child(3)
-      > div
-      > div
-      > div.col-span-4
-      > div
-      > div:nth-child(2) {
-      > div:nth-child(1):hover,
-      > div:nth-child(2):hover,
-      > div:nth-child(3) > div > div:hover {
-        background: @surface1 !important;
-      }
-      path {
-        fill: @accent-color;
-      }
+    .bg-offsetPlus {
+      background-color: @surface0;
     }
 
     .bg-offsetPlusDark {
-      background: @surface0 !important;
+      background-color: @mantle;
     }
-    // most hover states
-    *[class*=":hover:dark:bg-offsetPlusDark"]:hover,
-    *[class*="hover:bg-offsetPlus"]:hover,
-    *[class*="md:dark:hover:bg-offsetDark"]:hover {
-      background: @surface0 !important;
+
+    .bg-super,
+    .bg-superAlt,
+    .bg-superBG,
+    .bg-superBGDark,
+    .bg-superDark,
+    .bg-superDark\/10,
+    .bg-superDark\/100,
+    .bg-super\/10,
+    .bg-super\/100 {
+      background-color: @accent-color;
     }
-    // setting menu selector, and others
-    .bg-textMainDark {
+
+    .bg-textMain {
+      background-color: @overlay0;
+    }
+
+    .bg-textMainDark,
+    .bg-textMain\/10 {
       background-color: @text;
     }
 
-    .sc-aXZVg {
-      background: @mantle;
-      path {
-        fill: @text !important;
-      }
+    .bg-textOff {
+      background-color: @subtext1;
     }
 
-    // code block
-    .sc-gEvEer.ePundr,
-    .sc-gEvEer.ePundr > span {
-      background: @surface0 !important;
-      color: @text !important;
+    .bg-textOffDark,
+    .bg-textOff\/50 {
+      background-color: @subtext0;
     }
-    // syntax highlighting
-    span.token[style^="color: rgb(204, 153, 204);"] {
-      color: @pink !important;
+
+    .bg-white,
+    .bg-white\/30,
+    .bg-white\/50,
+    .bg-white\/80 {
+      background-color: @text;
     }
-    span.token[style^="color: rgb(102, 153, 204);"] {
-      color: @blue !important;
+
+    .text-background {
+      color: @base;
     }
-    span.token[style^="color: rgb(153, 153, 153);"] {
-      color: @subtext0 !important;
-    }
-    span.token[style^="color: rgb(204, 204, 204);"] {
-      color: @text !important;
-    }
-    span.token[style^="color: rgb(153, 204, 153);"] {
-      color: @green !important;
-    }
-    span.token[style^="color: rgb(249, 145, 87);"] {
-      color: @peach !important;
-    }
-    span.token.interpolation-punctuation.punctuation {
-      color: @red;
-    }
-    span.token.parameter {
-      color: @mauve;
-    }
-    span.token.punctuation {
-      color: @subtext1;
-    }
-    span.token.operator {
-      color: @teal;
-    }
-    // darker text on light bg
-    :is(:where(.dark) .dark\:bg-textMainDark),
-    :is(:where(.dark) .dark\:text-backgroundDark) {
+
+    .text-black {
       color: @crust;
     }
 
-    // accent color buttons
-    :is(:where(.dark) .dark\:bg-superDark) {
-      background: @accent-color;
+    .text-offset {
+      color: @mantle;
     }
 
-    // subtexts
-    .text-textOff,
-    :is(:where(.dark) .dark\:text-textOffDark) {
-      color: @subtext0;
+    .text-orange-400 {
+      color: @peach;
     }
 
-    // PPLX labs chat
-
-    #__next > main > div > div > div.grow {
-      background: @base;
-    }
-    .dark .dark\:divide-borderMainDark\/80 > :not([hidden]) ~ :not([hidden]) {
-      border-color: @surface1;
-    }
-    .dark .dark\:outline-superDark {
-      outline-color: @accent-color;
-    }
-    .text-super {
+    .text-super,
+    .text-superAlt,
+    .text-superDark,
+    .text-superDuper {
       color: @accent-color;
     }
 
-    // prose
-    .prose,
-    :is(:where(.dark) .dark\:prose-invert) {
-      --tw-prose-body: @text;
-      --tw-prose-headings: @text;
-      --tw-prose-lead: @text;
-      --tw-prose-links: @blue;
-      --tw-prose-bold: @text;
-      --tw-prose-counters: @text;
-      --tw-prose-bullets: @text;
-      --tw-prose-hr: @text;
-      --tw-prose-quotes: @text;
-      --tw-prose-quote-borders: @text;
-      --tw-prose-captions: @text;
-      --tw-prose-kbd: @text;
-      --tw-prose-kbd-shadows: @text;
-      --tw-prose-code: @text;
-      --tw-prose-pre-code: @text;
-      --tw-prose-pre-bg: @base;
-      --tw-prose-th-borders: @text;
-      --tw-prose-td-borders: @text;
+    .text-textMain {
+      color: @text;
+    }
+
+    .text-textMainDark,
+    .text-textOff {
+      color: @subtext1;
+    }
+
+    .text-textOff\/50 {
+      color: @subtext0;
+    }
+
+    .text-textOffDark {
+      color: @subtext1;
+    }
+
+    .text-textOffDark\/50 {
+      color: @subtext0;
+    }
+
+    .text-white {
+      color: @crust;
+    }
+
+    .text-default {
+      color: @text;
+    }
+
+    .text-zinc-700 {
+      color: @subtext1;
+    }
+
+    .stroke-background {
+      stroke: @surface0;
+    }
+
+    .stroke-super,
+    .stroke-superAlt,
+    .stroke-superDark {
+      stroke: @accent-color;
+    }
+
+    .stroke-textMain {
+      stroke: @text;
+    }
+
+    .stroke-textMainDark,
+    .stroke-textOff {
+      stroke: @subtext1;
+    }
+
+    .stroke-textOffDark {
+      stroke: @subtext0;
+    }
+
+    .fill-backgroundDark {
+      fill: @base;
+    }
+
+    .fill-super,
+    .fill-superAlt,
+    .fill-superDark {
+      fill: @accent-color;
+    }
+
+    .fill-textMain,
+    .fill-textMainDark {
+      fill: @text;
+    }
+
+    .fill-textOff,
+    .fill-textOffDark {
+      fill: @subtext1;
+    }
+
+    .border-\[black\]\/10 {
+      border-color: rgb(#rgbify(@mantle) / 10);
+    }
+
+    .border-background,
+    .border-black\/10,
+    .border-black\/5 {
+      border-color: @mantle;
+    }
+
+    .border-borderMain {
+      border-color: @surface1;
+    }
+
+    .border-borderMain\/10,
+    .border-borderMain\/50,
+    .border-borderMain\/75 {
+      border-color: @surface0;
+    }
+
+    .border-borderMainDark {
+      border-color: @base;
+    }
+
+    .border-offsetPlus {
+      border-color: @mantle;
+    }
+
+    .border-super,
+    .border-super\/10,
+    .border-super\/100 {
+      border-color: @accent-color;
+    }
+
+    .border-textMain\/0 {
+      border-color: transparent;
+    }
+
+    .border-textMainDark {
+      border-color: @mantle;
+    }
+
+    .border-textOff\/50 {
+      border-color: @subtext0;
+    }
+
+    .border-b-offset {
+      border-bottom-color: @subtext0;
+    }
+
+    [class*="hover:!bg-superAlt/20"]:hover {
+      background-color: rgb(#rgbify(@accent-color) / 51);
+    }
+
+    [class*="hover:bg-offset"]:hover {
+      background-color: @surface0;
+    }
+
+    [class*="hover:bg-offsetPlus"]:hover {
+      background-color: @surface1;
+    }
+
+    [class*="hover:bg-super"]:hover {
+      background-color: @accent-color;
+    }
+
+    [class*="hover:text-super"]:hover,
+    [class*="hover:text-superAlt"]:hover {
+      color: @accent-color;
+    }
+
+    [class*="hover:text-textMain"]:hover {
+      color: @text;
+    }
+
+    [class*="hover:text-textOff"]:hover {
+      color: @subtext0;
+    }
+
+    [class*="hover:text-white"]:hover {
+      color: @text;
+    }
+
+    .dark\:divide-borderMainDark\/50:where(
+        [data-color-scheme="dark"] .dark\:divide-borderMainDark\/50,
+        [data-color-scheme="dark"] .dark\:divide-borderMainDark\/50 *
+      )
+      > :not([hidden])
+      ~ :not([hidden]),
+    .divide-borderMain\/50 > :not([hidden]) ~ :not([hidden]) {
+      border-color: @surface1;
+    }
+
+    .focus\:\!border-backgroundDark:focus {
+      border-color: @mantle!important;
+    }
+
+    .focus\:bg-background:focus {
+      background-color: @base;
+    }
+
+    .focus\:text-super:focus {
+      color: @accent-color;
+    }
+
+    *[class*="ring"] {
+      --tw-ring-color: @surface2 !important;
+      --tw-ring-offset-color: @mantle !important;
+    }
+
+    /* Additional fixes: */
+
+    /* citations */
+    .citation:hover * {
+      color: @crust;
+    }
+    /* switch knob in settings */
+    .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]:before {
+      background-color: @accent-color !important;
     }
   }
 }

--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -386,7 +386,7 @@
       color: @crust !important;
     }
     /* switch knob in settings */
-    .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]:before {
+    .data-\[state\=checked\]\:before\:\!bg-super[data-state="checked"]::before {
       background-color: @accent-color !important;
     }
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

This fixes nearly everything on this userstyle because it now themes the tailwind utility classes. 

Note:
- please check the `ring` theming and see if it's ok. It looks fine to me as it's used very sparingly but it's not ideal.

Before:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/d19e2f43-f3a4-4afc-aa93-7613586eb650">


After:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/4d7b5989-fe1c-4695-a256-4e511ee732fb">

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
