### PR TITLE
fix(wikiwand): syntax highlighting

### DIFF
--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -101,7 +101,6 @@
     --color-bg: @base;
     --color-text: @text;
     --color-grey: @subtext0;
-    --color-subtle: @subtext0;
     --color-table: @surface0;
     --color-table-border: @surface0;
     --color-link: @accent-color;

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -397,7 +397,7 @@
     a.wl {
       color: @accent-color !important;
     }
-    pre, code {
+    pre, code, samp, kbd {
       border-color: @surface2 !important;
     }
     .summary_footer__Lk6z7 > span:nth-child(1),

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -100,6 +100,7 @@
 
     --color-bg: @base;
     --color-text: @text;
+    --color-subtle: @subtext0;
     --color-grey: @subtext0;
     --color-table: @surface0;
     --color-table-border: @surface0;

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -369,17 +369,23 @@
     a.wl {
       color: @accent-color !important;
     }
-    .kd, .s, .s2 {
+    .kd {
+      color: @mauve !important;
+    }
+    .s, .s2 {
       color: @green !important;
     }
-    .nc, .nf {
+    .nf, .na, .nb {
       color: @blue !important;
     }
-    .na, .nb, .kt {
+    .kt {
       color: @mauve !important;
     }
     .o {
       color: @subtext0 !important;
+    }
+    .nc {
+      color: @yellow !important;
     }
     .wm_content__0bruk .mw-highlight, pre {
       border-color: @surface2 !important;

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -16,6 +16,8 @@
 ==/UserStyle== */
 
 @-moz-document domain("wikiwand.com") {
+   @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
+  
   .root_light__Inhun {
     #catppuccin(@lightFlavor, @accentColor);
   }
@@ -56,6 +58,33 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
+    --ctp-rosewater: @rosewater;
+    --ctp-flamingo: @flamingo;
+    --ctp-pink: @pink;
+    --ctp-mauve: @mauve;
+    --ctp-red: @red;
+    --ctp-maroon: @maroon;
+    --ctp-peach: @peach;
+    --ctp-yellow: @yellow;
+    --ctp-green: @green;
+    --ctp-teal: @teal;
+    --ctp-sky: @sky;
+    --ctp-sapphire: @sapphire;
+    --ctp-blue: @blue;
+    --ctp-lavender: @lavender;
+    --ctp-text: @text;
+    --ctp-subtext1: @subtext1;
+    --ctp-subtext0: @subtext0;
+    --ctp-overlay2: @overlay2;
+    --ctp-overlay1: @overlay1;
+    --ctp-overlay0: @overlay0;
+    --ctp-surface2: @surface2;
+    --ctp-surface1: @surface1;
+    --ctp-surface0: @surface0;
+    --ctp-base: @base;
+    --ctp-mantle: @mantle;
+    --ctp-crust: @crust;
+    
     color-scheme: if(@lookup = latte, light, dark);
 
     ::selection {
@@ -368,24 +397,6 @@
     }
     a.wl {
       color: @accent-color !important;
-    }
-    .kd {
-      color: @mauve !important;
-    }
-    .s, .s2 {
-      color: @green !important;
-    }
-    .nf, .na, .nb {
-      color: @blue !important;
-    }
-    .kt {
-      color: @mauve !important;
-    }
-    .o {
-      color: @subtext0 !important;
-    }
-    .nc {
-      color: @yellow !important;
     }
     .wm_content__0bruk .mw-highlight, pre {
       border-color: @surface2 !important;

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -369,17 +369,14 @@
     a.wl {
       color: @accent-color !important;
     }
-    .kd, .nb {
+    .kd, .s, .s2 {
       color: @green !important;
     }
     .nc, .nf {
       color: @blue !important;
     }
-    .kt, .s, .s2 {
-      color: @red !important;
-    }
-    .na {
-      color: @yellow !important;
+    .na, .nb, .kt {
+      color: @mauve !important;
     }
     .o {
       color: @subtext0 !important;

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikiwand Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikiwand
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikiwand
-@version 1.2.1
+@version 1.2.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikiwand/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikiwand
 @description Soothing pastel theme for Wikiwand
@@ -72,6 +72,7 @@
     --color-bg: @base;
     --color-text: @text;
     --color-grey: @subtext0;
+    --color-subtle: @subtext0;
     --color-table: @surface0;
     --color-table-border: @surface0;
     --color-link: @accent-color;
@@ -367,6 +368,24 @@
     }
     a.wl {
       color: @accent-color !important;
+    }
+    .kd, .nb {
+      color: @green !important;
+    }
+    .nc, .nf {
+      color: @blue !important;
+    }
+    .kt, .s, .s2 {
+      color: @red !important;
+    }
+    .na {
+      color: @yellow !important;
+    }
+    .o {
+      color: @subtext0 !important;
+    }
+    .wm_content__0bruk .mw-highlight, pre {
+      border-color: @surface2 !important;
     }
     .summary_footer__Lk6z7 > span:nth-child(1),
     .input_icon__He3sV,

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -398,7 +398,7 @@
     a.wl {
       color: @accent-color !important;
     }
-    .wm_content__0bruk .mw-highlight, pre {
+    pre, code {
       border-color: @surface2 !important;
     }
     .summary_footer__Lk6z7 > span:nth-child(1),


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes syntax highlighting aswell as some borders too

<details>
<summary>before/after</summary>
<img src="https://github.com/user-attachments/assets/84345f37-6988-4110-9ce7-7fea3d939919">
<hr>
<img src="https://github.com/user-attachments/assets/a9bde0a1-e445-4fbf-be94-50a1ba09c5a7">
</details>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
