### PR TITLE
fix(brave): settings popup 

### DIFF
--- a/styles/brave-search/catppuccin.user.css
+++ b/styles/brave-search/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Brave Search Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/brave-search
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/brave-search
-@version 2.0.1
+@version 2.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/brave-search/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Abrave-search
 @description Soothing pastel theme for Brave Search
@@ -98,6 +98,7 @@
     --color-container-interactive: transparent;
     --color-button-background: @accent-color;
     --color-button-disabled: fade(@surface2, 30%);
+    --color-serp-settings-background: @mantle;
 
     dialog {
       color: @text;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes unthemed settings dropdown in the top right corner

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
