### PR TITLE
fix(libreddit): thumbnail title

### DIFF
--- a/styles/libreddit/catppuccin.user.css
+++ b/styles/libreddit/catppuccin.user.css
@@ -171,6 +171,12 @@ domain("redlib.privacyredirect.com") {
 
     --nsfw: @peach !important;
     --admin: @maroon !important;
+
+    /* thumbnail titles */
+    .post_thumbnail span {
+      background-color: @base;
+      color: @text;
+    }
   }
 }
 

--- a/styles/libreddit/catppuccin.user.css
+++ b/styles/libreddit/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Libreddit/Redlib Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/libreddit
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/libreddit
-@version 2.0.6
+@version 2.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/libreddit/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Alibreddit
 @description Soothing pastel theme for Libreddit and Redlib


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes unthemed thumbnail titles
also this is going to be my last pr before deleting the fork as i got way more stuff to do outside catppuccin
<details>
<summary>before/after</summary>
<img src="https://github.com/user-attachments/assets/e073ec6a-040c-4c29-9453-67b1138af48d">
<img src="https://github.com/user-attachments/assets/b7775123-3ee7-4d2f-8b27-9993d1d315d7">
</details>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
