### PR TITLE
feat(focus): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -534,11 +534,7 @@ userstyles:
     icon: reddit
     color: peach
     readme:
-      app-link:
-        [
-          "https://github.com/libreddit/libreddit",
-          "https://github.com/redlib-org/redlib",
-        ]
+      app-link: ["https://github.com/libreddit/libreddit", "https://github.com/redlib-org/redlib"]
     current-maintainers: []
     past-maintainers: [*unseen-ninja]
   lichess:
@@ -571,7 +567,7 @@ userstyles:
     icon: musicbrainz
     color: peach
     readme:
-      app-link: "https://listenbrainz.org"
+      app-link: 'https://listenbrainz.org'
     current-maintainers: [*00dani]
   mastodon:
     name: Mastodon

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -332,7 +332,7 @@ userstyles:
     categories: [education, productivity]
     color: peach
     readme:
-      app-link: "focusschoolsoftware.com"
+      app-link: "https://focusschoolsoftware.com"
     current-maintainers: [*incognitotgt]
   formative:
     name: Formative

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -329,7 +329,7 @@ userstyles:
     current-maintainers: [*NK308]
   focus:
     name: Focus SIS
-    categories: [userstyle, education, productivity]
+    categories: [education, productivity]
     color: peach
     readme:
       app-link: "focusschoolsoftware.com"

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -136,6 +136,8 @@ collaborators:
     url: https://github.com/jh-devv
   - &stellophiliac
     url: https://github.com/stellophiliac
+  - &incognitotgt
+    url: https//github.com/incognitotgt
 
 userstyles:
   advent-of-code:
@@ -325,6 +327,13 @@ userstyles:
     readme:
       app-link: "https://www.freedesktop.org"
     current-maintainers: [*NK308]
+  focus:
+    name: Focus SIS
+    categories: [userstyle, education, productivity]
+    color: peach
+    readme:
+      app-link: "focusschoolsoftware.com"
+    current-maintainers: [*incognitotgt]
   formative:
     name: Formative
     categories: [education, productivity]
@@ -525,7 +534,11 @@ userstyles:
     icon: reddit
     color: peach
     readme:
-      app-link: ["https://github.com/libreddit/libreddit", "https://github.com/redlib-org/redlib"]
+      app-link:
+        [
+          "https://github.com/libreddit/libreddit",
+          "https://github.com/redlib-org/redlib",
+        ]
     current-maintainers: []
     past-maintainers: [*unseen-ninja]
   lichess:
@@ -558,7 +571,7 @@ userstyles:
     icon: musicbrainz
     color: peach
     readme:
-      app-link: 'https://listenbrainz.org'
+      app-link: "https://listenbrainz.org"
     current-maintainers: [*00dani]
   mastodon:
     name: Mastodon

--- a/styles/brave-search/catppuccin.user.css
+++ b/styles/brave-search/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Brave Search Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/brave-search
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/brave-search
-@version 2.0.1
+@version 2.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/brave-search/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Abrave-search
 @description Soothing pastel theme for Brave Search
@@ -98,6 +98,7 @@
     --color-container-interactive: transparent;
     --color-button-background: @accent-color;
     --color-button-disabled: fade(@surface2, 30%);
+    --color-serp-settings-background: @mantle;
 
     dialog {
       color: @text;

--- a/styles/focus/catppuccin.user.css
+++ b/styles/focus/catppuccin.user.css
@@ -119,18 +119,29 @@
 		.site-header {
 			background: @mantle;
 			color: @text !important;
-		}
-		.swift-box-options {
-			border: @accent-color;
-			.swift-box-option-container {
-				color: @text;
-				border-color: @accent-color;
-				background: @overlay0 !important;
-				.swift-box-option-highlight {
-					background: @overlay1;
+			.help-button {
+				color: @text !important;
+			}
+			.site-session {
+				color: @text !important;
+				.site-session-text-value {
+					color: @text !important;
+				}
+			}
+			.swift-box-text-value, .swift-box-button { color: @text !important }
+			.swift-box-options {
+				border: @accent-color;
+				.swift-box-option-container {
+					color: @text;
+					border-color: @accent-color;
+					background: @overlay0 !important;
+					.swift-box-option-highlight {
+						background: @overlay1;
+					}
 				}
 			}
 		}
+
 		.cell-link {
 			color: @blue;
 		}
@@ -142,19 +153,20 @@
 				color: @base;
 			}
 		}
-		.dataTable-container {
+		table {
 			a {
 				color: @accent-color;
 			}
-			* > table {
-				border-color: @accent-color !important;
-				thead tr {
+			border-color: @accent-color !important;
+			thead th {
+					background: fade(@accent-color, 30) !important;
+				color: @text;
+			}
+			tr {
+				&:nth-child(odd) {
 					background: @surface0;
 				}
-				tr {
-					background: @surface0;
-				}
-				.dataTable-oddRow {
+				&:nth-child(even) {
 					background: fade(@accent-color, 30) !important;
 				}
 			}
@@ -165,15 +177,18 @@
 				color: fade(@accent-color, 90) !important;
 			}
 			.parent-menu-options-container {
-				background: @mantle;
+				background: @crust;
 				.parent-menu-option-title,
 				.parent-menu-sub-options-container {
-					background: @surface0;
+					background: @mantle;
 					color: @accent-color !important;
+				}
+				.parent-menu-sub-options-header {
+					color: @accent-color;
 				}
 				.parent-menu-option-title:hover,
 				.parent-menu-sub-options-container:hover {
-					background: fade(@surface0, 30%) !important;
+					background: fade(@mantle, 30%) !important;
 					color: @accent-color !important;
 				}
 			}
@@ -183,23 +198,54 @@
 				color: @accent-color !important;
 			}
 		}
-		.portal-block-title {
-			background: @accent-color;
-		}
 		.portal-block {
+			color: @text;
 			background: @surface1 !important;
-		}
-		.portal-background-color {
-			background: @accent-color;
-		}
-		.portal-block-tabs {
-			background: @surface1 !important;
-			color: @base;
-			.portal-block-tab {
-				background: @overlay0;
+
+			.portal-block-title {
+				background: @accent-color;
+				color: @base;
 			}
-			.portal-block-tab .active {
-				background: @accent-color !important;
+			.portal-block-subtitle {
+				background: @surface0;
+			}
+			.portal-background-color {
+				background: @accent-color;
+			}
+			.custom-background-color {
+				&:not(.active) {
+					background: @overlay0 !important;
+					color: @text !important;
+				}
+				&:is(.active) {
+					background: @accent-color !important;
+					color: @base !important;
+				}
+			}
+			.portal-block-tabs {
+				background: @surface1 !important;
+				color: @base;
+				.portal-block-tab {
+					&:not(.active) {
+						background: @overlay0 !important;
+						color: @text !important;
+					}
+					&:is(.active) {
+						background: @accent-color;
+						color: @base;
+					}
+				}
+			}
+			.portal-item-header {
+				background: @overlay1;
+				.portal-item-title,
+				.portal-item-subtitle,
+				time {
+					color: @text !important;
+				}
+			}
+			.portal-item-content {
+				background: @overlay0;
 			}
 		}
 	}

--- a/styles/focus/catppuccin.user.css
+++ b/styles/focus/catppuccin.user.css
@@ -65,7 +65,6 @@
 				a {
 					color: @blue;
 				}
-				border-color: @accent-color !important;
 				thead th {
 					background: fade(@accent-color, 30%) !important;
 					color: @text;
@@ -197,7 +196,15 @@
 				}
 			}
 		}
-
+		.Box {
+			.BoxHeading {
+				color: @base !important;
+				background: @accent-color !important;
+			}
+			.BoxContent {
+				background: @base !important;
+			}
+		}
 		.cell-link {
 			color: @blue;
 		}
@@ -356,7 +363,7 @@
 				color: @text !important;
 			}
 			* {
-				border-color: @accent-color !important;
+				border-color: @surface0 !important;
 			}
 		}
 		.layout-column-button-group {
@@ -366,30 +373,28 @@
 				}
 			}
 		}
-		#stu_list_preference {
-			.poptable-container {
-				table {
-					background-color: @base;
-					border-color: @surface0
+		.poptable-container {
+			table {
+				background-color: @base;
+				border-color: @surface0
+			}
+			.custom-border-color {
+				border-color: @surface0 !important
+			}
+			.custom-background-color {
+				background: @accent-color !important;
+				.TabContents {
+					color: @base !important;
 				}
-				.custom-border-color {
-					border-color: @surface0 !important
-				}
-				.custom-background-color {
-					background: @accent-color !important;
-					.TabContents {
-						color: @base !important;
-					}
-				}
-				font {
-					color: @accent-color !important
-				}
-				background-color: @base !important;
-				/* another fun hack to get it to style properly!!! */
-				.disallow-options-container {
-					outline: 50rem solid;
-					outline-color: @base;
-				}
+			}
+			font {
+				color: @accent-color !important
+			}
+			background-color: @base !important;
+			/* another fun hack to get it to style properly!!! */
+			.disallow-options-container {
+				outline: 50rem solid;
+				outline-color: @base;
 			}
 		}
 		.WhiteDrawHeader,
@@ -405,8 +410,25 @@
 				color: @base;
 			}
 		}
-		.student_schedule {
-			background: @surface0;
+		.listoutputbox {
+			color: @text !important;
+			background: @base !important;
+			.custom-background-color {
+				background: @accent-color !important;
+				.TabContents {
+					color: @base !important;
+				}
+			}
+			.lo_container {
+				* {
+					.colored-tables();
+				}
+				.left_container,
+				.center {
+					background: @base !important;
+				}
+				background: @base !important;
+			}
 		}
 		.requestStatus {
 			background-color: @surface0;
@@ -417,122 +439,10 @@
 
 /* prettier-ignore */
 @catppuccin: {
-	@latte: {
-		@rosewater: #dc8a78;
-		@flamingo: #dd7878;
-		@pink: #ea76cb;
-		@mauve: #8839ef;
-		@red: #d20f39;
-		@maroon: #e64553;
-		@peach: #fe640b;
-		@yellow: #df8e1d;
-		@green: #40a02b;
-		@teal: #179299;
-		@sky: #04a5e5;
-		@sapphire: #209fb5;
-		@blue: #1e66f5;
-		@lavender: #7287fd;
-		@text: #4c4f69;
-		@subtext1: #5c5f77;
-		@subtext0: #6c6f85;
-		@overlay2: #7c7f93;
-		@overlay1: #8c8fa1;
-		@overlay0: #9ca0b0;
-		@surface2: #acb0be;
-		@surface1: #bcc0cc;
-		@surface0: #ccd0da;
-		@base: #eff1f5;
-		@mantle: #e6e9ef;
-		@crust: #dce0e8;
-	}
-	;
-	@frappe: {
-		@rosewater: #f2d5cf;
-		@flamingo: #eebebe;
-		@pink: #f4b8e4;
-		@mauve: #ca9ee6;
-		@red: #e78284;
-		@maroon: #ea999c;
-		@peach: #ef9f76;
-		@yellow: #e5c890;
-		@green: #a6d189;
-		@teal: #81c8be;
-		@sky: #99d1db;
-		@sapphire: #85c1dc;
-		@blue: #8caaee;
-		@lavender: #babbf1;
-		@text: #c6d0f5;
-		@subtext1: #b5bfe2;
-		@subtext0: #a5adce;
-		@overlay2: #949cbb;
-		@overlay1: #838ba7;
-		@overlay0: #737994;
-		@surface2: #626880;
-		@surface1: #51576d;
-		@surface0: #414559;
-		@base: #303446;
-		@mantle: #292c3c;
-		@crust: #232634;
-	}
-	;
-	@macchiato: {
-		@rosewater: #f4dbd6;
-		@flamingo: #f0c6c6;
-		@pink: #f5bde6;
-		@mauve: #c6a0f6;
-		@red: #ed8796;
-		@maroon: #ee99a0;
-		@peach: #f5a97f;
-		@yellow: #eed49f;
-		@green: #a6da95;
-		@teal: #8bd5ca;
-		@sky: #91d7e3;
-		@sapphire: #7dc4e4;
-		@blue: #8aadf4;
-		@lavender: #b7bdf8;
-		@text: #cad3f5;
-		@subtext1: #b8c0e0;
-		@subtext0: #a5adcb;
-		@overlay2: #939ab7;
-		@overlay1: #8087a2;
-		@overlay0: #6e738d;
-		@surface2: #5b6078;
-		@surface1: #494d64;
-		@surface0: #363a4f;
-		@base: #24273a;
-		@mantle: #1e2030;
-		@crust: #181926;
-	}
-	;
-	@mocha: {
-		@rosewater: #f5e0dc;
-		@flamingo: #f2cdcd;
-		@pink: #f5c2e7;
-		@mauve: #cba6f7;
-		@red: #f38ba8;
-		@maroon: #eba0ac;
-		@peach: #fab387;
-		@yellow: #f9e2af;
-		@green: #a6e3a1;
-		@teal: #94e2d5;
-		@sky: #89dceb;
-		@sapphire: #74c7ec;
-		@blue: #89b4fa;
-		@lavender: #b4befe;
-		@text: #cdd6f4;
-		@subtext1: #bac2de;
-		@subtext0: #a6adc8;
-		@overlay2: #9399b2;
-		@overlay1: #7f849c;
-		@overlay0: #6c7086;
-		@surface2: #585b70;
-		@surface1: #45475a;
-		@surface0: #313244;
-		@base: #1e1e2e;
-		@mantle: #181825;
-		@crust: #11111b;
-	}
-	;
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
 }
 
 // vim:ft=less

--- a/styles/focus/catppuccin.user.css
+++ b/styles/focus/catppuccin.user.css
@@ -60,6 +60,32 @@
 		::selection {
 			background-color: fade(@accent-color, 30%);
 		}
+		.colored-tables() {
+			table {
+				a {
+					color: @blue;
+				}
+				border-color: @accent-color !important;
+				thead th {
+					background: fade(@accent-color, 30%) !important;
+					color: @text;
+				}
+				tr {
+					&:nth-child(odd) {
+						background: @surface0;
+						a {
+							color: @blue;
+						}
+					}
+					&:nth-child(even) {
+						background: fade(@accent-color, 30%) !important;
+						a {
+							color: @blue;
+						}
+					}
+				}
+			}
+		}
 		.violet {
 			background: @mauve !important;
 		}
@@ -84,6 +110,18 @@
 		.blue {
 			background: @blue !important;
 		}
+		.primary {
+			background: @accent-color !important;
+		}
+		.grey {
+			background: @surface0 !important;
+		}
+		.calculated-grade {
+			color: @blue;
+		}
+		.button {
+			background: @accent-color;
+		}
 		input,
 		textarea {
 			&::placeholder {
@@ -93,6 +131,33 @@
 		a {
 			color: @blue;
 		}
+		.swift-box-text-value,
+		.swift-box-button {
+			color: @text !important
+		}
+		.swift-box-options {
+			border-color: @accent-color
+		}
+		.swift-box-option-container {
+			color: @text;
+			border-color: @accent-color;
+			background: @overlay0 !important;
+			.swift-box-option-highlight {
+				background: @overlay1;
+				color: @text;
+			}
+			.swift-box-option-filter-container {
+				input {
+					background: @mantle !important;
+					border-color: @crust;
+				}
+				.swift-box-option-filter-icon {
+					color: @text !important;
+				}
+				background: @overlay0;
+				border-color: @accent-color;
+			}
+		}
 		body,
 		.portal::before,
 		.portal,
@@ -101,13 +166,15 @@
 		.site-container,
 		.sis-package,
 		.document-ready,
-		.site-content-container {
+		.site-content-container,
+		{
 			background: @base !important;
 			color: @text;
 		}
 		/* fun hack to get the homepage background to style properly */
 		.portal::before {
-			outline: 30rem solid @base;
+			outline: 30rem solid;
+			outline-color: @base;
 			outline-offset: -20rem !important;
 		}
 		#userwayAccessibilityIcon {
@@ -128,18 +195,6 @@
 					color: @text !important;
 				}
 			}
-			.swift-box-text-value, .swift-box-button { color: @text !important }
-			.swift-box-options {
-				border: @accent-color;
-				.swift-box-option-container {
-					color: @text;
-					border-color: @accent-color;
-					background: @overlay0 !important;
-					.swift-box-option-highlight {
-						background: @overlay1;
-					}
-				}
-			}
 		}
 
 		.cell-link {
@@ -152,44 +207,55 @@
 				background: @accent-color;
 				color: @base;
 			}
-		}
-		table {
-			a {
-				color: @accent-color;
+			table,
+			th,
+			td {
+				border-color: @text!important;
 			}
-			border-color: @accent-color !important;
-			thead th {
-					background: fade(@accent-color, 30) !important;
+		}
+		.menu-container {
+			background: @surface0;
+			.category-text {
 				color: @text;
 			}
-			tr {
-				&:nth-child(odd) {
-					background: @surface0;
-				}
-				&:nth-child(even) {
-					background: fade(@accent-color, 30) !important;
+			.vertical-category-icon > b {
+				color: @base;
+			}
+		}
+		.menu {
+			background: @mantle;
+			.link-text {
+				color: @text !important;
+				&:hover {
+					color: @subtext0 !important;
 				}
 			}
 		}
 		.parent-menu-container {
 			border-color: @overlay0 !important;
 			.fa {
-				color: fade(@accent-color, 90) !important;
+				color: fade(@accent-color, 90%) !important;
 			}
 			.parent-menu-options-container {
 				background: @crust;
 				.parent-menu-option-title,
-				.parent-menu-sub-options-container {
+				.parent-menu-sub-options-header {
 					background: @mantle;
 					color: @accent-color !important;
 				}
-				.parent-menu-sub-options-header {
-					color: @accent-color;
-				}
 				.parent-menu-option-title:hover,
-				.parent-menu-sub-options-container:hover {
+				.parent-menu-sub-options-header:hover {
 					background: fade(@mantle, 30%) !important;
 					color: @accent-color !important;
+				}
+			}
+			.parent-menu-sub-options {
+				background: fade(@mantle, 50%);
+				.parent-menu-form-option-title {
+					color: @accent-color !important;
+					&:hover {
+						color: fade(@accent-color, 75%) !important;
+					}
 				}
 			}
 			.parent-menu-footer,
@@ -199,6 +265,7 @@
 			}
 		}
 		.portal-block {
+			.colored-tables();
 			color: @text;
 			background: @surface1 !important;
 
@@ -247,6 +314,69 @@
 			.portal-item-content {
 				background: @overlay0;
 			}
+		}
+		.category-header {
+			color: @text;
+			background: @base !important;
+		}
+		.filter-container i {
+			color: @text !important;
+		}
+		.fields-column-expander {
+			background: @accent-color !important;
+			color: @base !important;
+			border-color: @overlay0 !important;
+		}
+		.ui.attached.segment {
+			border-color: @overlay0 !important;
+		}
+		.fields-column .info-segment {
+			* {
+				color: @text !important;
+			}
+			background: @surface0 !important;
+			.category-header > * {
+				color: @text !important;
+			}
+			.info-segment {
+				border-color: @surface0 !important;
+			}
+			.field-container {
+				outline-color: @base
+			}
+			.field-header {
+				background: @surface1;
+			}
+		}
+		.dataTable-container {
+			.colored-tables();
+			th,
+			td {
+				color: @text !important;
+			}
+		}
+		.layout-column-button-group {
+			button {
+				&:not(.grey) {
+					color: @base;
+				}
+			}
+		}
+		.WhiteDrawHeader,
+		.GrayDrawHeader,
+		.DarkGradientBG {
+			background: @base;
+			border-color: @surface0;
+			font {
+				color: @text !important
+			}
+		}
+		.student_schedule {
+			background: @surface0;
+		}
+		.requestStatus {
+			background-color: @surface0;
+			border-color: @accent-color;
 		}
 	}
 }

--- a/styles/focus/catppuccin.user.css
+++ b/styles/focus/catppuccin.user.css
@@ -72,7 +72,7 @@
 				}
 				tr {
 					&:nth-child(odd) {
-						background: @surface0;
+						background: @surface0 !important;
 						a {
 							color: @blue;
 						}
@@ -116,8 +116,9 @@
 		.grey {
 			background: @surface0 !important;
 		}
+
 		.calculated-grade {
-			color: @blue;
+			color: @blue !important;
 		}
 		.button {
 			background: @accent-color;
@@ -167,7 +168,7 @@
 		.sis-package,
 		.document-ready,
 		.site-content-container,
-		{
+		.form {
 			background: @base !important;
 			color: @text;
 		}
@@ -354,11 +355,40 @@
 			td {
 				color: @text !important;
 			}
+			* {
+				border-color: @accent-color !important;
+			}
 		}
 		.layout-column-button-group {
 			button {
 				&:not(.grey) {
 					color: @base;
+				}
+			}
+		}
+		#stu_list_preference {
+			.poptable-container {
+				table {
+					background-color: @base;
+					border-color: @surface0
+				}
+				.custom-border-color {
+					border-color: @surface0 !important
+				}
+				.custom-background-color {
+					background: @accent-color !important;
+					.TabContents {
+						color: @base !important;
+					}
+				}
+				font {
+					color: @accent-color !important
+				}
+				background-color: @base !important;
+				/* another fun hack to get it to style properly!!! */
+				.disallow-options-container {
+					outline: 50rem solid;
+					outline-color: @base;
 				}
 			}
 		}
@@ -369,6 +399,10 @@
 			border-color: @surface0;
 			font {
 				color: @text !important
+			}
+			#top_submit {
+				background: @accent-color;
+				color: @base;
 			}
 		}
 		.student_schedule {

--- a/styles/focus/catppuccin.user.css
+++ b/styles/focus/catppuccin.user.css
@@ -15,426 +15,419 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 @-moz-document regexp('^(https?:\\/\\/)?([a-zA-Z0-9-]+\\.)+focusschoolsoftware\\.com(\\/.*)?$') {
-	@media (prefers-color-scheme: light) {
-		:root {
-			#catppuccin(@lightFlavor, @accentColor);
-		}
-	}
-	@media (prefers-color-scheme: dark) {
-		:root {
-			#catppuccin(@darkFlavor, @accentColor);
-		}
-	}
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
 
-	#catppuccin(@lookup, @accent) {
-		@rosewater: @catppuccin[@@lookup][@rosewater];
-		@flamingo: @catppuccin[@@lookup][@flamingo];
-		@pink: @catppuccin[@@lookup][@pink];
-		@mauve: @catppuccin[@@lookup][@mauve];
-		@red: @catppuccin[@@lookup][@red];
-		@maroon: @catppuccin[@@lookup][@maroon];
-		@peach: @catppuccin[@@lookup][@peach];
-		@yellow: @catppuccin[@@lookup][@yellow];
-		@green: @catppuccin[@@lookup][@green];
-		@teal: @catppuccin[@@lookup][@teal];
-		@sky: @catppuccin[@@lookup][@sky];
-		@sapphire: @catppuccin[@@lookup][@sapphire];
-		@blue: @catppuccin[@@lookup][@blue];
-		@lavender: @catppuccin[@@lookup][@lavender];
-		@text: @catppuccin[@@lookup][@text];
-		@subtext1: @catppuccin[@@lookup][@subtext1];
-		@subtext0: @catppuccin[@@lookup][@subtext0];
-		@overlay2: @catppuccin[@@lookup][@overlay2];
-		@overlay1: @catppuccin[@@lookup][@overlay1];
-		@overlay0: @catppuccin[@@lookup][@overlay0];
-		@surface2: @catppuccin[@@lookup][@surface2];
-		@surface1: @catppuccin[@@lookup][@surface1];
-		@surface0: @catppuccin[@@lookup][@surface0];
-		@base: @catppuccin[@@lookup][@base];
-		@mantle: @catppuccin[@@lookup][@mantle];
-		@crust: @catppuccin[@@lookup][@crust];
-		@accent-color: @catppuccin[@@lookup][@@accent];
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
 
-		color-scheme: if(@lookup =latte, light, dark);
+    color-scheme: if(@lookup =latte, light, dark);
 
-		::selection {
-			background-color: fade(@accent-color, 30%);
-		}
-		.colored-tables() {
-			table {
-				a {
-					color: @blue;
-				}
-				thead th {
-					background: fade(@accent-color, 30%) !important;
-					color: @text;
-				}
-				tr {
-					&:nth-child(odd) {
-						background: @surface0 !important;
-						a {
-							color: @blue;
-						}
-					}
-					&:nth-child(even) {
-						background: fade(@accent-color, 30%) !important;
-						a {
-							color: @blue;
-						}
-					}
-				}
-			}
-		}
-		.violet {
-			background: @mauve !important;
-		}
-		.purple {
-			background: @lavender !important;
-		}
-		.teal {
-			background: @teal !important;
-		}
-		.olive {
-			background: @yellow !important;
-		}
-		.green {
-			background: @green !important;
-		}
-		.pink {
-			background: @pink !important;
-		}
-		.red {
-			background: @red !important;
-		}
-		.blue {
-			background: @blue !important;
-		}
-		.primary {
-			background: @accent-color !important;
-		}
-		.grey {
-			background: @surface0 !important;
-		}
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+    .colored-tables() {
+      table {
+        a {
+          color: @blue;
+        }
+        thead th {
+          background: fade(@accent-color, 30%) !important;
+          color: @text;
+        }
+        tr {
+          &:nth-child(odd) {
+            background: @surface0 !important;
+            a {
+              color: @blue;
+            }
+          }
+          &:nth-child(even) {
+            background: fade(@accent-color, 30%) !important;
+            a {
+              color: @blue;
+            }
+          }
+        }
+      }
+    }
+    .violet {
+      background: @mauve !important;
+    }
+    .purple {
+      background: @lavender !important;
+    }
+    .teal {
+      background: @teal !important;
+    }
+    .olive {
+      background: @yellow !important;
+    }
+    .green {
+      background: @green !important;
+    }
+    .pink {
+      background: @pink !important;
+    }
+    .red {
+      background: @red !important;
+    }
+    .blue {
+      background: @blue !important;
+    }
+    .primary {
+      background: @accent-color !important;
+    }
+    .grey {
+      background: @surface0 !important;
+    }
 
-		.calculated-grade {
-			color: @blue !important;
-		}
-		.button {
-			background: @accent-color;
-		}
-		input,
-		textarea {
-			&::placeholder {
-				color: @subtext0 !important;
-			}
-		}
-		a {
-			color: @blue;
-		}
-		.swift-box-text-value,
-		.swift-box-button {
-			color: @text !important
-		}
-		.swift-box-options {
-			border-color: @accent-color
-		}
-		.swift-box-option-container {
-			color: @text;
-			border-color: @accent-color;
-			background: @overlay0 !important;
-			.swift-box-option-highlight {
-				background: @overlay1;
-				color: @text;
-			}
-			.swift-box-option-filter-container {
-				input {
-					background: @mantle !important;
-					border-color: @crust;
-				}
-				.swift-box-option-filter-icon {
-					color: @text !important;
-				}
-				background: @overlay0;
-				border-color: @accent-color;
-			}
-		}
-		body,
-		.portal::before,
-		.portal,
-		.content-container,
-		.site-middle,
-		.site-container,
-		.sis-package,
-		.document-ready,
-		.site-content-container,
-		.form {
-			background: @base !important;
-			color: @text;
-		}
-		/* fun hack to get the homepage background to style properly */
-		.portal::before {
-			outline: 30rem solid;
-			outline-color: @base;
-			outline-offset: -20rem !important;
-		}
-		#userwayAccessibilityIcon {
-			img {
-				background-color: @blue !important;
-				border-radius: 50%
-			}
-		}
-		.site-header {
-			background: @mantle;
-			color: @text !important;
-			.help-button {
-				color: @text !important;
-			}
-			.site-session {
-				color: @text !important;
-				.site-session-text-value {
-					color: @text !important;
-				}
-			}
-		}
-		.Box {
-			.BoxHeading {
-				color: @base !important;
-				background: @accent-color !important;
-			}
-			.BoxContent {
-				background: @base !important;
-			}
-		}
-		.cell-link {
-			color: @blue;
-		}
-		.stat_table {
-			background: @surface0;
-			border-color: @accent-color;
-			.stats_header {
-				background: @accent-color;
-				color: @base;
-			}
-			table,
-			th,
-			td {
-				border-color: @text!important;
-			}
-		}
-		.menu-container {
-			background: @surface0;
-			.category-text {
-				color: @text;
-			}
-			.vertical-category-icon > b {
-				color: @base;
-			}
-		}
-		.menu {
-			background: @mantle;
-			.link-text {
-				color: @text !important;
-				&:hover {
-					color: @subtext0 !important;
-				}
-			}
-		}
-		.parent-menu-container {
-			border-color: @overlay0 !important;
-			.fa {
-				color: fade(@accent-color, 90%) !important;
-			}
-			.parent-menu-options-container {
-				background: @crust;
-				.parent-menu-option-title,
-				.parent-menu-sub-options-header {
-					background: @mantle;
-					color: @accent-color !important;
-				}
-				.parent-menu-option-title:hover,
-				.parent-menu-sub-options-header:hover {
-					background: fade(@mantle, 30%) !important;
-					color: @accent-color !important;
-				}
-			}
-			.parent-menu-sub-options {
-				background: fade(@mantle, 50%);
-				.parent-menu-form-option-title {
-					color: @accent-color !important;
-					&:hover {
-						color: fade(@accent-color, 75%) !important;
-					}
-				}
-			}
-			.parent-menu-footer,
-			.parent-menu-footer-button {
-				background: @surface0;
-				color: @accent-color !important;
-			}
-		}
-		.portal-block {
-			.colored-tables();
-			color: @text;
-			background: @surface1 !important;
+    .calculated-grade {
+      color: @blue !important;
+    }
+    .button {
+      background: @accent-color;
+    }
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+    a {
+      color: @blue;
+    }
+    .swift-box-text-value,
+    .swift-box-button {
+      color: @text !important;
+    }
+    .swift-box-options {
+      border-color: @accent-color;
+    }
+    .swift-box-option-container {
+      color: @text;
+      border-color: @accent-color;
+      background: @overlay0 !important;
+      .swift-box-option-highlight {
+        background: @overlay1;
+        color: @text;
+      }
+      .swift-box-option-filter-container {
+        input {
+          background: @mantle !important;
+          border-color: @crust;
+        }
+        .swift-box-option-filter-icon {
+          color: @text !important;
+        }
+        background: @overlay0;
+        border-color: @accent-color;
+      }
+    }
+    body,
+    .portal::before,
+    .portal,
+    .content-container,
+    .site-middle,
+    .site-container,
+    .sis-package,
+    .document-ready,
+    .site-content-container,
+    .form {
+      background: @base !important;
+      color: @text;
+    }
+    /* fun hack to get the homepage background to style properly */
+    .portal::before {
+      outline: 30rem solid;
+      outline-color: @base;
+      outline-offset: -20rem !important;
+    }
+    #userwayAccessibilityIcon {
+      img {
+        background-color: @blue !important;
+        border-radius: 50%;
+      }
+    }
+    .site-header {
+      background: @mantle;
+      color: @text !important;
+      .help-button {
+        color: @text !important;
+      }
+      .site-session {
+        color: @text !important;
+        .site-session-text-value {
+          color: @text !important;
+        }
+      }
+    }
+    .Box {
+      .BoxHeading {
+        color: @base !important;
+        background: @accent-color !important;
+      }
+      .BoxContent {
+        background: @base !important;
+      }
+    }
+    .cell-link {
+      color: @blue;
+    }
+    .stat_table {
+      background: @surface0;
+      border-color: @accent-color;
+      .stats_header {
+        background: @accent-color;
+        color: @base;
+      }
+      table,
+      th,
+      td {
+        border-color: @text!important;
+      }
+    }
+    .menu-container {
+      background: @surface0;
+      .category-text {
+        color: @text;
+      }
+      .vertical-category-icon > b {
+        color: @base;
+      }
+    }
+    .menu {
+      background: @mantle;
+      .link-text {
+        color: @text !important;
+        &:hover {
+          color: @subtext0 !important;
+        }
+      }
+    }
+    .parent-menu-container {
+      border-color: @overlay0 !important;
+      .fa {
+        color: fade(@accent-color, 90%) !important;
+      }
+      .parent-menu-options-container {
+        background: @crust;
+        .parent-menu-option-title,
+        .parent-menu-sub-options-header {
+          background: @mantle;
+          color: @accent-color !important;
+        }
+        .parent-menu-option-title:hover,
+        .parent-menu-sub-options-header:hover {
+          background: fade(@mantle, 30%) !important;
+          color: @accent-color !important;
+        }
+      }
+      .parent-menu-sub-options {
+        background: fade(@mantle, 50%);
+        .parent-menu-form-option-title {
+          color: @accent-color !important;
+          &:hover {
+            color: fade(@accent-color, 75%) !important;
+          }
+        }
+      }
+      .parent-menu-footer,
+      .parent-menu-footer-button {
+        background: @surface0;
+        color: @accent-color !important;
+      }
+    }
+    .portal-block {
+      .colored-tables();
+      color: @text;
+      background: @surface1 !important;
 
-			.portal-block-title {
-				background: @accent-color;
-				color: @base;
-			}
-			.portal-block-subtitle {
-				background: @surface0;
-			}
-			.portal-background-color {
-				background: @accent-color;
-			}
-			.custom-background-color {
-				&:not(.active) {
-					background: @overlay0 !important;
-					color: @text !important;
-				}
-				&:is(.active) {
-					background: @accent-color !important;
-					color: @base !important;
-				}
-			}
-			.portal-block-tabs {
-				background: @surface1 !important;
-				color: @base;
-				.portal-block-tab {
-					&:not(.active) {
-						background: @overlay0 !important;
-						color: @text !important;
-					}
-					&:is(.active) {
-						background: @accent-color;
-						color: @base;
-					}
-				}
-			}
-			.portal-item-header {
-				background: @overlay1;
-				.portal-item-title,
-				.portal-item-subtitle,
-				time {
-					color: @text !important;
-				}
-			}
-			.portal-item-content {
-				background: @overlay0;
-			}
-		}
-		.category-header {
-			color: @text;
-			background: @base !important;
-		}
-		.filter-container i {
-			color: @text !important;
-		}
-		.fields-column-expander {
-			background: @accent-color !important;
-			color: @base !important;
-			border-color: @overlay0 !important;
-		}
-		.ui.attached.segment {
-			border-color: @overlay0 !important;
-		}
-		.fields-column .info-segment {
-			* {
-				color: @text !important;
-			}
-			background: @surface0 !important;
-			.category-header > * {
-				color: @text !important;
-			}
-			.info-segment {
-				border-color: @surface0 !important;
-			}
-			.field-container {
-				outline-color: @base
-			}
-			.field-header {
-				background: @surface1;
-			}
-		}
-		.dataTable-container {
-			.colored-tables();
-			th,
-			td {
-				color: @text !important;
-			}
-			* {
-				border-color: @surface0 !important;
-			}
-		}
-		.layout-column-button-group {
-			button {
-				&:not(.grey) {
-					color: @base;
-				}
-			}
-		}
-		.poptable-container {
-			table {
-				background-color: @base;
-				border-color: @surface0
-			}
-			.custom-border-color {
-				border-color: @surface0 !important
-			}
-			.custom-background-color {
-				background: @accent-color !important;
-				.TabContents {
-					color: @base !important;
-				}
-			}
-			font {
-				color: @accent-color !important
-			}
-			background-color: @base !important;
-			/* another fun hack to get it to style properly!!! */
-			.disallow-options-container {
-				outline: 50rem solid;
-				outline-color: @base;
-			}
-		}
-		.WhiteDrawHeader,
-		.GrayDrawHeader,
-		.DarkGradientBG {
-			background: @base;
-			border-color: @surface0;
-			font {
-				color: @text !important
-			}
-			#top_submit {
-				background: @accent-color;
-				color: @base;
-			}
-		}
-		.listoutputbox {
-			color: @text !important;
-			background: @base !important;
-			.custom-background-color {
-				background: @accent-color !important;
-				.TabContents {
-					color: @base !important;
-				}
-			}
-			.lo_container {
-				* {
-					.colored-tables();
-				}
-				.left_container,
-				.center {
-					background: @base !important;
-				}
-				background: @base !important;
-			}
-		}
-		.requestStatus {
-			background-color: @surface0;
-			border-color: @accent-color;
-		}
-	}
+      .portal-block-title {
+        background: @accent-color;
+        color: @base;
+      }
+      .portal-block-subtitle {
+        background: @surface0;
+      }
+      .portal-background-color {
+        background: @accent-color;
+      }
+      .custom-background-color {
+        &:not(.active) {
+          background: @overlay0 !important;
+          color: @text !important;
+        }
+        &:is(.active) {
+          background: @accent-color !important;
+          color: @base !important;
+        }
+      }
+      .portal-block-tabs {
+        background: @surface1 !important;
+        color: @base;
+        .portal-block-tab {
+          &:not(.active) {
+            background: @overlay0 !important;
+            color: @text !important;
+          }
+          &:is(.active) {
+            background: @accent-color;
+            color: @base;
+          }
+        }
+      }
+      .portal-item-header {
+        background: @overlay1;
+        .portal-item-title,
+        .portal-item-subtitle,
+        time {
+          color: @text !important;
+        }
+      }
+      .portal-item-content {
+        background: @overlay0;
+      }
+    }
+    .category-header {
+      color: @text;
+      background: @base !important;
+    }
+    .filter-container i {
+      color: @text !important;
+    }
+    .fields-column-expander {
+      background: @accent-color !important;
+      color: @base !important;
+      border-color: @overlay0 !important;
+    }
+    .ui.attached.segment {
+      border-color: @overlay0 !important;
+    }
+    .fields-column .info-segment {
+      * {
+        color: @text !important;
+      }
+      background: @surface0 !important;
+      .category-header > * {
+        color: @text !important;
+      }
+      .info-segment {
+        border-color: @surface0 !important;
+      }
+      .field-container {
+        outline-color: @base;
+      }
+      .field-header {
+        background: @surface1;
+      }
+    }
+    .dataTable-container {
+      .colored-tables();
+      th,
+      td {
+        color: @text !important;
+      }
+      * {
+        border-color: @surface0 !important;
+      }
+    }
+    .layout-column-button-group {
+      button {
+        &:not(.grey) {
+          color: @base;
+        }
+      }
+    }
+    .poptable-container {
+      table {
+        background-color: @base;
+        border-color: @surface0;
+      }
+      .custom-border-color {
+        border-color: @surface0 !important;
+      }
+      .custom-background-color {
+        background: @accent-color !important;
+        .TabContents {
+          color: @base !important;
+        }
+      }
+      font {
+        color: @accent-color !important;
+      }
+      background-color: @base !important;
+      /* another fun hack to get it to style properly!!! */
+      .disallow-options-container {
+        outline: 50rem solid;
+        outline-color: @base;
+      }
+    }
+    .WhiteDrawHeader,
+    .GrayDrawHeader,
+    .DarkGradientBG {
+      background: @base;
+      border-color: @surface0;
+      font {
+        color: @text !important;
+      }
+      #top_submit {
+        background: @accent-color;
+        color: @base;
+      }
+    }
+    .listoutputbox {
+      color: @text !important;
+      background: @base !important;
+      .custom-background-color {
+        background: @accent-color !important;
+        .TabContents {
+          color: @base !important;
+        }
+      }
+      table {
+        color: @base;
+      }
+    }
+    .requestStatus {
+      background-color: @surface0;
+      border-color: @accent-color;
+    }
+  }
 }
 
 /* prettier-ignore */

--- a/styles/focus/catppuccin.user.css
+++ b/styles/focus/catppuccin.user.css
@@ -1,0 +1,328 @@
+/* ==UserStyle==
+@name Focus Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/focus
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/focus
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/focus/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Afocus
+@description Soothing pastel theme for Focus SIS
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+@-moz-document regexp('^(https?:\\/\\/)?([a-zA-Z0-9-]+\\.)+focusschoolsoftware\\.com(\\/.*)?$') {
+	@media (prefers-color-scheme: light) {
+		:root {
+			#catppuccin(@lightFlavor, @accentColor);
+		}
+	}
+	@media (prefers-color-scheme: dark) {
+		:root {
+			#catppuccin(@darkFlavor, @accentColor);
+		}
+	}
+
+	#catppuccin(@lookup, @accent) {
+		@rosewater: @catppuccin[@@lookup][@rosewater];
+		@flamingo: @catppuccin[@@lookup][@flamingo];
+		@pink: @catppuccin[@@lookup][@pink];
+		@mauve: @catppuccin[@@lookup][@mauve];
+		@red: @catppuccin[@@lookup][@red];
+		@maroon: @catppuccin[@@lookup][@maroon];
+		@peach: @catppuccin[@@lookup][@peach];
+		@yellow: @catppuccin[@@lookup][@yellow];
+		@green: @catppuccin[@@lookup][@green];
+		@teal: @catppuccin[@@lookup][@teal];
+		@sky: @catppuccin[@@lookup][@sky];
+		@sapphire: @catppuccin[@@lookup][@sapphire];
+		@blue: @catppuccin[@@lookup][@blue];
+		@lavender: @catppuccin[@@lookup][@lavender];
+		@text: @catppuccin[@@lookup][@text];
+		@subtext1: @catppuccin[@@lookup][@subtext1];
+		@subtext0: @catppuccin[@@lookup][@subtext0];
+		@overlay2: @catppuccin[@@lookup][@overlay2];
+		@overlay1: @catppuccin[@@lookup][@overlay1];
+		@overlay0: @catppuccin[@@lookup][@overlay0];
+		@surface2: @catppuccin[@@lookup][@surface2];
+		@surface1: @catppuccin[@@lookup][@surface1];
+		@surface0: @catppuccin[@@lookup][@surface0];
+		@base: @catppuccin[@@lookup][@base];
+		@mantle: @catppuccin[@@lookup][@mantle];
+		@crust: @catppuccin[@@lookup][@crust];
+		@accent-color: @catppuccin[@@lookup][@@accent];
+
+		color-scheme: if(@lookup =latte, light, dark);
+
+		::selection {
+			background-color: fade(@accent-color, 30%);
+		}
+		.violet {
+			background: @mauve !important;
+		}
+		.purple {
+			background: @lavender !important;
+		}
+		.teal {
+			background: @teal !important;
+		}
+		.olive {
+			background: @yellow !important;
+		}
+		.green {
+			background: @green !important;
+		}
+		.pink {
+			background: @pink !important;
+		}
+		.red {
+			background: @red !important;
+		}
+		.blue {
+			background: @blue !important;
+		}
+		input,
+		textarea {
+			&::placeholder {
+				color: @subtext0 !important;
+			}
+		}
+		a {
+			color: @blue;
+		}
+		body,
+		.portal::before,
+		.portal,
+		.content-container,
+		.site-middle,
+		.site-container,
+		.sis-package,
+		.document-ready,
+		.site-content-container {
+			background: @base !important;
+			color: @text;
+		}
+		/* fun hack to get the homepage background to style properly */
+		.portal::before {
+			outline: 30rem solid @base;
+			outline-offset: -20rem !important;
+		}
+		#userwayAccessibilityIcon {
+			img {
+				background-color: @blue !important;
+				border-radius: 50%
+			}
+		}
+		.site-header {
+			background: @mantle;
+			color: @text !important;
+		}
+		.swift-box-options {
+			border: @accent-color;
+			.swift-box-option-container {
+				color: @text;
+				border-color: @accent-color;
+				background: @overlay0 !important;
+				.swift-box-option-highlight {
+					background: @overlay1;
+				}
+			}
+		}
+		.cell-link {
+			color: @blue;
+		}
+		.stat_table {
+			background: @surface0;
+			border-color: @accent-color;
+			.stats_header {
+				background: @accent-color;
+				color: @base;
+			}
+		}
+		.dataTable-container {
+			a {
+				color: @accent-color;
+			}
+			* > table {
+				border-color: @accent-color !important;
+				thead tr {
+					background: @surface0;
+				}
+				tr {
+					background: @surface0;
+				}
+				.dataTable-oddRow {
+					background: fade(@accent-color, 30) !important;
+				}
+			}
+		}
+		.parent-menu-container {
+			border-color: @overlay0 !important;
+			.fa {
+				color: fade(@accent-color, 90) !important;
+			}
+			.parent-menu-options-container {
+				background: @mantle;
+				.parent-menu-option-title,
+				.parent-menu-sub-options-container {
+					background: @surface0;
+					color: @accent-color !important;
+				}
+				.parent-menu-option-title:hover,
+				.parent-menu-sub-options-container:hover {
+					background: fade(@surface0, 30%) !important;
+					color: @accent-color !important;
+				}
+			}
+			.parent-menu-footer,
+			.parent-menu-footer-button {
+				background: @surface0;
+				color: @accent-color !important;
+			}
+		}
+		.portal-block-title {
+			background: @accent-color;
+		}
+		.portal-block {
+			background: @surface1 !important;
+		}
+		.portal-background-color {
+			background: @accent-color;
+		}
+		.portal-block-tabs {
+			background: @surface1 !important;
+			color: @base;
+			.portal-block-tab {
+				background: @overlay0;
+			}
+			.portal-block-tab .active {
+				background: @accent-color !important;
+			}
+		}
+	}
+}
+
+/* prettier-ignore */
+@catppuccin: {
+	@latte: {
+		@rosewater: #dc8a78;
+		@flamingo: #dd7878;
+		@pink: #ea76cb;
+		@mauve: #8839ef;
+		@red: #d20f39;
+		@maroon: #e64553;
+		@peach: #fe640b;
+		@yellow: #df8e1d;
+		@green: #40a02b;
+		@teal: #179299;
+		@sky: #04a5e5;
+		@sapphire: #209fb5;
+		@blue: #1e66f5;
+		@lavender: #7287fd;
+		@text: #4c4f69;
+		@subtext1: #5c5f77;
+		@subtext0: #6c6f85;
+		@overlay2: #7c7f93;
+		@overlay1: #8c8fa1;
+		@overlay0: #9ca0b0;
+		@surface2: #acb0be;
+		@surface1: #bcc0cc;
+		@surface0: #ccd0da;
+		@base: #eff1f5;
+		@mantle: #e6e9ef;
+		@crust: #dce0e8;
+	}
+	;
+	@frappe: {
+		@rosewater: #f2d5cf;
+		@flamingo: #eebebe;
+		@pink: #f4b8e4;
+		@mauve: #ca9ee6;
+		@red: #e78284;
+		@maroon: #ea999c;
+		@peach: #ef9f76;
+		@yellow: #e5c890;
+		@green: #a6d189;
+		@teal: #81c8be;
+		@sky: #99d1db;
+		@sapphire: #85c1dc;
+		@blue: #8caaee;
+		@lavender: #babbf1;
+		@text: #c6d0f5;
+		@subtext1: #b5bfe2;
+		@subtext0: #a5adce;
+		@overlay2: #949cbb;
+		@overlay1: #838ba7;
+		@overlay0: #737994;
+		@surface2: #626880;
+		@surface1: #51576d;
+		@surface0: #414559;
+		@base: #303446;
+		@mantle: #292c3c;
+		@crust: #232634;
+	}
+	;
+	@macchiato: {
+		@rosewater: #f4dbd6;
+		@flamingo: #f0c6c6;
+		@pink: #f5bde6;
+		@mauve: #c6a0f6;
+		@red: #ed8796;
+		@maroon: #ee99a0;
+		@peach: #f5a97f;
+		@yellow: #eed49f;
+		@green: #a6da95;
+		@teal: #8bd5ca;
+		@sky: #91d7e3;
+		@sapphire: #7dc4e4;
+		@blue: #8aadf4;
+		@lavender: #b7bdf8;
+		@text: #cad3f5;
+		@subtext1: #b8c0e0;
+		@subtext0: #a5adcb;
+		@overlay2: #939ab7;
+		@overlay1: #8087a2;
+		@overlay0: #6e738d;
+		@surface2: #5b6078;
+		@surface1: #494d64;
+		@surface0: #363a4f;
+		@base: #24273a;
+		@mantle: #1e2030;
+		@crust: #181926;
+	}
+	;
+	@mocha: {
+		@rosewater: #f5e0dc;
+		@flamingo: #f2cdcd;
+		@pink: #f5c2e7;
+		@mauve: #cba6f7;
+		@red: #f38ba8;
+		@maroon: #eba0ac;
+		@peach: #fab387;
+		@yellow: #f9e2af;
+		@green: #a6e3a1;
+		@teal: #94e2d5;
+		@sky: #89dceb;
+		@sapphire: #74c7ec;
+		@blue: #89b4fa;
+		@lavender: #b4befe;
+		@text: #cdd6f4;
+		@subtext1: #bac2de;
+		@subtext0: #a6adc8;
+		@overlay2: #9399b2;
+		@overlay1: #7f849c;
+		@overlay0: #6c7086;
+		@surface2: #585b70;
+		@surface1: #45475a;
+		@surface0: #313244;
+		@base: #1e1e2e;
+		@mantle: #181825;
+		@crust: #11111b;
+	}
+	;
+}
+
+// vim:ft=less

--- a/styles/focus/preview.webp
+++ b/styles/focus/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e44fadf915c3e9f75d923376fa2ddfd04235aad151bbfe7aed97110fa050d99
+size 71254


### PR DESCRIPTION

## 🎉 Theme for Focus 🎉

Focus is a Student information System used by schools to manage student information, such as grades, classes, and enrollment.

## 💬 Additional Comments 💬

CSS classes are really weird and I ended up using a lot of !important, and I had to make an outline for the background to extend on the homepage.

Also, the preview image has things blurred as using the font did not apply everywhere, as the site's css uses !important way more than it should.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
