### PR TITLE
fix(proton): proton wallet logo

### DIFF
--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Proton Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/proton
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/proton
-@version 0.1.8
+@version 0.1.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/proton/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aproton
 @description Soothing pastel theme for Proton
@@ -90,6 +90,8 @@
       > path {
         .replaceColor(#B8D7FF, fill);
         .replaceColor(#8F69FF, fill);
+        .replaceColor(#6D4AFF, fill);
+        .replaceColor(#FFBB93, fill);
       }
 
       /* prettier-ignore */
@@ -119,6 +121,11 @@
         .replaceColor(#704CFF, stop-color);
         .replaceColor(#B39FFB, stop-color);
         .replaceColor(#FFE8DB, stop-color);
+        .replaceColor(#957AFD, stop-color);
+        .replaceColor(#FFC6C6, stop-color);
+        .replaceColor(#FA528E, stop-color);
+        .replaceColor(#FF8065, stop-color);
+        .replaceColor(#FFA51F, stop-color);
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- added color overrides for the new Proton Wallet logo in the app switcher

I might look into the details and enable this userstyle for Proton Pass and Wallet in the future, but there are some weird inline styles left in Proton Pass and I still haven't got access to Proton Wallet so yeah it's just maybe.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
