### PR TITLE
fix(stylus): unthemed elements

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -92,6 +92,10 @@
         --color-on: fade(@accent-color, 25%);
         --color-off: @surface2;
       }
+      :focus {
+        --focus-color1: @accent-color !important;
+        --focus-color2: fade(@accent-color, 25%) !important;
+      }
     }
 
     .active #filters-stats,
@@ -242,6 +246,35 @@
     }
     .CodeMirror-activeline-background {
       background: @mantle;
+    }
+    #live-reload-install-hint {
+      color: @teal;
+    }
+    #menu.delete header {
+      background: fade(@red, 25%);
+    }
+    #menu.delete > div,
+    #menu.delete [data-cmd="delete"] {
+      border-color: @red;
+    }
+    .entry.odd{
+      background-color: fade(@surface0, 25%)
+    }
+    .updater-icons > :not(.check-update)::after{
+      border-color: @yellow;
+      background: @base
+    }
+    .split-btn-menu{
+      border-color: @accent-color;
+    }
+    .split-btn-menu > :hover{
+      background: fade(@accent-color, 25%)
+    }
+    #help-popup .title{
+      background: @mantle
+    }
+    #toc li:hover{
+      background: fade(@accent-color, 20%)
     }
   }
 }

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stylus Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stylus
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version 1.2.2
+@version 1.2.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astylus
 @description Soothing pastel theme for Stylus

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -257,24 +257,28 @@
     #menu.delete [data-cmd="delete"] {
       border-color: @red;
     }
-    .entry.odd{
-      background-color: fade(@surface0, 25%)
+    .entry.odd {
+      background-color: fade(@surface0, 25%);
     }
-    .updater-icons > :not(.check-update)::after{
+    .updater-icons > :not(.check-update)::after {
       border-color: @yellow;
-      background: @base
+      background: @base;
     }
-    .split-btn-menu{
+    .split-btn-menu {
       border-color: @accent-color;
     }
-    .split-btn-menu > :hover{
-      background: fade(@accent-color, 25%)
+    .split-btn-menu > :hover {
+      background: fade(@accent-color, 25%);
     }
-    #help-popup .title{
-      background: @mantle
+    #help-popup .title {
+      background: @mantle;
     }
-    #toc li:hover{
-      background: fade(@accent-color, 20%)
+    #toc li:hover {
+      background: fade(@accent-color, 20%);
+    }
+    input:invalid {
+      background: fade(@red, 10%);
+      color: @red;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #813 
Fixes various unthemed elements in stylus:
![image](https://github.com/user-attachments/assets/75d948be-1fb7-45c2-9018-534a6d9e6def)
![image](https://github.com/user-attachments/assets/cc8efa26-96d3-4e83-ba10-ae03c0887a02)
![image](https://github.com/user-attachments/assets/42a88575-6452-492d-af25-3f5fd7b10aa9)
![image](https://github.com/user-attachments/assets/753f0999-eae9-4972-a9ac-4a30b53aca20)
![image](https://github.com/user-attachments/assets/26e366cc-eb05-4d06-bdd3-a56016efda1b)
![image](https://github.com/user-attachments/assets/d27930b3-ceb3-43dc-8c42-eaf140610938)
![image](https://github.com/user-attachments/assets/506b7ed1-af0a-4fd6-834c-a1d266428c33)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
