### PR TITLE
fix(pinterest): unthemed elements

### DIFF
--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -96,17 +96,23 @@
       --color-background-selected-base: @subtext1;
       --color-background-box-default: @mantle;
       --color-background-box-selected: @accent-color;
+      --color-background-box-primary: @accent-color;
       --color-background-box-secondary: @surface1;
       --color-background-overlay: @surface0;
+      --color-background-popover-primary: @mantle;
+      --color-background-popover-secondary: @overlay2;
       --color-background-tag-primary-hover: @surface2;
       --color-background-box-light: @mantle;
       --color-background-button-secondary-default: @surface0;
       --color-background-button-secondary-hover: @surface1;
+      --color-background-button-secondary-active: @surface2;
       --color-background-tag-primary-default: @surface1;
       --color-background-button-disabled-default: darken(@mantle, 2%);
       --color-background-formfield-primary: @surface0;
       --color-border-container: @surface1;
       --color-border-default: @mantle;
+      --color-border-popover-primary: @surface0;
+      --color-border-popover-secondary: @text;
       --color-text-success: @green;
       --color-text-warning: @yellow;
       --color-icon-success: @green;
@@ -153,6 +159,11 @@
     body {
       background-color: @base;
       color: @text;
+    }
+
+    /* the void (parts not loaded yet) */
+    html {
+      background: @base !important;
     }
 
     .EmojiPickerReact {
@@ -216,6 +227,14 @@
 
     div[data-test-id="header-Header"] div.P_h span.xnr {
       color: @text !important;
+    }
+
+    // search
+    div[data-test-id="dynamic-search-placeholder"] > div.Lfz.MIw.zI7.iyn.Hsu {
+      &.ojN,
+      &.QLY {
+        display: none;
+      }
     }
 
     // make top bar match
@@ -380,8 +399,16 @@
 
     /* Pin page */
 
+    // comment bar
     div[data-test-id="inline-comment-composer-container"] {
       border-color: transparent !important;
+      background: transparent !important;
+    }
+    div.public-DraftEditorPlaceholder-root {
+      color: @subtext1!important;
+    }
+    .LJB.Pw5.XgI.fev.ujU.wsz.zI7.iyn.Hsu {
+      border-color: @surface0 !important;
     }
 
     div[data-test-id="more-description-container"],
@@ -404,6 +431,7 @@
     }
 
     div[data-test-id="flashlight-button"],
+    div[data-test-id="flashlight"],
     div[data-test-id="shop-button"] {
       background-color: fadeout(@base, 20%) !important;
     }
@@ -708,8 +736,14 @@
       ) !important;
     }
 
-    div[data-test-id="standard-save-button"] span {
-      color: @mantle !important;
+    div[data-test-id="standard-save-button"] {
+      span {
+        color: @mantle !important;
+      }
+      // save button hover
+      .vfW {
+        background: darken(@accent-color, 10%) !important;
+      }
     }
 
     /* Other */
@@ -721,6 +755,21 @@
 
     div[data-layout-shift-boundary-id="PageContainer"] {
       --color-text-inverse: var(--color-text-light);
+    }
+
+    // pin side buttons background
+    .XiG.hUC.wYR.zI7.iyn.Hsu {
+      background: @base !important;
+    }
+    // pin external link on hover
+    .Jea.KS5.MIw.RDc.Rym.b8T.ho-.ojN.rDA.zI7.iyn.Hsu {
+      background: @surface0 !important;
+    }
+    // pin body shadow
+    [data-test-id="closeup-body-landscape"] {
+      .Mhr.l7T.zI7.iyn.Hsu {
+        box-shadow: 0 1px 20px 0 fade(@text, 10%) !important;
+      }
     }
   }
 }

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Pinterest Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pinterest
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pinterest
-@version 1.1.5
+@version 1.1.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pinterest/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apinterest
 @description Soothing pastel theme for Pinterest


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

fixed unthemed elements
save button & hovering on save button
![image](https://github.com/user-attachments/assets/6cdeed9c-4007-4601-b098-1acb138758d6)
![image](https://github.com/user-attachments/assets/6fcabf6b-b78c-4e81-bd1f-e2d3cd06f829)
hovering popups
![image](https://github.com/user-attachments/assets/d864b41a-39e2-41f2-ace4-19c3cbc43d67)
more options menu
![image](https://github.com/user-attachments/assets/9f2d47d7-a336-4019-a983-94e96f9ee157)
image search popup
![image](https://github.com/user-attachments/assets/212b5164-cfdd-4fb3-89ae-bc85ba00c932)
the search bar (there was a white shadows on it)
![image](https://github.com/user-attachments/assets/c2c78053-3ef1-4654-ac09-5ce36d586cff)
the comment bar (it wasn't round and the background was all dark)
![image](https://github.com/user-attachments/assets/3180ff1a-3e75-4cbe-b0aa-1740485ad889)
this section was sometimes unthemed
![image](https://github.com/user-attachments/assets/16bf3c18-4db0-451f-9ef7-16a4af6fe130)
the "open external link popup" when you hover over a pin
![image](https://github.com/user-attachments/assets/26dfdb30-f656-4242-9829-46a13e77b2d2)
pin body shadow
![image](https://github.com/user-attachments/assets/cedd9833-ef0e-466f-a6f1-eda7632d0733)
parts not loaded yet/the void/skeleton/<html> element


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
