### PR TITLE
fix(instagram): links in direct messages having horrible contrast

### DIFF
--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -795,14 +795,19 @@
 
     /* Chat button */
     .x1i10hfl:hover {
-      background-color: @surface0;
       color: @text;
+    }
+    .x1bvjpef {
+      color: @crust;
+    }
+    .x1bvjpef:hover {
+      color: darken(@accent-color, 30%)
     }
 
     /* notes */
     .xsnw5ke,
     .x3zg9eu::after {
-      background-color: @surface0;
+      background-color: @surface0 !important;
     }
     .x103n6ev,
     .xzxgvzf {

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Instagram Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/instagram
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/instagram
-@version 0.2.5
+@version 0.2.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/instagram/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainstagram
 @description Soothing pastel theme for Instagram
@@ -764,7 +764,7 @@
     @accent-color: @catppuccin[@@lookup][@@accent];
 
     .x11jlvup {
-      --chat-outgoing-message-bubble-background-color: @blue;
+      --chat-outgoing-message-bubble-background-color: fade(@blue, 80%);
     }
     .x1n2onr6 {
       --chat-incoming-message-bubble-background-color: @surface0;
@@ -801,7 +801,7 @@
       color: @crust;
     }
     .x1bvjpef:hover {
-      color: darken(@accent-color, 30%)
+      color: lighten(@accent-color, 5%)
     }
 
     /* notes */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧.
title.


| Before | after |
| ------------- | ------------- |
| <img width="320" alt="image" src="https://github.com/user-attachments/assets/79d86d36-8513-4772-816d-58523b7e8638">  | <img width="334" alt="image" src="https://github.com/user-attachments/assets/2273d1a5-3a0d-49b1-a0a4-4243542c3c16">  |

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒


- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
