### PR TITLE
fix(trinket): logo disappearing

### DIFF
--- a/styles/trinket/catppuccin.user.css
+++ b/styles/trinket/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Trinket Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/trinket
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/trinket
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/trinket/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atrinket
 @description Soothing pastel theme for Trinket

--- a/styles/trinket/catppuccin.user.css
+++ b/styles/trinket/catppuccin.user.css
@@ -1274,11 +1274,6 @@
       content: url("data:image/svg+xml,@{svg}");
     }
 
-    img[src$="trinket-logo.png"] {
-      padding-top: 1.1rem !important;
-      padding-left: 6rem !important;
-    }
-
     img[src$="trinket-logo-notag.png"] {
       margin: 50px 0 30px;
       padding-left: 300px;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the logo disappearing on the main/plans page
![image](https://github.com/user-attachments/assets/86789413-8fac-4a54-9286-6a017ce9f426)
![image](https://github.com/user-attachments/assets/ed048328-ff59-49ab-9cf7-9a9e3a988a6b)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
