### PR TITLE
refactor(wikiwand): rewrite for omni

### DIFF
--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -18,14 +18,17 @@
 @-moz-document domain("wikiwand.com") {
   @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
 
-  .root_light__Inhun {
+  .theme-system,
+  .theme-light,
+  .theme-desert,
+  .theme-calmness {
     #catppuccin(@lightFlavor, @accentColor);
   }
-
-  .root_earth__3sDLo,
-  .root_dark__oGh5X,
-  .root_auto__Xg3qF,
-  .root_grey__eKz_h {
+  .theme-system,
+  .theme-dark,
+  .theme-black,
+  .theme-deepOcean,
+  .theme-nature {
     #catppuccin(@darkFlavor, @accentColor);
   }
 
@@ -98,327 +101,42 @@
       }
     }
 
-    --color-bg: @base;
-    --color-text: @text;
-    --color-subtle: @subtext0;
-    --color-grey: @subtext0;
-    --color-table: @surface0;
-    --color-table-border: @surface0;
-    --color-link: @accent-color;
-    --toc-bg: @mantle;
-    --toc-text: @text;
-    --toc-border: @crust;
-    --tag-bg: @surface0;
-    --tag-text: @overlay1;
-    --navbar-bg: @crust;
-    --navbar-border: @mantle;
-    --navbar-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2),
-      0px 5px 10px rgba(0, 0, 0, 0.3);
+    --color-bg: @base !important;
+    --color-text: @text !important;
+    --color-grey: @subtext1 !important;
+    --color-accent: @accent-color !important;
+    --color-highlight: @surface2 !important;
+    --color-ash: @surface2 !important;
+    --color-border: @surface2 !important;
+    --color-blue-bg: @surface1 !important;
+    --color-blue-text: @blue !important;
+    --color-purple-bg: @surface1 !important;
+    --color-purple-text: @mauve !important;
+    --color-green-bg: @surface1 !important;
+    --color-green-text: @green !important;
+    --color-orange-bg: @surface1 !important;
+    --color-orange-text: @peach !important;
+    --color-table: @surface0 !important;
+    --color-link: @accent-color !important;
+    --color-score-A: @green !important;
+    --color-score-B: @mauve !important;
+    --color-score-C: @peach !important;
+    --color-score-F: @red !important;
+    --color-score-NA: var(--color-grey) !important;
+    --grad: linear-gradient(-45deg, @peach, @blue, @pink, @yellow) !important;
+    --box-shadow: 0px 1px 4px 1px @crust !important;
+    --box-shadow-dark: 0px 0px 1px 1px @crust, 0px 1px 5px 2px @crust !important;
+    --box-shadow-strong: 0px 1px 5px 2px @crust !important;
+    --backdrop-bg: @base !important;
+    --backdrop-bg-ash: fade(@surface1, 50%) !important;
 
-    .popover_arrow__pQSsX::before {
-      background-color: @surface1;
-      border-color: @surface2;
-    }
-    *[class*="dropdown_item"] {
-      color: @text;
-    }
-    .popover_popover__jgyGp {
-      background-color: @surface1;
-      border-color: @surface2;
-      border-radius: 0.625em;
-      box-shadow:
-        0 0 2px rgba(0, 0, 0, 0.1),
-        0 5px 10px rgba(0, 0, 0, 0.1);
-    }
-    .draggable_wrapper__YB014 {
-      background-color: @surface1;
-      border-color: @surface0;
-      box-shadow:
-        0 0 2px rgba(0, 0, 0, 0.2),
-        0 10px 20px rgba(0, 0, 0, 0.3);
-      color: @text;
-    }
-    .checkbox_checkbox__uXwIZ {
-      width: 1.125em;
-      height: 1.125em;
-      border-radius: 0.125em;
-      border-color: @surface1;
-      background-color: @surface2;
-      position: relative;
-    }
-    .checkbox_checkbox__uXwIZ::before {
-      background-color: @accent-color;
-    }
-    svg.audio_icon__eZ5Bx {
-      color: @text;
-    }
-    .checkbox_label__V5gon,
-    .audio_select__kmOPL {
-      color: @subtext0 !important;
-    }
-    .draggable_header__bfxdq {
-      border-color: @surface1 !important;
-    }
-    .footer_donation__Cje_Q {
-      display: none !important;
-    }
-    .dropdown_content__4NAxl {
-      background-color: @surface1;
-      border-color: @surface2;
-    }
-    p.settings_setLabel__NrVBx:nth-child(3),
-    article.settings_section__vRaq_:nth-child(1) {
-      color: @text;
-    }
-    .toggle_label__y7mDQ {
-      color: @text;
-    }
-    .toggle_bg__Qn4Oc {
-      background-color: @accent-color;
-    }
-    .toggle_label__y7mDQ.toggle_active__l_k3F {
-      color: @base;
-    }
-    .toggle_label__y7mDQ:not(.toggle_active__l_k3F):hover {
-      color: @accent-color;
-    }
-    .themeBtn_wrapper__KTkHk.themeBtn_active__4gb_I,
-    .themeBtn_wrapper__KTkHk:hover {
-      color: @accent-color;
-    }
-    .themeBtn_label__GyvdH {
-      color: @subtext1;
-    }
-    .toggle_toggle__jzkKG {
-      background-color: @surface2;
-    }
-    .settings_reset__GO2x4 {
-      border-top-color: @surface2;
-    }
-    .settings_resetBtn__3yLrG {
-      color: @text;
-    }
-    .settings_resetBtn__3yLrG:not(.settings_disabled__7X7Nu):hover {
-      color: @red;
-    }
-    .themeBtn_label__GyvdH span {
-      background-color: @surface2;
-      border-color: @surface2;
-    }
-    .themeBtn_wrapper__KTkHk.themeBtn_active__4gb_I
-      .themeBtn_demoWrapper__fdi7G {
-      border-color: @accent-color !important;
-    }
-    div.themeBtn_wrapper__KTkHk:nth-child(3)
-      > p:nth-child(2)
-      > span:nth-child(1)::before {
-      background-color: @accent-color;
-    }
-    .item_item__uLhiz.item_active__4kaIV {
-      color: @accent-color;
-    }
-    .item_item__uLhiz.item_active__4kaIV,
-    .item_item__uLhiz:hover {
-      background-color: @surface2;
-    }
-    .languages_wrapper__1Ad3R {
-      color: @subtext1;
-    }
-    .input_input__uGeT_ {
-      color: @text;
-      background-color: @overlay0;
-      border-radius: 4px;
-    }
-    .input_wrapper__aeypb {
-      border-color: transparent !important;
-    }
-    .action_action___vLQg {
-      color: @accent-color;
-    }
-    .share_btn__9IJpe {
-      color: @text;
-      background-color: @surface2;
-      border-color: @surface2;
-    }
-    .share_btn__9IJpe span {
-      color: @text;
-    }
-    .footer_socialWrapper__R1iSQ *:hover,
-    .footer_link__TA4rr:hover {
-      color: @accent-color;
-    }
-    .list_wrapper__TYM2l,
-    .input_wrapper__aeypb {
-      background-color: @surface1;
-      color: @text;
-    }
-    .input_wrapper__aeypb * {
-      color: @text;
-    }
-    .list_item_VVizU:hover {
-      background-color: @surface2 !important;
-    }
-    .search_header__gqnk7.search_article__L3Khv {
-      background: transparent;
-    }
-    .item_item__jj0Ue {
-      color: @text;
-    }
-    .item_item__jj0Ue:hover {
-      background-color: @surface2 !important;
-      border-color: @accent-color;
-    }
-    .modal_header__t094_ {
-      border-color: @surface1;
-      color: @text;
-    }
-    .list_item__VVizU.list_active__ahAYX,
-    .list_item__VVizU:hover {
-      background-color: @surface2;
-    }
-    .button_btn__ln0Hv {
-      color: @accent-color;
-      background-color: @surface0;
+    .mw-no-invert * {
+      color: @crust !important;
     }
 
-    .navbarMobile_footer__y5Kwi.navbarMobile_dark__eIcxf
-      .navbarMobile_icons__tirr9,
-    .navbarMobile_footer__y5Kwi.navbarMobile_dark__eIcxf
-      .navbarMobile_toc__iPfvP,
-    .navbarMobile_footer__y5Kwi.navbarMobile_grey__5dmnP
-      .navbarMobile_icons__tirr9,
-    .navbarMobile_footer__y5Kwi.navbarMobile_grey__5dmnP
-      .navbarMobile_toc__iPfvP {
-      background-color: @surface1;
-      color: @text;
-    }
-    .tooltip_tooltip_QQr79.tooltip_dark_ZWBHd,
-    .tooltip_tooltip_QQr79.tooltip_dark_ZWBHd > * > * {
-      background-color: @crust !important;
-    }
-    .dropdown_item__yrn67:hover {
-      background-color: @surface2;
-      color: @accent-color;
-      border-color: @accent-color !important;
-    }
-    .audio_dot__jeWOr.audio_active__li6PM {
-      background-color: @accent-color;
-    }
-    .audio_dot__jeWOr {
-      background-color: @surface2;
-      box-shadow: 6.666px 0 0 0 @surface2;
-      border-radius: 0;
-      border-color: @surface2 !important;
-    }
-    .gallery_icon__7LOBi {
-      background-color: @surface2;
-      color: @subtext1;
-    }
-    .gallery_disable__1QuKw {
-      background-color: @surface0;
-    }
-    .gallery_icon__7LOBi:hover {
-      background-color: @overlay0;
-      color: @accent-color;
-    }
-    .gallery_nav__BEeM3 {
-      background-color: @base;
-    }
-    .image_wrapper__Dq3Jq {
-      background-color: @crust;
-    }
-    .stage_caption__BvSjQ {
-      color: @subtext0;
-    }
-    .gallery_wrapper__1a7bM,
-    .thumbnails_wrapper__1Q5be {
-      background-color: @mantle !important;
-    }
-    .thumbnails_thumbnail__H4tNf {
-      background-color: #fafafa;
-      border-radius: 4px;
-      padding: 4px;
-    }
-
-    .list_loading__j43_R {
-      color: @accent-color;
-    }
-    .info_wrapper__HpdJH,
-    .info_arrow__ehjUI {
-      background-color: @surface1;
-      border-color: @surface1;
-    }
-
-    .info_wrapper__HpdJH::after {
-      background: linear-gradient(180deg, hsla(0, 0%, 98%, 0), @surface1 90%);
-    }
-    .list_item__VVizU.list_active__ahAYX {
-      color: @accent-color;
-    }
-    .item_star__arENF,
-    .item_article__sLPDb,
-    .icon_icon__0vohI {
-      color: @subtext1;
-    }
-    .item_star__arENF.item_active__4kaIV {
-      color: @yellow;
-    }
-    .action_action___vLQg.action_remove__z6g_k {
-      color: @text;
-    }
-    .action_action___vLQg:not(.action_limit__u0EDs):hover.action_remove__z6g_k {
-      color: @accent-color;
-    }
-    .item_remove__f1A5k {
-      background-color: @surface1;
-    }
-    .item_remove__f1A5k span,
-    .item_remove__f1A5k svg {
-      color: @red;
-    }
-    caption {
-      background-color: @surface0 !important;
-      border-color: @surface0 !important;
-    }
-    .summary_wordtuneWrapper__21QxG > img:nth-child(2) {
-      background-color: @accent-color;
-    }
-    code > a {
-      color: @accent-color !important;
-    }
-    table * {
-      background-color: @surface0 !important;
-      color: @text !important;
-      border-color: @surface2 !important;
-    }
-    table {
-      background-color: @surface0 !important;
-      border-color: transparent !important;
-    }
-    a.wl {
-      color: @accent-color !important;
-    }
-    pre,
-    code,
-    samp,
-    kbd {
-      border-color: @surface2 !important;
-    }
-    .summary_footer__Lk6z7 > span:nth-child(1),
-    .input_icon__He3sV,
-    .item_star__arENF.item_active__4kaIV * {
-      color: @accent-color !important;
-      fill: @accent-color !important;
-    }
-    .wikitable tr::before {
-      background-color: @surface0 !important;
-      border-color: @surface2 !important;
-    }
-    .infobox .mw-ref {
-      background: transparent !important;
-      * {
-        color: @accent-color !important;
-      }
+    .notheme * {
+      --color-text: auto;
+      --color-link: auto;
     }
   }
 }

--- a/styles/wikiwand/catppuccin.user.css
+++ b/styles/wikiwand/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikiwand Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikiwand
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikiwand
-@version 1.2.2
+@version 2.0.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikiwand/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikiwand
 @description Soothing pastel theme for Wikiwand


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

This updates the userstyle for omni wikiwand. This is a breaking change for users still on the old wikiwand version, but as I understand it, they have migrated fully to omni wikiwand.

Notes:
- Tables are somewhat broken, but they are broken without this userstyle too, so ¯\\\_(ツ)_/¯
- Syntax highlighting in some places might have been updated, I couldn't check if that's broken

This closes #1171 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
