### PR TITLE
fix(modrinth): dropdown icon

### DIFF
--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -159,6 +159,12 @@
     .BDVE3s9MFQttmbMUeYup-2 a strong {
       color: @accent-color;
     }
+    
+    // dropdown icon
+    .multiselect__select:before {
+        border-color: @text transparent transparent;
+        color: @text;
+    }
   }
 }
 

--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -159,11 +159,11 @@
     .BDVE3s9MFQttmbMUeYup-2 a strong {
       color: @accent-color;
     }
-    
+
     // dropdown icon
-    .multiselect__select:before {
-        border-color: @text transparent transparent;
-        color: @text;
+    .multiselect__select::before {
+      border-color: @text transparent transparent;
+      color: @text;
     }
   }
 }

--- a/styles/modrinth/catppuccin.user.css
+++ b/styles/modrinth/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Modrinth Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/modrinth
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/modrinth
-@version 1.2.7
+@version 1.2.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/modrinth/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amodrinth
 @description Soothing pastel theme for Modrinth


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes a unthemed dropdown icon at the mods page
![image](https://github.com/user-attachments/assets/fbc506b2-6ee6-44b0-869e-34076fc83259)
![image](https://github.com/user-attachments/assets/055575fc-0db7-46ac-ac8c-6027f8295ee8)
## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
