### PR TITLE
fix(porkbun): help button

### DIFF
--- a/styles/porkbun/catppuccin.user.css
+++ b/styles/porkbun/catppuccin.user.css
@@ -150,12 +150,12 @@
 
       .hsds-beacon button {
         background-color: @accent-color;
-        
+
         > span {
           color: @crust;
         }
       }
-      
+
       .hsds-beacon .kFUhAv svg {
         fill: @accent-color !important;
       }

--- a/styles/porkbun/catppuccin.user.css
+++ b/styles/porkbun/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Porkbun Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/porkbun
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/porkbun
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/porkbun/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aporkbun
 @description Soothing pastel theme for Porkbun
@@ -150,14 +150,14 @@
 
       .hsds-beacon button {
         background-color: @accent-color;
-
-        &:hover {
-          background-color: darken(@accent-color, 5%);
-        }
-
+        
         > span {
           color: @crust;
         }
+      }
+      
+      .hsds-beacon .kFUhAv svg {
+        fill: @accent-color !important;
       }
     }
 

--- a/styles/porkbun/catppuccin.user.css
+++ b/styles/porkbun/catppuccin.user.css
@@ -151,13 +151,13 @@
       .hsds-beacon button {
         background-color: @accent-color;
 
+        [class*="FabButtoncss__FabBackgroundUI"] > svg {
+          fill: @accent-color;
+        }
+
         > span {
           color: @crust;
         }
-      }
-
-      .hsds-beacon .kFUhAv svg {
-        fill: @accent-color !important;
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the broken help button on porkbun
![image](https://github.com/user-attachments/assets/de7567de-a66a-4d16-8978-82decafafa73)
![image](https://github.com/user-attachments/assets/b0a9f62a-a570-4569-abf1-20ccfcbdbb59)
i also removed ``&:hover`` because that doesn't do anything anymore

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
