### PR TITLE
fix(perplexity): search goals in pro-search mode

### DIFF
--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Perplexity Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/perplexity
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/perplexity
-@version 0.1.0
+@version 0.1.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/perplexity/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aperplexity
 @description Soothing pastel theme for Perplexity
@@ -419,6 +419,11 @@
       > div
       > div.line-clamp-1.break-all.transition-all.duration-300.white.font-sans.text-sm.text-white.selection\:bg-super\/50.selection\:text-textMain.dark\:selection\:bg-superDuper\/10.dark\:selection\:text-superDark {
       color: @text !important;
+    }
+
+    /* research goals in pro search */
+    .research-goal-title:hover {
+      background-color: @surface0;
     }
   }
 }

--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -422,8 +422,14 @@
     }
 
     /* research goals in pro search */
+    .research-goal::before {
+      border-color: @surface1;
+    }
     .research-goal-title:hover {
       background-color: @surface0;
+    }
+    .research-goal-timeline {
+      background-color: @surface1;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Search goals in pro-search mode are unthemed when they are hovered.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/fb1cc542-b52d-4803-9f77-1e699bccbc1f)|![image](https://github.com/user-attachments/assets/295285f1-fe6d-406f-b0ae-17a5a7c59868)|

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
