### PR TITLE
chore(tree-wide): add missing default css to 4 styles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   "deno.enable": true,
 
   "[less]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.css-language-features"
   },
   "[typescript]": {
     "editor.defaultFormatter": "denoland.vscode-deno"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   "deno.enable": true,
 
   "[less]": {
-    "editor.defaultFormatter": "vscode.css-language-features"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
     "editor.defaultFormatter": "denoland.vscode-deno"

--- a/styles/chatreplay/catppuccin.user.css
+++ b/styles/chatreplay/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatReplay Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatreplay
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatreplay
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatreplay/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatreplay
 @description Soothing pastel theme for ChatReplay

--- a/styles/chatreplay/catppuccin.user.css
+++ b/styles/chatreplay/catppuccin.user.css
@@ -73,6 +73,19 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
     & when (@platform = chat) {
       a:not(.username),
       i {

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -54,6 +54,19 @@
 
     @orange: mix(@peach, @yellow);
 
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
     [bgcolor="#fafaf0"],
     [bgcolor="#f6f6ef"] {
       background-color: @base;

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hacker News Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hacker-news
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news
-@version 1.0.0
+@version 1.0.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hacker-news/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahacker-news
 @description Soothing pastel theme for Hacker News

--- a/styles/vikunja/catppuccin.user.css
+++ b/styles/vikunja/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Vikunja Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/vikunja
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/vikunja
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/vikunja/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Avikunja
 @description Soothing pastel theme for Vikunja

--- a/styles/vikunja/catppuccin.user.css
+++ b/styles/vikunja/catppuccin.user.css
@@ -56,6 +56,17 @@
 
     color-scheme: if(@lookup = latte, light, dark);
 
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
     #hslbreakdown(@accent-color, primary);
     --site-background: @mantle;
     --content-heading-color: @text;

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.21
+@version 0.0.22
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia

--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -59,6 +59,19 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
     --ctp-rosewater: @rosewater;
     --ctp-flamingo: @flamingo;
     --ctp-pink: @pink;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

add this default css to the styles missing it (which fixes the selection background color not being themed)
```less
    color-scheme: if(@lookup = latte, light, dark);

    ::selection {
      background-color: fade(@accent-color, 30%);
    }

    input,
    textarea {
      &::placeholder {
        color: @subtext0 !important;
      }
    }
```
there are styles that doesn't have this but i didn't add it to them manually
- `codeberg`: imports css from the gitea theme (which already has selection background theming)
- `shinigami-eyes`: it's an extension and only requires changing colors related to the extension's elements and not the whole page

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
