### PR TITLE
feat(nodejs): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -1,4 +1,7 @@
 collaborators:
+  - &nikitarevenco
+    name: Nikita Revenco
+    url: https://github.com/nikitarevenco
   - &anubisnekhet
     url: https://github.com/AnubisNekhet
   - &ndsboy
@@ -504,6 +507,13 @@ userstyles:
     readme:
       app-link: "https://keyoxide.org"
     current-maintainers: [*uncenter]
+  nodejs:
+    name: NodeJS
+    categories: [development]
+    color: mauve
+    readme:
+      app-link: "https://nodejs.org"
+    current-maintainers: [*nikitarevenco]
   lastfm:
     name: Last.fm
     categories: [music, entertainment]

--- a/styles/nodejs/catppuccin.user.css
+++ b/styles/nodejs/catppuccin.user.css
@@ -1,0 +1,230 @@
+/* ==UserStyle==
+@name nodejs.org Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/nodejs.org
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/nodejs.org
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/example.org/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aexample.org
+@description Soothing pastel theme for node.js
+@author Nikita Revenco
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire*", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+@-moz-document domain("nodejs.org") {
+    html {
+        #catppuccin(@lightFlavor, @accentColor);
+    }
+
+    html.dark-mode {
+        #catppuccin(@darkFlavor, @accentColor);
+    }
+
+    #catppuccin(@lookup, @accent) {
+        @rosewater: @catppuccin[@@lookup][@rosewater];
+        @flamingo: @catppuccin[@@lookup][@flamingo];
+        @pink: @catppuccin[@@lookup][@pink];
+        @mauve: @catppuccin[@@lookup][@mauve];
+        @red: @catppuccin[@@lookup][@red];
+        @maroon: @catppuccin[@@lookup][@maroon];
+        @peach: @catppuccin[@@lookup][@peach];
+        @yellow: @catppuccin[@@lookup][@yellow];
+        @green: @catppuccin[@@lookup][@green];
+        @teal: @catppuccin[@@lookup][@teal];
+        @sky: @catppuccin[@@lookup][@sky];
+        @sapphire: @catppuccin[@@lookup][@sapphire];
+        @blue: @catppuccin[@@lookup][@blue];
+        @lavender: @catppuccin[@@lookup][@lavender];
+        @text: @catppuccin[@@lookup][@text];
+        @subtext1: @catppuccin[@@lookup][@subtext1];
+        @subtext0: @catppuccin[@@lookup][@subtext0];
+        @overlay2: @catppuccin[@@lookup][@overlay2];
+        @overlay1: @catppuccin[@@lookup][@overlay1];
+        @overlay0: @catppuccin[@@lookup][@overlay0];
+        @surface2: @catppuccin[@@lookup][@surface2];
+        @surface1: @catppuccin[@@lookup][@surface1];
+        @surface0: @catppuccin[@@lookup][@surface0];
+        @base: @catppuccin[@@lookup][@base];
+        @mantle: @catppuccin[@@lookup][@mantle];
+        @crust: @catppuccin[@@lookup][@crust];
+        @accent-color: @catppuccin[@@lookup][@@accent];
+
+        color-scheme: if(@lookup =latte, light, dark);
+
+        ::selection {
+            background-color: fade(@accent-color, 30%);
+        }
+
+        input,
+        textarea {
+            &::placeholder {
+                color: @subtext0 !important;
+            }
+        }
+
+        --black: @crust;
+        --black1: @mantle;
+        --black2: @overlay2;
+        --black3: @overlay0;
+        --blue1: @blue;
+        --white: @base;
+        --white-smoke: @surface0;
+        --grey-smoke: @surface1;
+        --red1: @red;
+        --red2: @red;
+        --red3: @peach;
+        --red4: @flamingo;
+        --green1: @green;
+        --green2: @teal;
+        --green3: @green;
+        --green4: @surface2;
+        --green5: @overlay1;
+        --gray1: @subtext1;
+        --gray2: @overlay0;
+        --gray3: @surface2;
+        --gray4: @overlay2;
+        --gray5: @subtext0;
+        --gray6: @text;
+        --gray7: @surface1;
+        --grey8: @mantle;
+        /*         --background-color-api-stability-link: rgba(239, 241, 245, 0.4); */
+        --background-color-api-stability-link: @blue;
+        --background-color-highlight: @surface0;
+        --color-brand-primary: @text;
+        --color-brand-secondary: @green;
+        --color-critical: @red;
+        --color-fill-app: @base;
+        --color-fill-side-nav: @text;
+        --color-links: @accent-color;
+        --color-text-mark: @subtext1;
+        --color-text-nav: @surface2;
+        --color-text-primary: @text;
+        --color-text-secondary: @teal;
+
+        code {
+            color: @text;
+            background-color: @mantle;
+        }
+
+
+        a code,
+        a {
+            color: @accent-color;
+        }
+
+        a:hover,
+        a code:hover {
+            background-color: @surface0;
+        }
+
+        pre {
+            background-color: @mantle;
+        }
+
+        #column2 li,
+        #intro {
+            background-color: @mantle !important;
+        }
+
+        #intro a {
+            color: @text;
+        }
+
+        #column2 li:hover {
+            background-color: lighten(@mantle, 10%) !important;
+        }
+
+        #column2 hr {
+            border-color: @surface0 !important;
+        }
+
+        #column2 li a.active {
+            color: lighten(@text, 10%)
+        }
+
+        #column2 li a {
+            color: @text;
+            text-decoration: none;
+        }
+
+        .api_stability_2 {
+            background-color: @green;
+        }
+
+        .picker a:hover,
+        .picker a:active {
+            background-color: lighten(@mantle, 10%);
+        }
+
+        .picker li {
+            accent-color: white !important;
+        }
+
+        .copy-button {
+            color: @base !important;
+            background-color: @accent-color !important;
+        }
+
+        .copy-button:hover {
+            background-color: lighten(@accent-color, 10%) !important;
+        }
+
+        .language-js {
+            color: @text !important;
+            background-color: @mantle !important;
+        }
+        .hljs-comment {
+            color: @overlay2 !important;
+        }
+        .hljs-number,
+        .hljs-literal {
+            color: @peach !important;
+        }
+        .hljs-built_in,
+        .hljs-variable {
+            color: @red !important;
+        }
+        .hljs-keyword {
+            color: @mauve !important;
+        }
+        .hljs-string {
+            color: @green !important;
+        }
+        .hljs-regexp {
+            color: @pink !important;
+        }
+        .function_ {
+            color: @blue !important;
+        }
+        .hljs-meta {
+            color: @mauve !important;
+        }
+        .class_,
+        .hljs-type {
+            color: @yellow !important;
+        }
+
+        tbody {
+            background-color: @mantle;
+        }
+        th,
+        td {
+            border-color: @surface0;
+        }
+        
+        .icon {
+            fill: @text !important;
+        } 
+    }
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}

--- a/styles/nodejs/preview.webp
+++ b/styles/nodejs/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:676bd77f20e746524ea7b3ccab01bb124546246d5f880e754f61109fc4191305
+size 21134


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [NodeJS](https://nodejs.org)🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

NodeJS is a javascript runtime, the nodejs website includes docs for it

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

Difficulties 

Right-clicking on these breadcrumbs applies a green background and at the moment I dont know how to remove it. none of the pseudoclasses work and it doesn't gain any additional class.

Same behaviour can be observed in a few different places, if i can figure out how to fix it here I'll probably be able to fix it in those places too
![image](https://github.com/user-attachments/assets/88a6e819-d451-4321-9da7-401424fc3091)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
