### PR TITLE
fix(github): tooltips

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.7.0
+@version      1.7.1
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -500,6 +500,9 @@
     --data-blue-color: @accent-color;
     --data-red-color: @red;
     --data-green-color: @green;
+    
+    --tooltip-fgColor: @text;
+    --tooltip-bgColor: @crust;
 
     .turbo-progress-bar {
       background-color: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes tooltips - not sure if they changed the vars recently or something, I thought they had been themed previously and I only started to notice this week.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
