### PR TITLE
fix(arch-wiki): containers displayed with wrong colors

### DIFF
--- a/styles/arch-wiki/catppuccin.user.css
+++ b/styles/arch-wiki/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Arch Wiki Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/arch-wiki
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/arch-wiki
-@version 0.0.8
+@version 0.0.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/arch-wiki/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aarch-wiki
 @description Soothing pastel theme for Arch Wiki
@@ -79,6 +79,62 @@
     #content code,
     #content tt {
       color: @text !important;
+    }
+
+    body.skin-vector-2022 .vector-sticky-header {
+      color: @text !important;
+      background-color: @mantle !important;
+      border-bottom-color: @blue !important;
+    }
+
+    #vector-main-menu-pinned-container,
+    #vector-page-tools-pinned-container {
+      background-color: @base !important;
+    }
+
+    #ooui-php-191,
+    #preferences .mw-htmlform-submit-buttons {
+      background-color: @mantle !important;
+    }
+
+    .mw-echo-ui-notificationItemWidget-content-message-header,
+    .oo-ui-labelElement-label {
+      color: @text !important;
+    }
+
+    .oo-ui-optionWidget-selected {
+      background-color: @surface2 !important;
+    }
+
+    .oo-ui-buttonElement-framed.oo-ui-widget-disabled > .oo-ui-buttonElement-button {
+      background-color: @surface0 !important;
+      color: @text !important;
+      border-color: @surface2 !important;
+      filter: brightness(0.4);
+      cursor: not-allowed;
+    }
+
+    .mw-htmlform-ooui .mw-htmlform-matrix tbody tr:nth-child(even) td {
+      background-color: @surface1 !important;
+    }
+
+    .mw-htmlform-ooui .mw-htmlform-matrix tbody tr:hover td {
+      background-color: @surface2 !important;
+    }
+
+    .mw-htmlform-ooui .mw-htmlform-matrix tbody tr:nth-child(odd) td,
+    .mw-rcfilters-ui-filterTagMultiselectWidget.oo-ui-widget-enabled .oo-ui-tagMultiselectWidget-handle,
+    .oo-ui-tagMultiselectWidget.oo-ui-widget-enabled.oo-ui-tagMultiselectWidget-outlined .oo-ui-tagItemWidget.oo-ui-widget-enabled,
+    .mw-rcfilters-ui-cell.mw-rcfilters-ui-filterTagMultiselectWidget-views-select,
+    .mw-rcfilters-ui-changesListWrapperWidget .mw-changeslist-legend,
+    .oo-ui-popupWidget-popup,
+    .mw-echo-ui-notificationItemWidget,
+    .mw-echo-ui-placeholderItemWidget {
+      background-color: @surface0 !important;
+    }
+
+    .mw-echo-ui-notificationsInboxWidget-toolbarWrapper {
+      background-color: @base !important;
     }
 
     #archnavbar {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes several unthemed containers througout the website, as well as texts with unreadable colors.

Closes #896

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
