### PR TITLE
fix(github): invisible button fg color

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -278,7 +278,7 @@
     --button-primary-borderColor-active: @green;
     --button-primary-borderColor-disabled: fade(@green, 70%);
     --button-primary-shadow-selected: 0px 0px 0px 0px #000;
-    --button-invisible-fgColor-rest: @accent-color;
+    --button-invisible-fgColor-rest: @text;
     --button-invisible-fgColor-hover: lighten(@accent-color, 10%);
     --button-invisible-fgColor-disabled: #6e7681;
     --button-invisible-iconColor-rest: @overlay2;

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.7.1
+@version      1.7.2
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Just started noticing this change where certain buttons had the wrong color (like the upload media one when writing a comment is accent when it should be text), seems like a change this week. Updates this var to match GitHub's.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
