### PR TITLE
feat(jisho): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -138,6 +138,8 @@ collaborators:
     url: https://github.com/stellophiliac
   - &neongamerbot
     url: https://github.com/NeonGamerBot-QK
+  - &Lichthagel
+    url: https://github.com/Lichthagel
 
 userstyles:
   advent-of-code:
@@ -497,6 +499,13 @@ userstyles:
     readme:
       app-link: "https://invoke-ai.github.io/InvokeAI"
     current-maintainers: [*ryanccn]
+  jisho:
+    name: Jisho
+    categories: [translation_tool, productivity]
+    color: green
+    readme:
+      app-link: "https://jisho.org"
+    current-maintainers: [*Lichthagel]
   keyoxide:
     name: Keyoxide
     categories: [development]

--- a/styles/jisho/catppuccin.user.css
+++ b/styles/jisho/catppuccin.user.css
@@ -272,6 +272,10 @@
       border-bottom-color: @accent-color;
     }
 
+    #what_is_this {
+      color: unset;
+    }
+
     .japanese_word__furigana-invisible {
       opacity: 0;
     }

--- a/styles/jisho/catppuccin.user.css
+++ b/styles/jisho/catppuccin.user.css
@@ -1,0 +1,445 @@
+/* ==UserStyle==
+@name Jisho Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/jisho
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/jisho
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/jisho/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ajisho
+@description Soothing pastel theme for Jisho
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain('jisho.org') {
+  @media (prefers-color-scheme: light) {
+    :root[data-color-theme="auto"] {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root[data-color-theme="auto"] {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
+
+  :root[data-color-theme="dark"] {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+  :root[data-color-theme="light"] {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    @accent-dim: if(
+      (@lookup = latte),
+      desaturate(lighten(@accent-color, 8%), 10%),
+      desaturate(darken(@accent-color, 8%), 10%)
+    );
+
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    body {
+      background-color: @base !important;
+      color: @text;
+
+      a {
+        color: @accent-color;
+
+        &:hover {
+          color: @accent-dim;
+        }
+      }
+    }
+
+    each(range(6), {
+      h@{value} {
+        color: @text;
+      }
+    });
+
+    button,
+    .button,
+    .tabs .tab-title > a {
+      background-color: @overlay0;
+      color: @text;
+
+      &:hover,
+      &:focus {
+        background-color: @overlay1;
+        color: @text;
+      }
+    }
+
+    .f-dropdown {
+      background-color: @mantle;
+      border-color: @overlay0;
+
+      &::before {
+        border-bottom-color: @surface0;
+      }
+
+      li:hover {
+        background-color: @crust;
+      }
+    }
+
+    header.row {
+      background-color: @base;
+    }
+
+    h1.logo a {
+      background-image: if(
+        @lookup = latte,
+        url(//assets.jisho.org/assets/jisho-logo-v4@2x-7330091c079b9dd59601401b052b52e103978221c8fb6f5e22406d871fcc746a.png),
+        url(//assets.jisho.org/assets/jisho-logo-v4-dark@2x-e676613b426d34187b61928823730a225b52165aaef99f948bd3dc5fc16fa787.png)
+      );
+    }
+
+    nav .links {
+      .color_theme_picker--wrapper:hover {
+        background-color: @mantle;
+      }
+
+      .color_theme_picker--choices {
+        background-color: @mantle;
+
+        li a:hover {
+          background-color: @crust;
+        }
+      }
+    }
+
+    form.search {
+      .input_methods,
+      .input_method_button h4 {
+        color: @subtext0;
+      }
+
+      .input_method_button:hover {
+        background-color: @surface0;
+      }
+
+      .main {
+        background-color: @surface0;
+        box-shadow: none;
+      }
+
+      .inner {
+        background-color: @surface1;
+
+        input {
+          color: @text;
+        }
+      }
+
+      .search_type {
+        border-right-color: @overlay0;
+        color: @subtext0;
+      }
+
+      .submit {
+        background-color: @overlay1;
+        color: @text;
+      }
+
+      .search-form_clear-button {
+        background-color: transparent; // ! Unsure if this needs a background, also extends beyond the input
+        color: @subtext0;
+      }
+
+      .results,
+      #radical_area .results {
+        .result_label {
+          color: @text;
+        }
+
+        .result {
+          background-color: @surface1;
+
+          &:hover {
+            color: @text;
+          }
+        }
+
+        each(range(8), {
+          .g@{value} {
+            color: @blue;
+          }
+        });
+      }
+
+      #radical_area {
+        .radical_table {
+          background-image: repeating-linear-gradient(
+            180deg,
+            @surface1,
+            @surface1 32px,
+            @surface2 32px,
+            @surface2 64px
+          );
+
+          .number {
+            background-color: @text;
+            color: @base;
+          }
+
+          .radical {
+            background-image: none; // ! some radicals are rendered with a background image by default
+            color: @text;
+
+            &.available:hover {
+              background-color: @overlay0;
+            }
+
+            &.selected {
+              border-color: @text;
+              background-color: mix(@base, @yellow, 50%);
+            }
+          }
+        }
+
+        &.combined_mode {
+          // ! what is combined mode?
+          .reset_radicals {
+            color: @subtext0;
+
+            &:hover {
+              color: @text;
+              background-color: @overlay0;
+            }
+          }
+        }
+      }
+
+      .handwriting {
+        .panel {
+          background-color: @surface1;
+        }
+
+        .pencil-icon {
+          color: @surface2 !important;
+        }
+      }
+    }
+
+    .speech_area_active #speech_button,
+    .radical_area_active #radical_button,
+    .handwriting_area_active #handwriting_button {
+      border-bottom-color: @accent-color;
+    }
+
+    .japanese_word__furigana-invisible {
+      opacity: 0;
+    }
+
+    #zen_bar li[data-pos="Noun"] a,
+    #zen_bar li[data-pos="Proper noun"] a,
+    #zen_bar li[data-pos="Pronoun"] a,
+    #zen_bar li[data-pos="Suffix"] a,
+    #zen_bar li[data-pos="Prefix"] a,
+    #zen_bar li[data-pos="Symbol"] a,
+    #zen_bar li[data-pos="Interjection"] a,
+    #zen_bar li[data-pos="Propernoun"] a {
+      color: @peach;
+      border-bottom-color: @peach;
+    }
+
+    #zen_bar li[data-pos="Particle"] a {
+      color: @red;
+      border-bottom: 1px solid @red;
+    }
+
+    #zen_bar li[data-pos="Verb"] a {
+      color: @subtext0;
+      border-bottom-color: @subtext0;
+    }
+
+    #main_results h4 .result_count {
+      color: @subtext0;
+    }
+
+    .fact {
+      outline-color: @mantle;
+      border-color: @base;
+      background-color: @mantle;
+    }
+
+    .concept_light {
+      border-bottom-color: @overlay0;
+    }
+
+    .concept_light-status .concept_light-tag {
+      color: @base;
+      background-color: @subtext0;
+
+      &.concept_light-common {
+        background-color: @green;
+      }
+
+      a {
+        color: @base;
+      }
+    }
+    .concept_light-meanings {
+      .meaning-tags,
+      .meaning-definition-section_divider {
+        color: @subtext0;
+      }
+    }
+
+    .concept_light .sentence,
+    .meaning-abstract,
+    .supplemental_info {
+      color: @subtext0;
+    }
+
+    .kanji_light {
+      border-bottom-color: @overlay0;
+
+      .info {
+        color: @subtext0;
+      }
+    }
+
+    .sentences_block .sentence {
+      border-bottom-color: @overlay0;
+    }
+
+    #secondary aside .minor-text {
+      color: @subtext0;
+    }
+
+    .kanji_strokes {
+      .kanji_play_button,
+      .replay_button,
+      .toggle_kanji_actions {
+        color: @text;
+        background-color: transparent;
+      }
+
+      .actions {
+        background-color: @base;
+      }
+    }
+
+    .stroke_order_diagram--bounding_box,
+    .stroke_order_diagram--guide_line {
+      stroke: @surface0;
+    }
+
+    .stroke_order_diagram--path_start {
+      fill: fade(@red, 80%);
+    }
+
+    .stroke_order_diagram--current_path {
+      stroke: @text;
+    }
+
+    .stroke_order_diagram--existing_path {
+      stroke: fade(@subtext0, 50%);
+    }
+
+    .kanji {
+      table {
+        background-color: @mantle;
+        border-color: @overlay0;
+      }
+
+      tr {
+        background-color: @surface0;
+
+        td {
+          color: @subtext0;
+        }
+      }
+    }
+
+    .discussion_thread {
+      .comment_body {
+        background-color: @surface0;
+        border-color: @overlay0;
+
+        .discussion_status {
+          background-color: @surface1;
+          border-bottom-color: @overlay0;
+          color: @subtext0;
+        }
+
+        .discussion_about {
+          background-color: mix(@surface0, @teal, 80%);
+          color: @teal;
+        }
+
+        .comment_status {
+          background-color: @surface2;
+          color: @subtext0;
+        }
+      }
+
+      .discussion_title a {
+        color: @text !important;
+      }
+    }
+
+    footer {
+      .ornament {
+        background-color: @red;
+        box-shadow: 0 0 10px 5px if(@lookup = latte, @base, @overlay0);
+      }
+    }
+  }
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}
+
+// vim:ft=less

--- a/styles/jisho/preview.webp
+++ b/styles/jisho/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b330dfc5ea9c5b0a7d0cde7aa63236496821e56e4b7289792f40196def279a
+size 74732


### PR DESCRIPTION
## 🎉 Theme for [Jisho.org](https://jisho.org/) 🎉

> Jisho is a powerful Japanese-English dictionary. It lets you find words, kanji, example sentences and more quickly and easily. 

![jisho-mocha](https://github.com/user-attachments/assets/763620b8-c046-40f8-a4e8-fc53283dc856)

## 💬 Additional Comments 💬

There are some minor inconsistencies/inconveniences. See the included comments.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
