### PR TITLE
docs(README.md): update usage instructions and section headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ giving it a unique and appealing aesthetic in line with Catppuccin's color palet
 
 ## Usage
 
-For both of the below installation methods, you will need the Stylus browser extension installed. Install [Stylus](https://github.com/openstyles/stylus) for [Chrome](https://chromewebstore.google.com/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne) or [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/styl-us/). If you use Chrome, make sure to enable "Allow access to file URLs" in [the Chrome extension settings for Stylus](chrome://extensions/?id=clngdbkpkpeebahjckkjfobafhncgmne).
+For both of the below installation methods, you will need the Stylus browser extension installed. Install [Stylus](https://github.com/openstyles/stylus) for [Chrome](https://chromewebstore.google.com/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne) or [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/styl-us/). If you use Chrome, make sure to enable "Allow access to file URLs" in the Chrome extension settings for Stylus (visit `chrome://extensions/?id=clngdbkpkpeebahjckkjfobafhncgmne`).
 
 
 ### All Userstyles

--- a/README.md
+++ b/README.md
@@ -36,21 +36,14 @@ giving it a unique and appealing aesthetic in line with Catppuccin's color palet
 
 &nbsp;
 
-## 🖥️ Install
+## Usage
 
-Install [Stylus](https://github.com/openstyles/stylus) for your browser by clicking one of the badges below.
-
-<p align="center">
-  <a href="https://addons.mozilla.org/en-GB/firefox/addon/styl-us/"><img src="https://img.shields.io/badge/Firefox_Add--ons-f5a97f?style=for-the-badge&logo=Firefox-Browser&logoColor=24273a"></a>
-  <a href="https://chromewebstore.google.com/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne"><img src="https://img.shields.io/badge/Chrome_Web_Store-b7bdf8?style=for-the-badge&logo=GoogleChrome&logoColor=24273a"></a>
-</p>
-
-> [!TIP]
-> If you use Chrome, make sure to enable "Allow access to file URLs" in the Stylus extension settings.
-
-### All Userstyles (recommended)
-
-See instructions on the [GitHub release page](https://github.com/catppuccin/userstyles/releases/tag/all-userstyles-export).
+1. Install [Stylus](https://github.com/openstyles/stylus) for [Chrome](https://chromewebstore.google.com/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne) or [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/styl-us/).
+   - If you use Chrome, make sure to enable "Allow access to file URLs" in the Stylus extension settings.
+2. Download the compiled Stylus export file, containing our recommended Stylus settings and all userstyles preloaded: [`import.json` (download)](https://github.com/catppuccin/userstyles/releases/download/all-userstyles-export/import.json).
+3. Open the Stylus "manage" page.
+4. On the sidebar panel, click the **Import** button in the **Backup** section, and select the downloaded file from step 2.
+5. Enjoy!
 
 ### Individual Userstyles
 
@@ -58,7 +51,7 @@ See instructions on the [GitHub release page](https://github.com/catppuccin/user
 2. Install userstyles by clicking the **Stylus Install** badge in each README.
 3. Enjoy!
 
-## Usage
+## Configuration
 
 All usertyles come with three default configuration options; the light flavor, the dark flavor, and the accent color. Some userstyles may offer additional site-specific options as well.
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,20 @@ giving it a unique and appealing aesthetic in line with Catppuccin's color palet
 
 ## Usage
 
-1. Install [Stylus](https://github.com/openstyles/stylus) for [Chrome](https://chromewebstore.google.com/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne) or [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/styl-us/).
-   - If you use Chrome, make sure to enable "Allow access to file URLs" in the Stylus extension settings.
-2. Download the compiled Stylus export file, containing our recommended Stylus settings and all userstyles preloaded: [`import.json` (download)](https://github.com/catppuccin/userstyles/releases/download/all-userstyles-export/import.json).
-3. Open the Stylus "manage" page.
-4. On the sidebar panel, click the **Import** button in the **Backup** section, and select the downloaded file from step 2.
-5. Enjoy!
+For both of the below installation methods, you will need the Stylus browser extension installed. Install [Stylus](https://github.com/openstyles/stylus) for [Chrome](https://chromewebstore.google.com/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne) or [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/styl-us/). If you use Chrome, make sure to enable "Allow access to file URLs" in [the Chrome extension settings for Stylus](chrome://extensions/?id=clngdbkpkpeebahjckkjfobafhncgmne).
+
+
+### All Userstyles
+
+1. Download the compiled Stylus export file, containing our recommended Stylus settings and all userstyles preloaded: [`import.json` (download)](https://github.com/catppuccin/userstyles/releases/download/all-userstyles-export/import.json).
+2. Open the Stylus "manage" page.
+3. On the sidebar panel, click the **Import** button in the **Backup** section, and select the downloaded file from step 2.
+4. Enjoy!
 
 ### Individual Userstyles
 
 1. Enable CSP Patching from Stylus's **Settings** > **Advanced**.
-2. Install userstyles by clicking the **Stylus Install** badge in each README.
+2. Install userstyles from the list below by clicking the **Stylus Install** badge in each README.
 3. Enjoy!
 
 ## Configuration


### PR DESCRIPTION
Closes #1254. Brings the instructions from https://github.com/catppuccin/userstyles/releases/tag/all-userstyles-export into the main README instead of requiring an extra step. Still working on organizing and displaying the two methods of installation.

Plan for updated release notes contents is:

```diff
This is a rolling release that holds builds generated by the GitHub Actions build process. 
+ See the [usage instructions](https://github.com/catppuccin/userstyles#usage) for more information.
- 
- ### Usage instructions
- 
- 1. Download the `import.json` file from the "Assets" section below.
- 
- > [!TIP]
- > If you want more control over what is included in the `import.json` file, e.g. all userstyles with the accent color `peach`, see "[All Userstyles Import Generator](https://ctp-aui.uncenter.dev/)" by @uncenter.
- 
- 2. Open the Stylus "manage" page.
- 3. Locate backup (on the left bar) and select import.
-    - Select the downloaded file.
- 4. Enjoy!
```