### PR TITLE
docs(CONTRIBUTING.md): link directly to the Stylus wiki

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,7 +15,7 @@ request.
 
 This repositories uses [Deno](https://deno.com/) extensively for linting and automation. We recommend setting up Deno locally to improve your workflow — see ["Installation" - Deno Docs](https://docs.deno.com/runtime/manual/getting_started/installation). With Deno installed locally, you can run the lint script using `deno task lint` (and `deno task lint:fix` to automatically apply fixes) and the formatting script using `deno task format`.
 
-When editing a userstyle, we suggest setting up live reloading so your local changes can be automatically reloaded through Stylus. See ["How can I see my changes in real time?"](./tips-and-tricks.md#how-can-i-see-my-changes-in-real-time).
+When editing a userstyle, we suggest setting up live reloading so your local changes can be automatically reloaded through Stylus. See ["Initial installation and live reload" - Stylus Wiki](https://github.com/openstyles/stylus/wiki/Writing-UserCSS#initial-installation-and-live-reload).
 
 ## Recommendations
 


### PR DESCRIPTION
in https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md there's a hyperlink that links to https://github.com/catppuccin/userstyles/blob/main/docs/tips-and-tricks.md which links to https://github.com/openstyles/stylus/wiki/Writing-UserCSS without providing any additional information. therefore i think it's better to save a click and link directly to the stylus wiki. that is unless this was done purposefully so users know the existence of the tips and tricks file?