### PR TITLE
fix(youtube): misc elements and adjust background colors

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.4
+@version 4.2.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -129,7 +129,7 @@
       --yt-spec-dark-blue-alpha-30: fadeout(@sapphire, 0.3) !important;
 
       --yt-spec-base-background: @base !important;
-      --yt-spec-raised-background: @base !important;
+      --yt-spec-raised-background: @surface0 !important;
       --yt-spec-menu-background: @mantle !important;
       --yt-spec-inverted-background: @text !important;
       --yt-spec-additive-background: fadeout(@surface0, 0.1) !important;
@@ -210,7 +210,7 @@
       --yt-spec-badge-chip-background: if(
         @lookup =latte,
         @crust,
-        @surface1
+        @surface0
       ) !important;
       --yt-spec-verified-badge-background: @overlay0 !important;
       --yt-spec-call-to-action-fadeoutd: fadeout(@sapphire, 0.3) !important;
@@ -751,6 +751,10 @@
     ytd-thumbnail-overlay-resume-playback-renderer {
       background-color: @surface1;
     }
+    .badge-shape-wiz--thumbnail-default {
+      color: @text;
+      background: fade(@crust, 60%);
+    }
 
     /* Panels, popups, tooltips */
 
@@ -798,6 +802,9 @@
       &::after {
         background-color: @subtext0;
       }
+    }
+    .ytp-menuitem[aria-checked="true"] .ytp-menuitem-toggle-checkbox {
+      background: @accent-color;
     }
 
     .ytp-menuitem {

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -132,7 +132,7 @@
       --yt-spec-raised-background: @surface0 !important;
       --yt-spec-menu-background: @mantle !important;
       --yt-spec-inverted-background: @text !important;
-      --yt-spec-additive-background: fadeout(@surface0, 0.1) !important;
+      --yt-spec-additive-background: fadeout(@surface1, 0.1) !important;
       --yt-spec-outline: @surface0 !important;
       --yt-spec-shadow: fadeout(@crust, 0.25) !important;
       --yt-spec-text-primary: @text !important;

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -166,7 +166,7 @@
       --yt-spec-static-ad-yellow: @peach !important;
       --yt-spec-static-grey: @subtext0 !important;
       --yt-spec-static-overlay-background-solid: @crust !important;
-      --yt-spec-static-overlay-background-heavy: @surface0;
+      --yt-spec-static-overlay-background-heavy: @crust;
       --yt-spec-static-overlay-background-medium: fade(@crust, 50%) !important;
       --yt-spec-static-overlay-background-medium-light: fadeout(
         @crust,
@@ -753,7 +753,7 @@
     }
     .badge-shape-wiz--thumbnail-default {
       color: @text;
-      background: fade(@crust, 60%);
+      background: fade(@crust, 80%);
     }
 
     /* Panels, popups, tooltips */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- changed `--yt-spec-raised-background` from `@base` to `@surface0` (because the search suggestions background should be a bit brighter than the main background)
- theme the video duration on the thumbnails
- make the description background darker (same color as the buttons like in unthemed youtube) by changing `--yt-spec-badge-chip-background` to `@surface0` on non-latte flavors
- make the enabled menu item switch background colored with the accent color

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
