### PR TITLE
chore: add .envrc for direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
-use flake
+if has nix_direnv_version; then
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ deno_cache/
 __pycache__/
 node_modules/
 dist/
+.direnv/
 
 .idea/
 .vscode/


### PR DESCRIPTION
This adds an `.envrc` file to automatically use the nix flake dev shell when entering this repository (for direnv users)