### PR TITLE
fix(google-drive): update logo selector

### DIFF
--- a/styles/google-drive/catppuccin.user.css
+++ b/styles/google-drive/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Drive Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google-drive
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-drive
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-drive/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-drive
 @description Soothing pastel theme for Google Drive

--- a/styles/google-drive/catppuccin.user.css
+++ b/styles/google-drive/catppuccin.user.css
@@ -660,7 +660,7 @@
     }
 
     /* Drive icon */
-    .gb_Nc.gb_Nd {
+    [src="//ssl.gstatic.com/images/branding/product/1x/drive_2020q4_48dp.png"] {
       @darkBlue: mix(@blue, @base, 80%);
       @darkGreen: mix(@green, @base, 80%);
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The logo had become unthemed due to the autogenerated classes changing. This updates the selector and uses a more stable attribute (`src`).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
