### PR TITLE
fix(youtube): video highlight

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -923,6 +923,12 @@
       }
     }
 
+    /* Video highlight */
+    ytd-rich-item-renderer.ytd-rich-item-renderer-highlight {
+        background-color: fade(@accent-color, 10%) !important;
+        box-shadow: fade(@accent-color, 10%) 0px 0px 0px 10px !important;
+    }
+
     #shorts-container {
       --yt-spec-static-overlay-text-primary: @white;
       .yt-spec-button-shape-next--overlay.yt-spec-button-shape-next--tonal {

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -926,7 +926,7 @@
     /* Video highlight */
     ytd-rich-item-renderer.ytd-rich-item-renderer-highlight {
         background-color: fade(@accent-color, 10%) !important;
-        box-shadow: fade(@accent-color, 10%) 0px 0px 0px 10px !important;
+        box-shadow: fade(@accent-color, 10%) 1px 1px 1px 10px !important;
     }
 
     #shorts-container {

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.5
+@version 4.2.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes the video highlight being unthemed.

I'm also gonna start to make more simple and easy-to-review PRs rather than last time where these PRs were really bad. (and also stop reviewing init PRs)

<details>
<summary>Before & After</summary>
<img src="https://github.com/user-attachments/assets/494bcdb7-4191-47e7-869a-d650fa86df80" width="300" height="256">
<img src="https://github.com/user-attachments/assets/3136a52a-2e0c-4a94-9b15-7787675461dd" width="300" height="256">
</details>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
