### PR TITLE
fix(gmail): update header icons and search bar selectors, banner message

### DIFF
--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -154,7 +154,12 @@
       background-color: @mantle;
     }
     /* Header icons */
-    .gb_Jc svg, .gb_Nc.gb_Sc svg, .gb_Jc .gb_pd .gb_qd, .gb_Jc .gb_pd .gb_Ic, .gb_Jc .gb_pd .gb_sd, .gb_Nc.gb_Sc .gb_qd {
+    .gb_Jc svg,
+    .gb_Nc.gb_Sc svg,
+    .gb_Jc .gb_pd .gb_qd,
+    .gb_Jc .gb_pd .gb_Ic,
+    .gb_Jc .gb_pd .gb_sd,
+    .gb_Nc.gb_Sc .gb_qd {
       color: @text;
     }
     /* Search mail input */

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Gmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/gmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
-@version 0.2.1
+@version 0.2.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agmail
 @description Soothing pastel theme for Gmail

--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -154,16 +154,11 @@
       background-color: @mantle;
     }
     /* Header icons */
-    .gb_Fc svg,
-    .gb_Lc.gb_Pc svg,
-    .gb_Fc .gb_7c .gb_fd,
-    .gb_Fc .gb_7c .gb_Ec,
-    .gb_Fc .gb_7c .gb_9c,
-    .gb_Lc.gb_Pc .gb_fd {
+    .gb_Jc svg, .gb_Nc.gb_Sc svg, .gb_Jc .gb_pd .gb_qd, .gb_Jc .gb_pd .gb_Ic, .gb_Jc .gb_pd .gb_sd, .gb_Nc.gb_Sc .gb_qd {
       color: @text;
     }
     /* Search mail input */
-    .gb_Fc .gb_Md {
+    .gb_Jc .gb_fd {
       background-color: @crust;
 
       .gb_je,
@@ -579,6 +574,36 @@
     .Tm .ya {
       background-color: @surface1;
       color: @text;
+    }
+    /* You could lose access banner */
+    .GR {
+      background-color: @base;
+
+      /* Primary text */
+      .GX {
+        color: @text;
+      }
+      /* Subtext */
+      .GT {
+        color: @subtext1;
+      }
+
+      /* Dismiss button */
+      .GW {
+        color: @text;
+
+        &::before {
+          background-color: @text;
+        }
+      }
+      /* Add recovery info button */
+      .GV {
+        color: @accent-color;
+
+        &::before {
+          background-color: @accent-color;
+        }
+      }
     }
     /* Attachments chips */
     .brc {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the header icons (3 to the left of pfp, menu/hamburger on the far left), fixes the search bar input background, and themes a banner for adding recovery info.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
