### PR TITLE
fix(gmail): header icons and search bar, other tooltip variant

### DIFF
--- a/styles/gmail/catppuccin.user.css
+++ b/styles/gmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Gmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/gmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
-@version 0.2.2
+@version 0.2.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agmail
 @description Soothing pastel theme for Gmail
@@ -105,7 +105,7 @@
     }
 
     /* Tooltips */
-    .T-ays-iP {
+    .T-ays-iP, .gb_Ac {
       background-color: @crust;
       color: @text;
     }
@@ -154,16 +154,11 @@
       background-color: @mantle;
     }
     /* Header icons */
-    .gb_Jc svg,
-    .gb_Nc.gb_Sc svg,
-    .gb_Jc .gb_pd .gb_qd,
-    .gb_Jc .gb_pd .gb_Ic,
-    .gb_Jc .gb_pd .gb_sd,
-    .gb_Nc.gb_Sc .gb_qd {
+    .gb_Lc svg, .gb_Pc.gb_Uc svg, .gb_Lc .gb_rd .gb_sd, .gb_Lc .gb_rd .gb_Kc, .gb_Lc .gb_rd .gb_ud, .gb_Pc.gb_Uc .gb_sd {
       color: @text;
     }
     /* Search mail input */
-    .gb_Jc .gb_fd {
+    .gb_Lc .gb_hd {
       background-color: @crust;
 
       .gb_je,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

They changed the classes literally hours after #1281 -_-, this updates them yet again. Also themes another class for tooltips.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
