### PR TITLE
fix(hacker-news): set body text color

### DIFF
--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -73,6 +73,7 @@
     }
     body {
       background-color: @mantle;
+      color: @text;
     }
 
     td {

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hacker News Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hacker-news
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news
-@version 1.0.1
+@version 1.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hacker-news/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahacker-news
 @description Soothing pastel theme for Hacker News


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes some text on the login page which is just the page default, setting it here works and presumably fixes other text like it.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
