### PR TITLE
refactor(cobalt): support for new ui

### DIFF
--- a/styles/cobalt/catppuccin.user.css
+++ b/styles/cobalt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name cobalt Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/cobalt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/cobalt
-@version 0.1.0
+@version 0.1.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/cobalt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acobalt
 @description Soothing pastel theme for cobalt
@@ -65,19 +65,26 @@
       }
     }
 
-    --accent: @accent-color;
-    --accent-highlight: fade(@accent-color, 4%);
-    --accent-subtext: @text;
-    --accent-hover: @surface1;
-    --accent-hover-elevated: @surface2;
-    --accent-hover-transparent: fade(@surface1, 5%);
-    --accent-button: @surface0;
-    --accent-button-elevated: @surface1;
-    --glass: fade(@base, 85%);
-    --glass-lite: fade(@base, 98%);
-    --subbackground: @surface0;
-    --background: @base;
-    --background-backdrop: fade(@crust, 5%);
+    --primary: @base;
+    --secondary: @subtext0;
+    --gray: @surface2;
+    --blue: @blue;
+    --green: @green;
+    --button: @surface0;
+    --button-hover: darken(@surface0, 5%);
+    --button-active-hover: darken(@subtext0, 5%);
+    --button-elevated: @surface1;
+    --button-elevated-hover: darken(@surface1, 5%);
+    --button-text: @text;
+    --sidebar-bg: @mantle;
+    --sidebar-highlight: @subtext0;
+    --input-border: @surface2;
+    --popup-bg: @mantle;
+    --toggle-bg-enabled: @accent-color;
+    
+    #cobalt-logo path {
+        fill: @text;
+    }
   }
 }
 

--- a/styles/cobalt/catppuccin.user.css
+++ b/styles/cobalt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name cobalt Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/cobalt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/cobalt
-@version 0.1.5
+@version 0.2.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/cobalt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acobalt
 @description Soothing pastel theme for cobalt


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
I rewrote cobalt so it can be compatible with the new UI.
Fixes #1284 
![image](https://github.com/user-attachments/assets/f0389645-639b-4e9b-aa9d-7e9b9e47c964)

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
