### PR TITLE
fix(cobalt): applicator selectors & unthemed vars

### DIFF
--- a/styles/cobalt/catppuccin.user.css
+++ b/styles/cobalt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name cobalt Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/cobalt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/cobalt
-@version 0.2.0
+@version 0.2.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/cobalt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acobalt
 @description Soothing pastel theme for cobalt

--- a/styles/cobalt/catppuccin.user.css
+++ b/styles/cobalt/catppuccin.user.css
@@ -16,10 +16,10 @@
 ==/UserStyle== */
 
 @-moz-document domain('cobalt.tools') {
-  :root[data-theme="dark"] {
+  [data-theme="dark"] {
     #catppuccin(@darkFlavor, @accentColor);
   }
-  :root[data-theme="light"] {
+  [data-theme="light"] {
     #catppuccin(@lightFlavor, @accentColor);
   }
 
@@ -66,10 +66,13 @@
     }
 
     --primary: @base;
-    --secondary: @subtext0;
-    --gray: @surface2;
+    --secondary: @text;
+    --gray: @subtext0;
     --blue: @blue;
     --green: @green;
+    --red: @maroon;
+    --dark-red: @red;
+    --white: @crust;
     --button: @surface0;
     --button-hover: darken(@surface0, 5%);
     --button-active-hover: darken(@subtext0, 5%);
@@ -77,7 +80,7 @@
     --button-elevated-hover: darken(@surface1, 5%);
     --button-text: @text;
     --sidebar-bg: @mantle;
-    --sidebar-highlight: @subtext0;
+    --sidebar-highlight: @text;
     --input-border: @surface2;
     --popup-bg: @mantle;
     --toggle-bg-enabled: @accent-color;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

...

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
