### PR TITLE
fix(cobalt): sidebar hover & donation page

### DIFF
--- a/styles/cobalt/catppuccin.user.css
+++ b/styles/cobalt/catppuccin.user.css
@@ -86,6 +86,49 @@
     --popup-bg: @mantle;
     --toggle-bg-enabled: @accent-color;
 
+    #donate-page {
+      --donate-gradient-start: @surface1 !important;
+      --donate-gradient-end: @surface0 !important;
+    }
+
+    #banner-left {
+      color: @text;
+    }
+      
+    #banner-subtitle {
+      color: @subtext0;
+      opacity: 1;
+    }
+      
+    .donate-card button {
+      color: @text !important;
+    }
+    
+    .donate-card {
+      color: @text;
+    }
+    
+    .donate-card-title {
+      color: @text;
+    }
+    
+    .donate-card-subtitle {
+      color: @subtext0;
+      opacity: 1;
+    }
+    
+    #input-container.focused {
+      box-shadow: 0 0 0 2px @text inset !important;
+    }
+    
+    #input-dollar-sign {
+      color: @text;
+    }
+    
+    #donation-custom-input {
+      color: @text !important;
+    }
+
     #cobalt-logo path {
       fill: @text;
     }

--- a/styles/cobalt/catppuccin.user.css
+++ b/styles/cobalt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name cobalt Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/cobalt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/cobalt
-@version 0.2.1
+@version 0.2.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/cobalt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acobalt
 @description Soothing pastel theme for cobalt
@@ -80,6 +80,7 @@
     --button-elevated-hover: darken(@surface1, 5%);
     --button-text: @text;
     --sidebar-bg: @mantle;
+    --sidebar-hover: @surface0;
     --sidebar-highlight: @text;
     --input-border: @surface2;
     --popup-bg: @mantle;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Just noticed this as well, the hover over a button/tab on the sidebar was unthemed.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
