### PR TITLE
fix(stylus): delete button

### DIFF
--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stylus Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stylus
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stylus
-@version 1.2.5
+@version 1.2.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stylus/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astylus
 @description Soothing pastel theme for Stylus

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -276,7 +276,7 @@
       }
 
       > div,
-      & [data-cmd="delete"] {
+      [data-cmd="delete"] {
         border-color: @red;
       }
     }

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -276,7 +276,7 @@
       }
 
       > div,
-      &[data-cmd="delete"] {
+      & [data-cmd="delete"] {
         border-color: @red;
       }
     }
@@ -304,7 +304,7 @@
       background: fade(@red, 10%);
       color: @red;
     }
-    .applies-to{
+    .applies-to {
       background-color: @mantle;
     }
   }

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -304,9 +304,6 @@
       background: fade(@red, 10%);
       color: @red;
     }
-    .applies-to {
-      background-color: @mantle;
-    }
   }
 }
 

--- a/styles/stylus/catppuccin.user.css
+++ b/styles/stylus/catppuccin.user.css
@@ -304,6 +304,9 @@
       background: fade(@red, 10%);
       color: @red;
     }
+    .applies-to{
+      background-color: @mantle;
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

### fix the delete button in the popup
before
![image](https://github.com/user-attachments/assets/545d3eac-6ca0-4cf2-bab3-b8e32ddaa8c4)
after
![image](https://github.com/user-attachments/assets/6640f3f3-97f7-4aa4-80e0-94920a16ae75)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
