### PR TITLE
fix(github): unthemed elements

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -576,6 +576,10 @@
       fill: @accent-color;
       stroke: @accent-color;
     }
+
+    .subnav-link.selected{
+      border-bottom-color: @accent-color
+    }
   }
 }
 

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.7.4
+@version      1.7.5
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -505,6 +505,9 @@
     --tooltip-fgColor: @text;
     --tooltip-bgColor: @crust;
 
+    /* Refined GitHub */
+    --rgh-heat-color: @peach;
+
     .turbo-progress-bar {
       background-color: @accent-color;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
theme the bottom border of the selected navigation bar item with the accent color at [/explore](https://github.com/explore) (and topic pages etc)
![image](https://github.com/user-attachments/assets/07e5350f-dd4d-44bf-bd5b-b5bf7f092e82)
theme the `--rgh-heat-color` variable (which is used by [refined github](https://github.com/refined-github/refined-github) to highlight recent commits and most downloaded releases) with the peach color
![image](https://github.com/user-attachments/assets/702bd01e-0bbc-46ec-8e61-1700766bb781)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
