### PR TITLE
fix(github): updated enhanced repo insights views

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.7.5
+@version      1.7.6
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -499,6 +499,7 @@
 
     /* New Enhanced Repo Insights Views - https://github.com/orgs/community/discussions/135572 */
     --data-blue-color: @accent-color;
+    --data-blue-color-emphasis: @accent-color;
     --data-red-color: @red;
     --data-green-color: @green;
 

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -497,11 +497,10 @@
     --shadow-floating-legacy: 0px 6px 12px -3px @crust, 0px 6px 18px 0px @crust;
     --outline-focus: @blue solid 2px;
 
-    /* New Enhanced Repo Insights Views - https://github.com/orgs/community/discussions/135572 */
-    --data-blue-color: @accent-color;
+    /* Enhanced Repo Insights Views - https://github.com/orgs/community/discussions/135572 */
     --data-blue-color-emphasis: @accent-color;
-    --data-red-color: @red;
-    --data-green-color: @green;
+    --data-red-color-emphasis: @red;
+    --data-green-color-emphasis: @green;
 
     --tooltip-fgColor: @text;
     --tooltip-bgColor: @crust;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes unthemed data graphs on the enhanced repo insight views

<details>
<summary>before & after</summary>
<img src="https://github.com/user-attachments/assets/e419f93d-8020-4bcb-ab6b-0f4a47ac713b">
<img src="https://github.com/user-attachments/assets/1ac79bda-92d8-486f-82aa-55f21175e82f">
</details>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
