### PR TITLE
fix(hacker-news): use accent for brand, link & selection colors

### DIFF
--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -148,11 +148,6 @@
       color: @text;
     }
 
-    /* Comment hyperlinks */
-    .commtext a:link {
-      color: @sapphire;
-    }
-
     /* Comment box */
     input,
     textarea,

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -116,13 +116,17 @@
     .comhead {
       &,
       a:link,
-      a:visited {
-        color: @overlay2;
+      a:visited,
+      a:hover {
+        color: @overlay2 !important;
       }
     }
 
     a:link {
       color: @blue;
+      &:hover{
+        color: @sky
+      }
     }
     .hnmore a:link,
     a:visited {

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -52,8 +52,6 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
-    @orange: mix(@peach, @yellow);
-
     color-scheme: if(@lookup = latte, light, dark);
 
     ::selection {
@@ -82,7 +80,7 @@
 
     /* Header */
     td[bgcolor="#ff6600"] {
-      background-color: @orange;
+      background-color: @accent-color;
 
       .pagetop,
       .pagetop a {
@@ -193,7 +191,7 @@
     }
 
     table[bgcolor="#ff6600"] {
-      background-color: @orange;
+      background-color: @accent-color;
     }
   }
 }

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hacker News Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hacker-news
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news
-@version 1.0.2
+@version 1.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hacker-news/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahacker-news
 @description Soothing pastel theme for Hacker News
@@ -124,8 +124,8 @@
 
     a:link {
       color: @blue;
-      &:hover{
-        color: @sky
+      &:hover {
+        color: @sky;
       }
     }
     .hnmore a:link,

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -17,10 +17,14 @@
 
 @-moz-document domain("news.ycombinator.com") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -89,7 +89,7 @@
 
       img[src="y18.svg"] {
         @svg: escape(
-          '<svg height="18" viewBox="4 4 188 188" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M4 4h188v188H4z" fill="@{peach}"/><path d="M73.252 45.01 96 92.401l22.748-47.391h19.566l-34.324 64.487v41.493H88.01v-41.493L53.686 45.01z" fill="@{crust}"/></svg>'
+          '<svg height="18" viewBox="4 4 188 188" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M4 4h188v188H4z" fill="@{accent-color}"/><path d="M73.252 45.01 96 92.401l22.748-47.391h19.566l-34.324 64.487v41.493H88.01v-41.493L53.686 45.01z" fill="@{crust}"/></svg>'
         );
         content: url("data:image/svg+xml,@{svg}");
         border-color: @crust !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
# header+logo color update
![image](https://github.com/user-attachments/assets/336e9dc6-3e50-411e-9982-8626eb113678)
use the accent color instead of a mix of peach and yellow allegedly called "orange" (never heard of it)
# selection color
it wasn't being applied correctly so i added `:root`
# links
there isn't any reason links in comment should be colored differently. also hovered links now are colored with sky (as per the style guide)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
