### PR TITLE
fix(paste.rs): syntax highlighting token selectors, code background

### DIFF
--- a/styles/paste.rs/catppuccin.user.css
+++ b/styles/paste.rs/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name paste.rs Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/paste.rs
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/paste.rs
-@version 0.0.5
+@version 0.0.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/paste.rs/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apaste.rs
 @description Soothing pastel theme for paste.rs
@@ -69,6 +69,7 @@
       background-color: @base;
       color: @text;
     }
+    
     a {
       color: @accent-color;
     }
@@ -91,8 +92,13 @@
     input[type="submit"]:hover {
       background-color: @mantle;
     }
+    
+    main {
+      color: @text;
+      border-color: @surface0;
+    }
 
-    td.linenos > pre {
+    .code.gutter {
       background-color: @base !important;
       span {
         /* Line Numbers */
@@ -148,57 +154,47 @@
     }
 
     /* Syntax-highlighted code */
-    td.code > pre {
+    .code.text > pre {
       background-color: @base !important;
+      background-image: none;
+      
+      span { color: red !important; }
 
       /* General Text, Braces, Delimiters, Parameters, Classes, Metadata */
-      span[style="color:#000000;"] {
+      span[style*="color:#323232"] {
         color: @text !important;
       }
 
       /* Keywords, Operators */
-      span[style="color:#d73a49;"] {
+      span[style*="color:#a71d5d"] {
         color: @mauve !important;
       }
 
       /* Strings */
-      span[style="color:#032f62;"] {
+      span[style*="color:#183691"],
+      span[style*="color:#ed6a43"] {
         color: @green !important;
       }
 
-      /* Escape Sequences */
-      span[style="color:#183691;"] {
-        color: @pink !important;
-      }
-
       /* Comments */
-      span[style="color:#969896;"] {
+      span[style*="color:#969896"] {
         color: @overlay2 !important;
       }
 
       /* Constants, Numbers */
-      span[style="color:#005cc5;"] {
+      span[style*="color:#0086b3"] {
         color: @peach !important;
       }
 
       /* Methods, Functions */
-      span[style="color:#6f42c1;"],
-      span[style="color:#22863a;"] {
+      span[style*="color:#795da3"],
+      span[style*="color:#62a35c"],
+      span[style*="color:#63a35c"]{
         color: @blue !important;
       }
 
-      /* Builtins */
-      span[style="color:#0086b3;"] {
-        color: @red !important;
-      }
-
-      /* Metadata */
-      span[style="color:#795da3;"] {
-        color: @yellow !important;
-      }
-
       /* Errors */
-      span[style="background-color:#b31d28;color:#fafbfc;"] {
+      span[style*="background-color:#f5f5f5"][style*="color:#b52a1d"] {
         color: @text !important;
         background: fade(@red, 60%) !important;
       }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fix syntax highlighting since last update

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
