### PR TITLE
refactor(tree-wide): add missing `:root` to 9 styles

### DIFF
--- a/styles/advent-of-code/catppuccin.user.css
+++ b/styles/advent-of-code/catppuccin.user.css
@@ -17,10 +17,14 @@
 
 @-moz-document domain("adventofcode.com") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/advent-of-code/catppuccin.user.css
+++ b/styles/advent-of-code/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Advent Of Code Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/advent-of-code
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/advent-of-code
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/advent-of-code/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aadvent-of-code
 @description Soothing pastel theme for Advent Of Code

--- a/styles/crowdin/catppuccin.user.css
+++ b/styles/crowdin/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Crowdin Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/crowdin
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/crowdin
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/crowdin/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acrowdin
 @description Soothing pastel theme for Crowdin

--- a/styles/crowdin/catppuccin.user.css
+++ b/styles/crowdin/catppuccin.user.css
@@ -18,10 +18,14 @@
 @-moz-document regexp("https://crowdin.com(?!/translate).*")
 {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/invokeai/catppuccin.user.css
+++ b/styles/invokeai/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name InvokeAI Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/invokeai
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/invokeai
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/invokeai/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainvokeai
 @description Soothing pastel theme for InvokeAI

--- a/styles/invokeai/catppuccin.user.css
+++ b/styles/invokeai/catppuccin.user.css
@@ -17,10 +17,14 @@
 
 @-moz-document regexp("http:\\/\\/(127\\.0\\.0\\.1|localhost):9090(.*)") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/lastfm/catppuccin.user.css
+++ b/styles/lastfm/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Last.fm Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/lastfm
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/lastfm
-@version 1.2.0
+@version 1.2.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/lastfm/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Alastfm
 @description Soothing pastel theme for Last.fm

--- a/styles/lastfm/catppuccin.user.css
+++ b/styles/lastfm/catppuccin.user.css
@@ -17,10 +17,14 @@
 
 @-moz-document domain("last.fm") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/openmediavault/catppuccin.user.css
+++ b/styles/openmediavault/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name openmediavault Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/openmediavault
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/openmediavault
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/openmediavault/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aopenmediavault
 @description Soothing pastel theme for openmediavault

--- a/styles/openmediavault/catppuccin.user.css
+++ b/styles/openmediavault/catppuccin.user.css
@@ -17,10 +17,14 @@
 
 @-moz-document domain("openmediavault.example.com") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/paste.rs/catppuccin.user.css
+++ b/styles/paste.rs/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name paste.rs Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/paste.rs
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/paste.rs
-@version 0.0.6
+@version 0.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/paste.rs/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apaste.rs
 @description Soothing pastel theme for paste.rs

--- a/styles/paste.rs/catppuccin.user.css
+++ b/styles/paste.rs/catppuccin.user.css
@@ -17,10 +17,14 @@
 
 @-moz-document domain("paste.rs") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -17,11 +17,15 @@
 
 @-moz-document regexp("^https?:\\/\\/(www|[a-z]{2}).pinterest.(com(.(au|mx))?|co(.(uk|kr))?|at|ca|ch|cl|de|dk|es|fr|ie|it|jp|nz|ph|pt|ru|se)\\/.*") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
 
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {
@@ -56,6 +60,10 @@
 
     color-scheme: if(@lookup = latte, light, dark);
 
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
     input,
     textarea {
       &::placeholder {
@@ -63,94 +71,92 @@
       }
     }
 
-    :root {
-      --color-text-light: if((@lookup = latte), @mantle, @text);
-      --color-text-dark: if((@lookup = latte), @text, @mantle);
-      --color-text-default: @text;
-      --color-text-inverse: @mantle;
-      --color-text-subtle: @subtext0;
-      --color-text-error: @accent-color;
-      --color-text-shopping: @accent-color;
-      --color-text-link: @accent-color;
+    --color-text-light: if((@lookup = latte), @mantle, @text);
+    --color-text-dark: if((@lookup = latte), @text, @mantle);
+    --color-text-default: @text;
+    --color-text-inverse: @mantle;
+    --color-text-subtle: @subtext0;
+    --color-text-error: @accent-color;
+    --color-text-shopping: @accent-color;
+    --color-text-link: @accent-color;
 
-      --color-text-icon-light: if((@lookup = latte), @mantle, @subtext1);
-      --color-text-icon-dark: if((@lookup = latte), @subtext1, @mantle);
-      --color-text-icon-default: @subtext0;
-      --color-icon-subtle: @subtext1;
-      --color-text-icon-inverse: @mantle;
-      --color-text-icon-subtle: @subtext0;
-      --color-text-icon-error: @accent-color;
-      --color-text-icon-brand-primary: @accent-color;
+    --color-text-icon-light: if((@lookup = latte), @mantle, @subtext1);
+    --color-text-icon-dark: if((@lookup = latte), @subtext1, @mantle);
+    --color-text-icon-default: @subtext0;
+    --color-icon-subtle: @subtext1;
+    --color-text-icon-inverse: @mantle;
+    --color-text-icon-subtle: @subtext0;
+    --color-text-icon-error: @accent-color;
+    --color-text-icon-brand-primary: @accent-color;
 
-      --color-background-light: if((@lookup = latte), @mantle, @subtext1);
-      --color-background-dark: if((@lookup = latte), @text, @mantle);
-      --color-background-default: @base;
-      --color-background-inverse-base: @subtext1;
-      --color-background-primary-base: @accent-color;
-      --color-background-secondary-base: @mantle;
-      --color-background-secondary-active: @mantle;
-      --color-background-selected-base: @subtext1;
-      --color-background-box-default: @mantle;
-      --color-background-box-selected: @accent-color;
-      --color-background-box-primary: @accent-color;
-      --color-background-box-secondary: @surface1;
-      --color-background-overlay: @surface0;
-      --color-background-popover-primary: @mantle;
-      --color-background-popover-secondary: @overlay2;
-      --color-background-tag-primary-hover: @surface2;
-      --color-background-box-light: @mantle;
-      --color-background-button-secondary-default: @surface0;
-      --color-background-button-secondary-hover: @surface1;
-      --color-background-button-secondary-active: @surface2;
-      --color-background-tag-primary-default: @surface1;
-      --color-background-button-disabled-default: darken(@mantle, 2%);
-      --color-background-formfield-primary: @surface0;
-      --color-border-container: @surface1;
-      --color-border-default: @mantle;
-      --color-border-popover-primary: @surface0;
-      --color-border-popover-secondary: @text;
-      --color-text-success: @green;
-      --color-text-warning: @yellow;
-      --color-icon-success: @green;
-      --color-icon-warning: @yellow;
-      --color-icon-error: @red;
-      --color-icon-info: @blue;
-      --color-icon-recommendation: @mauve;
-      --color-icon-brand-primary: @accent-color;
-      --color-icon-inverse: @crust;
-      --color-background-brand: @accent-color;
-      --color-background-box-brand: @accent-color;
-      --color-background-button-primary-default: @accent-color;
-      --color-background-badge-warning: @yellow;
-      --color-background-badge-success: @green;
-      --color-background-education: @blue;
-      --color-background-primary-strong: @accent-color;
-      --color-background-shopping: @blue;
+    --color-background-light: if((@lookup = latte), @mantle, @subtext1);
+    --color-background-dark: if((@lookup = latte), @text, @mantle);
+    --color-background-default: @base;
+    --color-background-inverse-base: @subtext1;
+    --color-background-primary-base: @accent-color;
+    --color-background-secondary-base: @mantle;
+    --color-background-secondary-active: @mantle;
+    --color-background-selected-base: @subtext1;
+    --color-background-box-default: @mantle;
+    --color-background-box-selected: @accent-color;
+    --color-background-box-primary: @accent-color;
+    --color-background-box-secondary: @surface1;
+    --color-background-overlay: @surface0;
+    --color-background-popover-primary: @mantle;
+    --color-background-popover-secondary: @overlay2;
+    --color-background-tag-primary-hover: @surface2;
+    --color-background-box-light: @mantle;
+    --color-background-button-secondary-default: @surface0;
+    --color-background-button-secondary-hover: @surface1;
+    --color-background-button-secondary-active: @surface2;
+    --color-background-tag-primary-default: @surface1;
+    --color-background-button-disabled-default: darken(@mantle, 2%);
+    --color-background-formfield-primary: @surface0;
+    --color-border-container: @surface1;
+    --color-border-default: @mantle;
+    --color-border-popover-primary: @surface0;
+    --color-border-popover-secondary: @text;
+    --color-text-success: @green;
+    --color-text-warning: @yellow;
+    --color-icon-success: @green;
+    --color-icon-warning: @yellow;
+    --color-icon-error: @red;
+    --color-icon-info: @blue;
+    --color-icon-recommendation: @mauve;
+    --color-icon-brand-primary: @accent-color;
+    --color-icon-inverse: @crust;
+    --color-background-brand: @accent-color;
+    --color-background-box-brand: @accent-color;
+    --color-background-button-primary-default: @accent-color;
+    --color-background-badge-warning: @yellow;
+    --color-background-badge-success: @green;
+    --color-background-education: @blue;
+    --color-background-primary-strong: @accent-color;
+    --color-background-shopping: @blue;
 
-      --g-colorTransparentWhite: fadeout(@base, 30%);
-      --g-colorTransparentDarkGray: fadeout(@mantle, 20%);
-      --g-colorGray0: @mantle;
-      --g-colorGray0Hovered: darken(@mantle, 2.5%);
-      --g-colorGray0Active: darken(@mantle, 5%);
-      --g-colorGray50: @mantle;
-      --g-colorGray100: @mantle;
-      --g-colorGray100Hovered: darken(@surface0, 2.5%);
-      --g-colorGray100Active: darken(@surface0, 5%);
-      --g-colorGray200: @subtext0;
-      --g-colorGray300: @subtext1;
-      --g-colorRed100: @accent-color;
-      --g-colorRed100Hovered: darken(@accent-color, 7.5%);
-      --g-colorRed100Active: darken(@accent-color, 10%);
-      --g-color-focus: fadeout(@accent-color, 50%);
-      --color-gray-roboflow-400: @crust;
-      --color-gray-roboflow-200: @mantle;
+    --g-colorTransparentWhite: fadeout(@base, 30%);
+    --g-colorTransparentDarkGray: fadeout(@mantle, 20%);
+    --g-colorGray0: @mantle;
+    --g-colorGray0Hovered: darken(@mantle, 2.5%);
+    --g-colorGray0Active: darken(@mantle, 5%);
+    --g-colorGray50: @mantle;
+    --g-colorGray100: @mantle;
+    --g-colorGray100Hovered: darken(@surface0, 2.5%);
+    --g-colorGray100Active: darken(@surface0, 5%);
+    --g-colorGray200: @subtext0;
+    --g-colorGray300: @subtext1;
+    --g-colorRed100: @accent-color;
+    --g-colorRed100Hovered: darken(@accent-color, 7.5%);
+    --g-colorRed100Active: darken(@accent-color, 10%);
+    --g-color-focus: fadeout(@accent-color, 50%);
+    --color-gray-roboflow-400: @crust;
+    --color-gray-roboflow-200: @mantle;
 
-      --g-blue: @accent-color;
-      --color-background-info-base: @blue;
-      --color-background-error-base: @red;
-      --color-background-warning-base: @peach;
-      --color-background-success-base: @green;
-    }
+    --g-blue: @accent-color;
+    --color-background-info-base: @blue;
+    --color-background-error-base: @red;
+    --color-background-warning-base: @peach;
+    --color-background-success-base: @green;
 
     body {
       background-color: @base;
@@ -158,11 +164,8 @@
     }
 
     /* the void (parts not loaded yet) */
-    html {
+    & {
       background: @base !important;
-      ::selection {
-        background-color: fade(@accent-color, 30%);
-      }
     }
 
     .EmojiPickerReact {

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -17,11 +17,15 @@
 
 @-moz-document regexp("^https?:\\/\\/(www|[a-z]{2}).pinterest.(com(.(au|mx))?|co(.(uk|kr))?|at|ca|ch|cl|de|dk|es|fr|ie|it|jp|nz|ph|pt|ru|se)\\/.*") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
 
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Pinterest Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/pinterest
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pinterest
-@version 1.1.6
+@version 1.1.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pinterest/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apinterest
 @description Soothing pastel theme for Pinterest

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -56,10 +56,6 @@
 
     color-scheme: if(@lookup = latte, light, dark);
 
-    ::selection {
-      background-color: fade(@accent-color, 30%);
-    }
-
     input,
     textarea {
       &::placeholder {
@@ -164,6 +160,9 @@
     /* the void (parts not loaded yet) */
     html {
       background: @base !important;
+      ::selection {
+        background-color: fade(@accent-color, 30%);
+      }
     }
 
     .EmojiPickerReact {

--- a/styles/pinterest/catppuccin.user.css
+++ b/styles/pinterest/catppuccin.user.css
@@ -17,15 +17,11 @@
 
 @-moz-document regexp("^https?:\\/\\/(www|[a-z]{2}).pinterest.(com(.(au|mx))?|co(.(uk|kr))?|at|ca|ch|cl|de|dk|es|fr|ie|it|jp|nz|ph|pt|ru|se)\\/.*") {
   @media (prefers-color-scheme: light) {
-    :root {
-      #catppuccin(@lightFlavor, @accentColor);
-    }
+    #catppuccin(@lightFlavor, @accentColor);
   }
 
   @media (prefers-color-scheme: dark) {
-    :root {
-      #catppuccin(@darkFlavor, @accentColor);
-    }
+    #catppuccin(@darkFlavor, @accentColor);
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/quizlet/catppuccin.user.css
+++ b/styles/quizlet/catppuccin.user.css
@@ -17,10 +17,14 @@
 
 @-moz-document domain("quizlet.com") {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/quizlet/catppuccin.user.css
+++ b/styles/quizlet/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Quizlet Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/quizlet
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/quizlet
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/quizlet/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aquizlet
 @description Soothing pastel theme for Quizlet

--- a/styles/spotify-web/catppuccin.user.css
+++ b/styles/spotify-web/catppuccin.user.css
@@ -16,10 +16,14 @@
 ==/UserStyle== */
 @-moz-document domain('open.spotify.com') {
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/spotify-web/catppuccin.user.css
+++ b/styles/spotify-web/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Spotify Web Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/spotify-web
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/spotify-web
-@version 0.0.3
+@version 0.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/spotify-web/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aspotify-web
 @description Soothing pastel theme for Spotify Web


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

userstyles that depend on the user's system theme use this snippet from the template style:
```less
  @media (prefers-color-scheme: light) {
    :root {
      #catppuccin(@lightFlavor, @accentColor);
    }
  }
  @media (prefers-color-scheme: dark) {
    :root {
      #catppuccin(@darkFlavor, @accentColor);
    }
  }
```
however some userstyles doesn't have the `:root` part which results in the selection background color not working

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
