### PR TITLE
fix(duckduckgo): light theme flash on page load

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.2.7
+@version 0.2.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -16,12 +16,23 @@
 ==/UserStyle== */
 
 @-moz-document domain(duckduckgo.com) {
-  :root:not(.dark-bg) {
-    #catppuccin(@lightFlavor, @accentColor);
-  }
+  :root {
+    &:not(.dark-bg):not(.no-theme) {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
 
-  :root.dark-bg {
-    #catppuccin(@darkFlavor, @accentColor);
+    &.dark-bg {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+
+    &.no-theme {
+      @media (prefers-color-scheme: light) {
+        #catppuccin(@lightFlavor, @accentColor);
+      }
+      @media (prefers-color-scheme: dark) {
+        #catppuccin(@darkFlavor, @accentColor);
+      }
+    }
   }
 
   #catppuccin(@lookup, @accent) {

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -17,7 +17,7 @@
 
 @-moz-document domain(duckduckgo.com) {
   :root {
-    &:not(.dark-bg):not(.no-theme) {
+    &:not(.dark-bg, .no-theme) {
       #catppuccin(@lightFlavor, @accentColor);
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

on duckduckgo when the page loads and before js finished loading the page have a `no-theme` class.
on unthemed duckduckgo this class makes the page follows the system theme
but with catppuccin that defaults to the light mode, which causes a light flash for a short time on load

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
