### PR TITLE
fix(mastodon): add `.theme-system` to applicator selectors

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Mastodon Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version 1.3.3
+@version 1.3.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amastodon
 @description Soothing pastel theme for Mastodon
@@ -37,6 +37,7 @@ domain("toot.wales") {
 
   @media (prefers-color-scheme: light) {
     .theme-default,
+    .theme-system,
     .skin-default,
     .skin-system {
       #catppuccin(@lightFlavor, @accentColor);
@@ -45,6 +46,7 @@ domain("toot.wales") {
 
   @media (prefers-color-scheme: dark) {
     .theme-default,
+    .theme-system,
     .skin-default,
     .skin-system {
       #catppuccin(@darkFlavor, @accentColor);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes the system theme not working on https://mastodon.social  by adding ``.theme-system`` to the applicator selectors

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
