### PR TITLE
fix(vikunja): fix icon buttons & loading spinners

### DIFF
--- a/styles/vikunja/catppuccin.user.css
+++ b/styles/vikunja/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Vikunja Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/vikunja
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/vikunja
-@version 0.0.2
+@version 0.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/vikunja/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Avikunja
 @description Soothing pastel theme for Vikunja
@@ -163,6 +163,10 @@
       &:active {
         background: darken(@accent-color, 10%);
       }
+      
+      span.icon {
+        color: @base !important;
+      }
     }
 
     button.base-button:not(.is-primary) {
@@ -224,6 +228,10 @@
     .progress-bar {
       --progress-bar-background-color: @crust;
       --progress-value-background-color: @accent-color;
+    }
+
+    .loader-container.is-loading::after {
+      --loader-border-color: @accent-color;
     }
 
     /* Gantt */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes icon buttons having icon with different color than text and the unthemed loading spinner.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
