### PR TITLE
fix(youtube): shorts text on homepage

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.7
+@version 4.2.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -976,6 +976,14 @@
           color: @text;
         }
       }
+    }
+
+    /* Shorts titles and views on homepage */
+    .ShortsLockupViewModelHostOutsideMetadataEndpoint {
+      color: @text;
+    }
+    .ShortsLockupViewModelHostOutsideMetadataSubhead {
+      color: @subtext1;
     }
 
     /* Buy super thanks bar */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
(see bottom of image)

| Before | After |
| --- | --- |
| ![CleanShot 2024-09-14 at 14 57 48](https://github.com/user-attachments/assets/b99c5093-8086-4771-a847-8127cde1ef0b) | ![CleanShot 2024-09-14 at 14 57 28](https://github.com/user-attachments/assets/d787d4c2-71f2-471b-80d9-fd42e148b43f) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
