### PR TITLE
fix(mastodon): about page

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -149,7 +149,8 @@ domain("toot.wales") {
     .status__content,
     .status__content__text,
     .card__bar .display-name strong,
-    .about__mail {
+    .about__mail,
+    .about__domain-blocks__domain h6 {
       color: @text;
     }
 
@@ -169,7 +170,8 @@ domain("toot.wales") {
     .label_input .search__input,
     .search__input:focus,
     .account__header__fields dt,
-    .rules-list__hint {
+    .rules-list__hint,
+    .about__domain-blocks__domain {
       color: @subtext0;
     }
 

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Mastodon Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version 1.3.4
+@version 1.3.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amastodon
 @description Soothing pastel theme for Mastodon

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -148,7 +148,8 @@ domain("toot.wales") {
     .reply-indicator__content,
     .status__content,
     .status__content__text,
-    .card__bar .display-name strong {
+    .card__bar .display-name strong,
+    .about__mail {
       color: @text;
     }
 
@@ -167,7 +168,8 @@ domain("toot.wales") {
     .account .account__display-name,
     .label_input .search__input,
     .search__input:focus,
-    .account__header__fields dt {
+    .account__header__fields dt,
+    .rules-list__hint {
       color: @subtext0;
     }
 
@@ -194,8 +196,28 @@ domain("toot.wales") {
     .status__content a.unhandled-link,
     .announcements__item__content a.unhandled-link,
     .reactions-bar__item.active .reactions-bar__item__count,
-    .column-header.active .column-header__icon {
+    .column-header.active .column-header__icon,
+    .about__section__title {
       color: @accent-color;
+    }
+
+    .prose {
+        h1, h2, h3, h4, strong {
+            color: @text;
+        }
+        color: @subtext0;
+    }
+    
+    .rules-list {
+        color: @text;
+        li:before {
+            background-color: @accent-color;
+            color: @crust;
+        }
+    }
+      
+    .about__domain-blocks__domain:nth-child(2n) {
+        background-color: @surface0;
     }
 
     .icon-button.active.inverted {

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -202,22 +202,26 @@ domain("toot.wales") {
     }
 
     .prose {
-        h1, h2, h3, h4, strong {
-            color: @text;
-        }
-        color: @subtext0;
-    }
-    
-    .rules-list {
+      h1,
+      h2,
+      h3,
+      h4,
+      strong {
         color: @text;
-        li:before {
-            background-color: @accent-color;
-            color: @crust;
-        }
+      }
+      color: @subtext0;
     }
-      
+
+    .rules-list {
+      color: @text;
+      li:before {
+        background-color: @accent-color;
+        color: @crust;
+      }
+    }
+
     .about__domain-blocks__domain:nth-child(2n) {
-        background-color: @surface0;
+      background-color: @surface0;
     }
 
     .icon-button.active.inverted {

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -214,7 +214,7 @@ domain("toot.wales") {
 
     .rules-list {
       color: @text;
-      li:before {
+      li::before {
         background-color: @accent-color;
         color: @crust;
       }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes a bunch of unthemed stuff I found on the about page (https://mastodon.social/about) including unthemed text

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
