### PR TITLE
feat(akkoma): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -157,6 +157,13 @@ userstyles:
     readme:
       app-link: "https://www.amplenote.com"
     current-maintainers: [*stellophiliac]
+  akkoma:
+    name: Akkoma
+    categories: [social_networking]
+    color: mauve
+    readme:
+      app-link: "https://akkoma.social/"
+    current-maintainers: []
   anilist:
     name: ["AniList", "AniChart"]
     categories: [entertainment, social_networking]

--- a/styles/akkoma/catppuccin.user.css
+++ b/styles/akkoma/catppuccin.user.css
@@ -1,0 +1,175 @@
+/* ==UserStyle==
+@name Akkoma Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/akkoma
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/akkoma
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/akkoma/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aakkoma
+@description Soothing pastel theme for Akkoma
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+
+@var checkbox wallpaper "Enable Instance wallpaper" 0
+
+==/UserStyle== */
+
+/* Domains picked from https://akkoma.fediverse.observer/list. */
+
+@-moz-document domain('seafoam.space'),
+domain('labyrinth.zone'),
+domain('mycrowd.ca'),
+domain('blob.cat'),
+domain('fedi.absturztau.be'),
+domain('eepy.express') {
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    /* background, foreground, colors, icons and links */
+    --bg: @base;
+    --wallpaper: @mantle;
+    --fg: @surface0;
+    --cRed: @red;
+    --cGreen: @green;
+    --cOrange: @peach;
+    --cBlue: @blue;
+    --accent: @accent-color;
+    --link: @accent-color;
+    --fgLink: @accent-color;
+    --topBarLink: @subtext0;
+    --panelLink: @accent-color;
+    --panel: @mantle;
+    --topBar: @base;
+    --icon: @subtext0;
+    --poll: @surface0;
+    --border: @surface0;
+    --underlay: none !important;
+    /* text */
+    --text: @text;
+    --selectedMenuPopoverText: @text;
+    --lightText: @text;
+    --tabActiveText: @text;
+    --topBarText: @text;
+    --inputTopbarText: @text;
+    --inputPanelText: @text;
+    --inputText: @text;
+    --panelText: @text;
+    --btnText: @text;
+    --btnTopBarText: @text;
+    --fgText: @subtext0;
+    --pollText: @subtext0;
+    /* fainted text, aswell as some colored ones */
+    --faint: fade(@subtext0, 50%) !important;
+    --panelFaint: fade(@subtext0, 50%) !important;
+    --popoverFaintText: fade(@subtext0, 50%);
+    --faintLink: fade(@accent-color, 50%);
+    --postCyantext: @sapphire;
+    --postGreentext: @green;
+    /* buttons (including disabled ones) */
+    --btn: @surface0;
+    --btnDisabled: darken(@surface0, 10%);
+    --btnDisabledText: @subtext0;
+    /* notifications/alerts */
+    --badgeNotification: @red;
+    --badgeNotificationText: @crust;
+    --alertPopupNeutral: @surface0;
+    --alertPopupNeutralText: @text;
+    --alertPopupSuccess: @green;
+    --alertPopupSuccessText: @crust;
+    --alertPopupWarning: @yellow;
+    --alertPopupWarningText: @text;
+    --alertPopupError: @red;
+    --alertPopupErrorText: @crust;
+    /* input */
+    --input: @surface0;
+    /* selections */
+    --selectedPost: @mantle;
+    --selectedPostText: @subtext0;
+    --selectedPostLightText: @text;
+    --selectedPostIcon: @text;
+    --selectedPostFaintText: @subtext0;
+    --selectedMenuFaintLink: @accent-color;
+    --selectedMenuPopoverFaintLink: @accent-color;
+    --selectedMenuIcon: @accent-color;
+    --selectedMenu: @surface0;
+    --selectedMenuText: @text;
+    /* dropdowns (or popovers) */
+    --popover: @surface0 !important;
+    --popoverText: @text;
+    --popoverIcon: @subtext0;
+    --selectedMenuPopover: darken(@surface0, 5%);
+    /* profile tint */
+    --profileTint: @mantle !important;
+
+    /* disable/enable instance wallpaper */
+    & when (@wallpaper = 0) {
+      #app-loaded {
+        --body-background-image: @mantle !important;
+      }
+    }
+  }
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}
+
+// vim:ft=less

--- a/styles/akkoma/catppuccin.user.css
+++ b/styles/akkoma/catppuccin.user.css
@@ -20,12 +20,12 @@
 
 /* Domains picked from https://akkoma.fediverse.observer/list. */
 
-@-moz-document domain('seafoam.space'),
-domain('labyrinth.zone'),
-domain('mycrowd.ca'),
-domain('blob.cat'),
+@-moz-document domain('blob.cat'),
+domain('pleroma.noellabo.jp'),
 domain('fedi.absturztau.be'),
-domain('eepy.express') {
+domain('labyrinth.zone'),
+domain('seafoam.space'),
+domain('void.lgbt') {
   @media (prefers-color-scheme: light) {
     :root {
       #catppuccin(@lightFlavor, @accentColor);

--- a/styles/akkoma/catppuccin.user.css
+++ b/styles/akkoma/catppuccin.user.css
@@ -154,15 +154,6 @@ domain('void.lgbt') {
     --popoverText: @text;
     --popoverIcon: @subtext0;
     --selectedMenuPopover: darken(@surface0, 5%);
-    /* roundness */
-    --btnRadius: 3px;
-    --inputRadius: 3px;
-    --checkboxRadius: 2px;
-    --panelRadius: 3px;
-    --avatarRadius: 3px;
-    --avatarAltRadius: 50px;
-    --tooltipRadius: 2px;
-    --attachmentRadius: 3px;
     /* profile tint */
     --profileTint: @mantle !important;
 

--- a/styles/akkoma/catppuccin.user.css
+++ b/styles/akkoma/catppuccin.user.css
@@ -123,6 +123,8 @@ domain('void.lgbt') {
     --btn: @surface0;
     --btnDisabled: darken(@surface0, 10%);
     --btnDisabledText: @subtext0;
+    --btnPressed: darken(@surface0, 5%);
+    --btnPressedText: @subtext0;
     /* notifications/alerts */
     --badgeNotification: @red;
     --badgeNotificationText: @crust;
@@ -152,6 +154,15 @@ domain('void.lgbt') {
     --popoverText: @text;
     --popoverIcon: @subtext0;
     --selectedMenuPopover: darken(@surface0, 5%);
+    /* roundness */
+    --btnRadius: 3px;
+    --inputRadius: 3px;
+    --checkboxRadius: 2px;
+    --panelRadius: 3px;
+    --avatarRadius: 3px;
+    --avatarAltRadius: 50px;
+    --tooltipRadius: 2px;
+    --attachmentRadius: 3px;
     /* profile tint */
     --profileTint: @mantle !important;
 

--- a/styles/akkoma/preview.webp
+++ b/styles/akkoma/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:552d95bf8ac338efc508ebdbd5b7317f8acbeaa10d3b8591c982c3574e675b2c
+size 224620


### PR DESCRIPTION
## 🎉 Theme for [Akkoma](https://akkoma.social/) 🎉
![image](https://github.com/user-attachments/assets/f2dbbf10-6e07-4726-813d-5cd725453460)
Akkoma is a small microblogging platform, aka the cooler pleroma

## 💬 Additional Comments 💬
N/A

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [X] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [X] I have ensured that the new directory is in **lower-kebab-case**.
  - [X] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [X] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [X] I have included the following files:
  - [X] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [X] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
