### PR TITLE
fix(youtube): shorts progress bar

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -977,6 +977,11 @@
         color: @white;
       }
 
+      .YtProgressBarLineProgressBarPlayed,
+      .YtProgressBarPlayheadProgressBarPlayheadDot {
+        background-color: @accent-color !important;
+      }
+
       .yt-spec-button-shape-next--overlay-dark.yt-spec-button-shape-next--filled {
         background-color: @accent-color;
         color: @crust;

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.9
+@version 4.3.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes the unthemed progressbar on shorts.

<details>
<summary>Preview</summary>
<img src="https://github.com/user-attachments/assets/1c920b4d-caac-4ccf-9d4c-8a5a0a0686ef">
</details>


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
