### PR TITLE
fix(youtube): revert `--yt-spec-raised-background` back to base

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.9
+@version 4.2.10
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -129,7 +129,7 @@
       --yt-spec-dark-blue-alpha-30: fadeout(@sapphire, 0.3) !important;
 
       --yt-spec-base-background: @base !important;
-      --yt-spec-raised-background: @surface0 !important;
+      --yt-spec-raised-background: @base !important;
       --yt-spec-menu-background: @mantle !important;
       --yt-spec-inverted-background: @text !important;
       --yt-spec-additive-background: fadeout(@surface1, 0.1) !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Reverts a variable change that unintentionally messed up other places.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
