### PR TITLE
fix(migadu-webmail): misc

### DIFF
--- a/styles/migadu-webmail/catppuccin.user.css
+++ b/styles/migadu-webmail/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Migadu Webmail Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/migadu-webmail
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/migadu-webmail
-@version 0.0.10
+@version 0.0.11
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/migadu-webmail/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amigadu-webmail
 @description Soothing pastel theme for Migadu Webmail
@@ -80,7 +80,7 @@
     --dropdown-menu-bg-color: @base;
     --dropdown-menu-hover-bg-color: @surface1;
     --dropdown-menu-hover-color: @text;
-    --dropdown-menu-disable-color: @overlay0;
+    --dropdown-menu-disabled-color: @subtext0;
     --dropdown-menu-border-clr: @surface0;
     --folders-color: @text;
     --folders-disabled-color: @surface2;
@@ -428,6 +428,7 @@
     .messageListItem {
       &.focused {
         border-left-color: @surface2;
+        background-color: @surface0;
       }
 
       &.checked {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes a typo relating to a color for a disabled element and the background color for a specific variant of focused messages.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
