### PR TITLE
Update catppuccin.user.css

### DIFF
--- a/styles/paste.rs/catppuccin.user.css
+++ b/styles/paste.rs/catppuccin.user.css
@@ -1,11 +1,10 @@
 /* ==UserStyle==
-@name paste.rs Catppuccin
-@namespace github.com/catppuccin/userstyles/styles/paste.rs
-@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/paste.rs
-@version 0.0.7
-@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/paste.rs/catppuccin.user.css
-@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apaste.rs
-@description Soothing pastel theme for paste.rs
+@name Gmail Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/gmail
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gmail
+@version 0.1.5
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agmail
+@description Soothing pastel theme for Gmail
 @author Catppuccin
 @license MIT
 
@@ -14,206 +13,841 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
-
-@-moz-document domain("paste.rs") {
-  @media (prefers-color-scheme: light) {
-    :root {
-      #catppuccin(@lightFlavor, @accentColor);
-    }
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      #catppuccin(@darkFlavor, @accentColor);
-    }
-  }
-
-  #catppuccin(@lookup, @accent) {
-    @rosewater: @catppuccin[@@lookup][@rosewater];
-    @flamingo: @catppuccin[@@lookup][@flamingo];
-    @pink: @catppuccin[@@lookup][@pink];
-    @mauve: @catppuccin[@@lookup][@mauve];
-    @red: @catppuccin[@@lookup][@red];
-    @maroon: @catppuccin[@@lookup][@maroon];
-    @peach: @catppuccin[@@lookup][@peach];
-    @yellow: @catppuccin[@@lookup][@yellow];
-    @green: @catppuccin[@@lookup][@green];
-    @teal: @catppuccin[@@lookup][@teal];
-    @sky: @catppuccin[@@lookup][@sky];
-    @sapphire: @catppuccin[@@lookup][@sapphire];
-    @blue: @catppuccin[@@lookup][@blue];
-    @lavender: @catppuccin[@@lookup][@lavender];
-    @text: @catppuccin[@@lookup][@text];
-    @subtext1: @catppuccin[@@lookup][@subtext1];
-    @subtext0: @catppuccin[@@lookup][@subtext0];
-    @overlay2: @catppuccin[@@lookup][@overlay2];
-    @overlay1: @catppuccin[@@lookup][@overlay1];
-    @overlay0: @catppuccin[@@lookup][@overlay0];
-    @surface2: @catppuccin[@@lookup][@surface2];
-    @surface1: @catppuccin[@@lookup][@surface1];
-    @surface0: @catppuccin[@@lookup][@surface0];
-    @base: @catppuccin[@@lookup][@base];
-    @mantle: @catppuccin[@@lookup][@mantle];
-    @crust: @catppuccin[@@lookup][@crust];
-    @accent-color: @catppuccin[@@lookup][@@accent];
-
-    color-scheme: if(@lookup = latte, light, dark);
-
-    ::selection {
-      background-color: fade(@accent-color, 30%);
-    }
-
-    input,
-    textarea {
-      &::placeholder {
-        color: @subtext0 !important;
-      }
-    }
-
-    body {
-      background-color: @base;
-      color: @text;
-    }
-
-    a {
-      color: @accent-color;
-    }
-
-    /* Web UI */
-    textarea,
-    select,
-    input[type="submit"] {
-      background-color: @base;
-      color: @text;
-      border-color: @overlay0;
-      border-radius: 4px;
-    }
-    textarea:focus,
-    select:focus,
-    input[type="submit"]:focus {
-      border-color: @accent-color;
-      outline-color: @overlay0;
-    }
-    input[type="submit"]:hover {
-      background-color: @mantle;
-    }
-
-    main {
-      color: @text;
-      border-color: @surface0;
-    }
-
-    .code.gutter {
-      background-color: @base !important;
-      span {
-        /* Line Numbers */
-        color: @overlay0 !important;
-      }
-    }
-
-    article.markdown-body {
-      color: @text;
-
-      h6 {
-        color: @text;
-      }
-
-      a {
-        color: @accent-color;
-      }
-
-      img {
-        background: none;
-      }
-
-      pre {
-        background: @surface0;
-      }
-
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-        border-color: @surface0;
-      }
-
-      blockquote {
-        border-color: @surface1;
-
-        p {
-          color: @text;
+@-moz-document domain("mail.google.com") {
+    @media (prefers-color-scheme: light) {
+        :root {
+            #catppuccin(@lightFlavor, @accentColor);
         }
-      }
-
-      table {
-        border-color: @surface0 !important;
-        tr,
-        th,
-        td {
-          border-color: @surface1;
-          background: none !important;
+    }
+    @media (prefers-color-scheme: dark) {
+        :root {
+            #catppuccin(@darkFlavor, @accentColor);
         }
-      }
     }
 
-    /* Syntax-highlighted code */
-    .code.text > pre {
-      background-color: @base !important;
-      background-image: none;
+    #catppuccin(@lookup, @accent) {
+        @rosewater: @catppuccin[@@lookup][@rosewater];
+        @flamingo: @catppuccin[@@lookup][@flamingo];
+        @pink: @catppuccin[@@lookup][@pink];
+        @mauve: @catppuccin[@@lookup][@mauve];
+        @red: @catppuccin[@@lookup][@red];
+        @maroon: @catppuccin[@@lookup][@maroon];
+        @peach: @catppuccin[@@lookup][@peach];
+        @yellow: @catppuccin[@@lookup][@yellow];
+        @green: @catppuccin[@@lookup][@green];
+        @teal: @catppuccin[@@lookup][@teal];
+        @sky: @catppuccin[@@lookup][@sky];
+        @sapphire: @catppuccin[@@lookup][@sapphire];
+        @blue: @catppuccin[@@lookup][@blue];
+        @lavender: @catppuccin[@@lookup][@lavender];
+        @text: @catppuccin[@@lookup][@text];
+        @subtext1: @catppuccin[@@lookup][@subtext1];
+        @subtext0: @catppuccin[@@lookup][@subtext0];
+        @overlay2: @catppuccin[@@lookup][@overlay2];
+        @overlay1: @catppuccin[@@lookup][@overlay1];
+        @overlay0: @catppuccin[@@lookup][@overlay0];
+        @surface2: @catppuccin[@@lookup][@surface2];
+        @surface1: @catppuccin[@@lookup][@surface1];
+        @surface0: @catppuccin[@@lookup][@surface0];
+        @base: @catppuccin[@@lookup][@base];
+        @mantle: @catppuccin[@@lookup][@mantle];
+        @crust: @catppuccin[@@lookup][@crust];
+        @accent-color: @catppuccin[@@lookup][@@accent];
 
-      span {
-        color: red !important;
-      }
+        color-scheme: if(@lookup =latte, light, dark);
 
-      /* General Text, Braces, Delimiters, Parameters, Classes, Metadata */
-      span[style*="color:#323232"] {
-        color: @text !important;
-      }
+        ::selection {
+            background-color: fade(@accent-color, 30%);
+        }
 
-      /* Keywords, Operators */
-      span[style*="color:#a71d5d"] {
-        color: @mauve !important;
-      }
+        input,
+        textarea {
+            &::placeholder {
+                color: @subtext0 !important;
+            }
+        }
 
-      /* Strings */
-      span[style*="color:#183691"],
-      span[style*="color:#ed6a43"] {
-        color: @green !important;
-      }
+        .ZG,
+        .boo .aQl > .J-JN-M-I-Jm,
+        .boo .aaa > .J-JN-M-I-Jm,
+        .boo .ZE > .J-JN-M-I-Jm,
+        .bs1 + .bs3,
+        .btj + .aD,
+        body {
+            color: @text !important;
+        }
 
-      /* Comments */
-      span[style*="color:#969896"] {
-        color: @overlay2 !important;
-      }
+        /* input box */
+        .bs0 > .acM,
+        .bti > .btg {
+            color: @text !important;
+        }
 
-      /* Constants, Numbers */
-      span[style*="color:#0086b3"] {
-        color: @peach !important;
-      }
+        /* quick settings */
+        .IU {
+            background: @base !important;
+            box-shadow: inset 1px 0 0 @mantle !important;
+        }
+        .Q0,
+        .VM .Q5,
+        .VM .OG,
+        .Q2,
+        .bCh,
+        .aIY,
+        .a21,
+        .ST,
+        .OB {
+            color: @text !important;
+        }
+        .Tj,
+        .dt,
+        .OD {
+            color: @accent-color !important;
+        }
 
-      /* Methods, Functions */
-      span[style*="color:#795da3"],
-      span[style*="color:#62a35c"],
-      span[style*="color:#63a35c"] {
-        color: @blue !important;
-      }
+        /* background */
+        #loading {
+            background: @base !important;
+        }
+        [style="background:#4285f4"] {
+            background: @blue !important;
+        }
+        [style="background:#34a853"] {
+            background: @green !important;
+        }
+        [style="background:#ea4335"] {
+            background: @red !important;
+        }
+        .la-c.la-l {
+            background: darken(@red, 10%);
+        }
+        .la-c.la-r {
+            background: @yellow;
+        }
 
-      /* Errors */
-      span[style*="background-color:#f5f5f5"][style*="color:#b52a1d"] {
-        color: @text !important;
-        background: fade(@red, 60%) !important;
-      }
+        header,
+        .nH.w-asV,
+        .bkL,
+        .bhZ.bym,
+        .bhZ.bjB,
+        .bhZ.bym.baA {
+            background: @crust !important;
+        }
+
+        /* links */
+        .aRq {
+            color: @sapphire !important;
+            &:hover {
+                color: @teal !important;
+            }
+        }
+
+        /* header */
+        .aeH,
+        .aqK {
+            background: @mantle !important;
+        }
+
+        /* search */
+        .gb_Lc .gb_Ee {
+            background: @surface0 !important;
+        }
+        .gb_Lc .gb_3e,
+        .gb_Ee.gb_Fe .gb_Ze,
+        .gb_Pc .gb_we {
+            color: @text !important;
+        }
+        .gb_Ee.gb_Fe button svg {
+            color: @text !important;
+            opacity: 1;
+        }
+        .aRp {
+            background: @surface0 !important;
+        }
+        .gssb_i {
+            background: @surface1 !important;
+            color: @text !important;
+        }
+        .gssb_e,
+        .gssb_m {
+            background: @surface0 !important;
+            color: @text !important;
+        }
+        /* selected unread email */
+        .x7 {
+            color: @mantle !important;
+            background: @accent-color !important;
+        }
+
+        /* checkbox */
+        .bzn .G-tF .T-Jo {
+            filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(150%) contrast(75%);
+        }
+
+        /* keyboard dropdown */
+        .d-Na-JG-M {
+            background-color: @surface1 !important;
+        }
+        .d-Na-N {
+            color: @text !important;
+        }
+        .d-Na-N-JW {
+            background-color: fade(@accent-color, 20%) !important;
+        }
+        .d-Na-JX-I,
+        .d-Na-J3,
+        .d-Na-N.d-Na-KO .d-Na-Jo {
+            filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(250%) contrast(75%);
+        }
+        .d-Na-axR,
+        .RK-Jk.RK-Qq-axH {
+            border-color: @overlay0;
+        }
+
+        /* virtual keyboard */
+        .RK-H {
+            background-color: @surface0 !important;
+        }
+        .RK-QJ {
+            color: @text;
+        }
+        .RK-Jk {
+            color: @text !important;
+            background-image: linear-gradient(to bottom, @surface1, @surface2);
+        }
+
+        /* left bar */
+        .CL.Q7:hover,
+        .CL.Wj:hover,
+        .CL.Q7.NQ,
+        .CL.Wj.NQ,
+        .TK .TO.nZ:active,
+        .TK .TO.ol:active,
+        .TK .TO.nZ,
+        .TK .TO.ol,
+        .byl .TK .nZ.aBP,
+        .byl .TK .nZ.aS3,
+        .byl .TK .nZ.aS4,
+        .byl .TK .nZ.aS5,
+        .byl .TK .nZ.aS6 {
+            background: @surface0 !important;
+        }
+        .TO.NQ,
+        .n6 .ah9:hover,
+        .n6 .ah9.aiu:hover,
+        .n6 .ah9:focus,
+        .TK .TO:active,
+        .n6 .ah9.aiu:active {
+            background: @surface1 !important;
+        }
+        .aAv,
+        .TO .nU > .n0,
+        .TO.NQ .nU > .n0,
+        .TO.nZ .nU > .n0,
+        .ah9 > .CJ,
+        .n3 > .CL > .CK {
+            color: @text !important;
+        }
+        .h0,
+        .Dj {
+            color: @subtext0 !important;
+        }
+
+        /* right bar */
+        .bAw .brC-aT5-aOt-Jw {
+            background: @crust !important;
+        }
+        .WR.aeN {
+            background: @crust !important;
+        }
+        .brC-aMv-auO .bse-bvF-I.aT5-aOt-I-JW .aT5-aOt-I-JX-atM-J6,
+        .brC-aMv-auO .bse-bvF-I.aT5-aOt-I-JO .aT5-aOt-I-JX-atM-J6 {
+            background: lighten(@crust, 4%);
+        }
+        /* inbox area */
+        .Wr > .Wn {
+            color: @text !important;
+        }
+        .aVj > .qd {
+            color: @text !important;
+        }
+        .qd {
+            #\:2c {
+                color: @accent-color !important;
+            }
+            #\:2d {
+                color: @accent-color !important;
+            }
+        }
+
+        .H2.HD {
+            background: @surface0 !important;
+            border-color: @surface1 !important;
+        }
+        .bkK > .nH {
+            background: @mantle !important;
+        }
+        /* inbox item */
+        .yO {
+            background: @mantle !important;
+            &:hover {
+                box-shadow: inset 1px 0 0 @surface0,
+                inset -1px 0 0 @surface0,
+                0 0 4px 0 @base,
+                0 0 6px 2px @base !important;
+            }
+        }
+        /* quick text */
+        .y2 {
+            color: @subtext0 !important;
+        }
+        .aeJ,
+        .aRs {
+            .J-KU:hover {
+                background: @surface0 !important;
+            }
+            background: @base !important;
+            .aRu {
+                .aRv {
+                    color: @subtext0 !important;
+                }
+                color: @subtext1 !important;
+            }
+        }
+        .aAA.J-KU-Jg-K9 {
+            background: @base !important;
+        }
+        .J-KU-KO.aAy {
+            .aKz {
+                color: @accent-color !important;
+            }
+            &::before {
+                background: @accent-color !important;
+            }
+        }
+        .aKx > .aKz {
+            color: @subtext0 !important;
+        }
+        .y6,
+        .bA4 {
+            color: @text !important;
+        }
+        /* buttons hovers */
+        .T-I-JW.amD::before,
+        .T-I-JW.adg::before,
+        .T-I-JW > .asa::before {
+            background: @surface0 !important;
+        }
+
+        /* attachements in comfortable mode */
+        .brg {
+            color: @text !important;
+        }
+
+        /* date when the message was sent */
+        .yO > .xW {
+            color: fade(@text, 50%) !important;
+        }
+        .bq3 {
+            color: @text !important;
+        }
+
+        /* unsub button */
+        .aJ6 {
+            color: @text;
+        }
+        .aOd.T-I {
+            box-shadow: inset 0 0 0 1px fade(@text, 50%) !important;
+        }
+
+        /* svgs */
+        .gb_Pc svg,
+        .gb_Kc svg,
+        .gb_Uc.gb_Zc svg,
+        .gb_Pc .gb_gd .gb_od,
+        .gb_Pc .gb_gd .gb_Oc,
+        .gb_Pc .gb_gd .gb_id,
+        .gb_Uc.gb_Zc .gb_od {
+            color: @text !important;
+        }
+        /* send one now */
+        .x0 {
+            color: @text !important;
+        }
+
+        /* compose window */
+        .afW {
+            border-color: @surface1;
+        }
+        .afV {
+            background: @surface2 !important;
+            box-shadow: 0 0 0 1px @overlay0 inset;
+            color: @text !important;
+        }
+        .akl,
+        .aoT,
+        .aYF,
+        .agP,
+        .az9,
+        .gQ {
+            color: @text;
+        }
+        .IZ,
+        .agP,
+        .agh,
+        .gQ,
+        .afx {
+            background: @surface0 !important;
+        }
+        .oL,
+        .gO {
+            color: @subtext0;
+        }
+        /* message sent dialog */
+        .vh {
+            color: @text !important;
+        }
+        /* Gmail logo */
+        [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_default_1x_r5.png"],
+        [src="https://ssl.gstatic.com/ui/v1/icons/mail/rfr/logo_gmail_lockup_dark_1x_r5.png"] {
+            height: unset !important;
+            width: unset !important;
+            @svg: escape( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="17.727 14.319 30 22.5" width="30" height="22.5"><path fill="@{blue}" d="M19.773 36.819h4.773V25.227l-6.819-5.114v14.659a2.044 2.044 0 0 0 2.045 2.045"/><path fill="@{green}" d="M40.909 36.819h4.773a2.044 2.044 0 0 0 2.045-2.045v-14.66l-6.819 5.114"/><path fill="@{yellow}" d="M40.909 16.364v8.864l6.819-5.114v-2.727c0-2.529-2.888-3.971-4.909-2.455"/><path fill="@{red}" d="M24.545 25.227v-8.863l8.181 6.136 8.181-6.136v8.864l-8.181 6.136m-15-13.977v2.727l6.819 5.114v-8.864l-1.909-1.431c-2.025-1.517-4.91-.075-4.91 2.455"/></svg>');
+            content: url("data:image/svg+xml,@{svg}");
+        }
+        /* x new */
+        .aDG {
+            background-color: @crust !important;
+            color: @text !important;
+        }
+        .aKs {
+            color: @subtext1 !important;
+        }
+
+        /* theme */
+        div.Kj-JD {
+            background-color: @base;
+        }
+        .a80.Kj-JD-K7 {
+            box-shadow: 0 5px 10px -5px @crust;
+        }
+        .a81 {
+            border-color: @surface0;
+        }
+
+
+        /* no star warning */
+        .Tm .TC {
+            background: @base !important;
+            color: @text !important;
+        }
+
+        /* dropdown */
+        .ZF-z6,
+        .ZF-zT,
+        .ZF-Av .lJ,
+        .ZF-Av .lN,
+        .aaZ,
+        .aoT,
+        .J-M,
+        .bAp.b8.UC .vh,
+        .ajA,
+        .nH .Hy .m,
+        .J-N-JT,
+        .J-JK-JT,
+        .J-LC-JT,
+        form[role="search"],
+        form[role="search"] table,
+        form[role="search"] div,
+        form[role="search"] td {
+            background: @surface0 !important;
+        }
+
+        div.Kj-JD-Jl > button.J-at1-atl,
+        div.Kj-JD-Jl > button.J-at1-auR {
+            background: @accent-color !important;
+            color: @crust !important;
+        }
+        div.Kj-JD-Jl > button,
+        .bBh .Kj-JD-Jl > .J-at1-auR,
+        .Kj-JD-K7-K0,
+        .J-N {
+            color: @text !important;
+        }
+        .J-N-JT,
+        .J-N-JW {
+            color: @text !important;
+            background: @surface2 !important;
+        }
+        .J-N-JT .J-N-Jz,
+        .J-N-JW .J-N-Jz {
+            color: @text !important;
+        }
+        .T-I-Kq > .asa::before,
+        .T-I-Kq.T-I-JO > .asa::before {
+            background: @surface1 !important;
+        }
+
+        /* compose button */
+        .T-I-KE {
+            background: @accent-color !important;
+            color: @crust !important;
+            & when (@lookup =latte) {
+                color: @text !important;
+            }
+            &:hover {
+                background: darken(@accent-color, 10%);
+                color: @crust !important;
+            }
+        }
+
+        /* drive usage */
+        .aiC {
+            background: @overlay0 !important;
+        }
+        .aiA {
+            background: @accent-color !important;
+        }
+        /* icons */
+        .aAy > .aKp,
+        .xY > .T-Jo,
+        .T-I .T-I-J3,
+        td.apU > .T-KT.aXw::before,
+        .bqX:not(.pW):hover::before,
+        .nZ > .TN.aHS-bnt .qj::before {
+            filter: brightness(0) saturate(90%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(250%) contrast(75%);
+        }
+
+        .WR .z0 > .L3::before {
+            filter: brightness(0) saturate(80%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(20%) contrast(75%);
+        }
+
+        td.apU > .T-KT.T-KT-Jp::before {
+            filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%) hue-rotate(337deg) brightness(300%);
+        }
+        .J-N-JX,
+        .J-Ph-hFsbo,
+        .OB,
+        .Q1:not(:checked) + .Vo::before,
+        .SV {
+            filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(250%) contrast(75%);
+        }
+        .brC-aMv-auO .aT5-aOt-I-JX {
+            fill: @accent-color;
+        }
+        .brC-aMv-auO .brC-dA-I.aT5-aOt-I-Jp .aT5-aOt-I-JX-atM {
+            background-color: @base;
+        }
+
+        /* sidebar icons */
+        .TO:not(.nZ) .qj:not(.aEe),
+        .n3 .CL.Q7::before,
+        .n3 .CL.Wj::before,
+        .n3 .CL.H5o3mc::before,
+        .n6 .n4 .G-asx,
+        .n6 .air .G-asx,
+        .TN .TH {
+            filter: brightness(0) saturate(80%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(220%) contrast(75%);
+        }
+
+        /* help dropdown */
+        .t9 {
+            background-color: @surface0 !important;
+        }
+        .ua {
+            color: @text !important;
+        }
+        .ua.bk5 {
+            background-color: @overlay0;
+        }
+
+        /* labels */
+        .J-awr {
+            color: @text;
+        }
+        .J-N-Jz {
+            color: @text !important;
+        }
+        .J-Kh {
+            border-color: @text;
+        }
+        .aEe,
+        .aEc.aHS-bnr .qj {
+            background-color: @text !important;
+        }
+
+        /* sidebar */
+        .bsU {
+            color: @text;
+        }
+        .aAw .aAu {
+            filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(250%) contrast(75%);
+        }
+        /* sidebar: collapsed */
+        .aeN.WR.baA.nH.oy8Mbf.bhZ {
+            .bsU {
+                background: @peach !important;
+                color: @text !important;
+            }
+        }
+
+        /* svgs */
+        .gb_De.gb_af.bEP svg,
+        .gb_Ce svg,
+        .gb_Mc svg,
+        .gb_ie.gb_h.gb_gd.t6 svg,
+        .gb_A svg,
+        .FH svg,
+        .gb_Rc.gb_Vc svg,
+        .gb_Mc .gb_dd .gb_ld,
+        .gb_Mc .gb_dd .gb_Lc,
+        .gb_Mc .gb_dd .gb_fd,
+        .gb_Rc.gb_Vc .gb_ld {
+            color: @subtext0;
+        }
+
+        /* toolbar */
+        .Hl,
+        .Hq,
+        .Ha,
+        [role="menuitemcheckbox"] > div > div,
+        [role="listbox"] .J-Z-M-I-J6-H > .J-Z-M-I-JG,
+        div.ajR .ajT,
+        .btC .dv,
+        .btC .aaA.a1,
+        .btC .J-N-JX.a1,
+        .btC .aaA.e5,
+        .aaZ .J-N-JX.e5,
+        .btC .aaA.QT,
+        .btC .J-N-JX.QT,
+        .btC .aaA.aA7,
+        .aaZ .J-N-JX.aA7,
+        .btC .aaA.buc,
+        .btC .J-N-JX.buc,
+        .btC .aaA.BP,
+        .aaZ .J-N-JX.BP,
+        .btC .aaA.a5,
+        .btC .aaA.a2X,
+        .aaZ .J-N-JX.a5,
+        .aaZ .J-N-JX.a2X,
+        [role="toolbar"] [role="button"]:not(.H2,
+        .Ol) {
+            filter: brightness(0) saturate(100%) invert(28%) sepia(17%) saturate(835%) hue-rotate(196deg) brightness(250%) contrast(75%) !important;
+        }
+
+        /* advanced settings */
+        div.Kj-JD-Jz {
+            color: @subtext0 !important;
+        }
+        .alO,
+        .v .fY,
+        .v .f1,
+        .r4 {
+            background: @base !important;
+        }
+        .v .f1,
+        .v .f1 .f0 {
+            color: @text !important;
+        }
+        .qL {
+            color: black !important;
+        }
+        .v .fZ {
+            box-shadow: inset 0 -2px 0 0 @accent-color;
+            .f0 {
+                color: @accent-color !important;
+            }
+        }
+        .alP,
+        .sA,
+        .r4 .e {
+            color: @sapphire !important;
+            &:hover {
+                color: @teal !important;
+            }
+        }
+        .Ze {
+            background: @surface0 !important;
+        }
+        .a8Y > .T-I-ax7 {
+            background: @surface0 !important;
+            color: @text !important;
+            &:hover {
+                background: @surface1 !important;
+            }
+        }
+        .T-I-atl {
+            background: @accent-color !important;
+            color: @crust !important;
+            &:hover {
+                background: lighten(@accent-color, 10%) !important;
+            }
+        }
+
+        /* loading */
+        #explosion_clipper_div > .la-i > div {
+            background: @surface0 !important;
+        }
+
+        #nlpt {
+            background-color: @surface0 !important;
+            &::before {
+                background-color: @overlay0 !important;
+            }
+        }
+
+        .la-b > .la-l,
+        .la-b > .la-r,
+        .la-b > .la-m {
+            background: @surface1 !important;
+        }
+
+        .la-k .la-l,
+        .la-k .la-r {
+            border-color: @base !important;
+        }
+
+        .la-k .la-m {
+            background: @base !important;
+            clip-path: polygon(47% 100%, 100% 47%, 100% 100%);
+        }
+
+        .la-i > .la-l,
+        .la-i > .la-r {
+            border-color: @surface0 !important;
+        }
+
+        .la-i > .la-m {
+            background: @surface0 !important;
+        }
+
+        .msgb {
+            color: @text;
+            a {
+                color: @accent-color !important;
+            }
+        }
     }
-  }
 }
 
 /* prettier-ignore */
 @catppuccin: {
-  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
-  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
-  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
-  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+    @latte: {
+        @rosewater: #dc8a78;
+        @flamingo: #dd7878;
+        @pink: #ea76cb;
+        @mauve: #8839ef;
+        @red: #d20f39;
+        @maroon: #e64553;
+        @peach: #fe640b;
+        @yellow: #df8e1d;
+        @green: #40a02b;
+        @teal: #179299;
+        @sky: #04a5e5;
+        @sapphire: #209fb5;
+        @blue: #1e66f5;
+        @lavender: #7287fd;
+        @text: #4c4f69;
+        @subtext1: #5c5f77;
+        @subtext0: #6c6f85;
+        @overlay2: #7c7f93;
+        @overlay1: #8c8fa1;
+        @overlay0: #9ca0b0;
+        @surface2: #acb0be;
+        @surface1: #bcc0cc;
+        @surface0: #ccd0da;
+        @base: #eff1f5;
+        @mantle: #e6e9ef;
+        @crust: #dce0e8;
+    }
+    ;
+    @frappe: {
+        @rosewater: #f2d5cf;
+        @flamingo: #eebebe;
+        @pink: #f4b8e4;
+        @mauve: #ca9ee6;
+        @red: #e78284;
+        @maroon: #ea999c;
+        @peach: #ef9f76;
+        @yellow: #e5c890;
+        @green: #a6d189;
+        @teal: #81c8be;
+        @sky: #99d1db;
+        @sapphire: #85c1dc;
+        @blue: #8caaee;
+        @lavender: #babbf1;
+        @text: #c6d0f5;
+        @subtext1: #b5bfe2;
+        @subtext0: #a5adce;
+        @overlay2: #949cbb;
+        @overlay1: #838ba7;
+        @overlay0: #737994;
+        @surface2: #626880;
+        @surface1: #51576d;
+        @surface0: #414559;
+        @base: #303446;
+        @mantle: #292c3c;
+        @crust: #232634;
+    }
+    ;
+    @macchiato: {
+        @rosewater: #f4dbd6;
+        @flamingo: #f0c6c6;
+        @pink: #f5bde6;
+        @mauve: #c6a0f6;
+        @red: #ed8796;
+        @maroon: #ee99a0;
+        @peach: #f5a97f;
+        @yellow: #eed49f;
+        @green: #a6da95;
+        @teal: #8bd5ca;
+        @sky: #91d7e3;
+        @sapphire: #7dc4e4;
+        @blue: #8aadf4;
+        @lavender: #b7bdf8;
+        @text: #cad3f5;
+        @subtext1: #b8c0e0;
+        @subtext0: #a5adcb;
+        @overlay2: #939ab7;
+        @overlay1: #8087a2;
+        @overlay0: #6e738d;
+        @surface2: #5b6078;
+        @surface1: #494d64;
+        @surface0: #363a4f;
+        @base: #24273a;
+        @mantle: #1e2030;
+        @crust: #181926;
+    }
+    ;
+    @mocha: {
+        @rosewater: #f5e0dc;
+        @flamingo: #f2cdcd;
+        @pink: #f5c2e7;
+        @mauve: #cba6f7;
+        @red: #f38ba8;
+        @maroon: #eba0ac;
+        @peach: #fab387;
+        @yellow: #f9e2af;
+        @green: #a6e3a1;
+        @teal: #94e2d5;
+        @sky: #89dceb;
+        @sapphire: #74c7ec;
+        @blue: #89b4fa;
+        @lavender: #b4befe;
+        @text: #cdd6f4;
+        @subtext1: #bac2de;
+        @subtext0: #a6adc8;
+        @overlay2: #9399b2;
+        @overlay1: #7f849c;
+        @overlay0: #6c7086;
+        @surface2: #585b70;
+        @surface1: #45475a;
+        @surface0: #313244;
+        @base: #1e1e2e;
+        @mantle: #181825;
+        @crust: #11111b;
+    }
+    ;
 }
 
 // vim:ft=less


### PR DESCRIPTION
Priority Inbox: Group headers now adopt the text color based on the preferred theme.
Icons: Updated the styles for the following icons: search, advanced search, question mark, gear icon, Google apps, and labels.
Settings Text: The "Settings" text now matches the chosen accent color, consistent with the subheadings.
SideBar Collapsed: The notification dot, now follows the chosen accent color 😄

Please go the the `Preview` tab and click on the link to the appropriate pull request template.

Are you...

- [Adding a new userstyle?](?expand=1&template=userstyle-creation.md)
- [Updating/fixing an existing userstyle?](?expand=1&template=userstyle-update.md)
- Something else? Delete this text and write a short, meaningful description of your changes instead.
