### PR TITLE
fix(google-photos): text

### DIFF
--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -489,7 +489,12 @@
     .x1vyqd,
     .CqtWH,
     .wbspQd,
-    .vUbGoc {
+    .vUbGoc,
+    .GIYFWc,
+    .btKbVe,
+    .l9UZue, 
+    .hEFMYc,
+    .BrvAFe {
       color: @text;
     }
     /* top bar */
@@ -516,7 +521,10 @@
     .cuFkEd,
     .hcClrf,
     .o7Osof .HhLEze,
-    .k4Or1e {
+    .k4Or1e,
+    .uNz2Jf, 
+    .PzGzq,
+    .QWd4Mb {
       color: @subtext0;
     }
     /* "view" button links */

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Photos Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google-photos
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-photos
-@version 0.0.5
+@version 0.0.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-photos/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-photos
 @description Soothing pastel theme for Google Photos


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes unthemed text :)
theres some text that only display when using google photos for the first time, which i fixed

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
