### PR TITLE
fix(syncthing): make panel headers different from background

### DIFF
--- a/styles/syncthing/catppuccin.user.css
+++ b/styles/syncthing/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Syncthing Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/syncthing
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/syncthing
-@version 0.1.4
+@version 0.1.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/syncthing/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Asyncthing
 @description Soothing pastel theme for Syncthing
@@ -158,7 +158,7 @@
     .panel-default > .panel-heading {
       color: @text !important;
       border-color: @surface0 !important;
-      background-color: @base !important;
+      background-color: @surface0 !important;
     }
 
     .panel-footer {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Instead of the panel headers being `base`, like the background, they are set to `surface0`. This looks better imo.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
