### PR TITLE
fix(youtube): properly color the "LIVE" badge icon

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.11
+@version 4.2.12
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -186,7 +186,7 @@
         0.3
       ) !important;
       --yt-spec-static-overlay-call-to-action: @accent-color !important;
-      --yt-spec-static-overlay-icon-active-other: @text !important;
+      --yt-spec-static-overlay-icon-active-other: @crust !important;
       --yt-spec-static-overlay-icon-inactive: @surface1 !important;
       --yt-spec-static-overlay-icon-disabled: @surface2 !important;
       --yt-spec-static-overlay-button-primary: @accent-color !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Currently the icon in the LIVE badge on livestreams uses the `@text` color. This makes it hard to distinguish on the background of the badge, which uses `@accent-color`. This fix changes the icon to use the `@crust` color, matching it to the badge's text.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
