### PR TITLE
feat(css-filter-generator): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -283,6 +283,13 @@ userstyles:
     readme:
       app-link: "https://crowdin.com"
     current-maintainers: [*ryanccn]
+  css-filter-generator:
+    name: CSS Filter Generator
+    categories: [development]
+    color: teal
+    readme:
+      app-link: "https://angel-rs.github.io/css-color-filter-generator/"
+    current-maintainers: [*trinkey]
   deepl:
     name: DeepL
     categories: [translation_tool, productivity]

--- a/styles/css-filter-generator/catppuccin.user.css
+++ b/styles/css-filter-generator/catppuccin.user.css
@@ -1,0 +1,199 @@
+/* ==UserStyle==
+@name CSS Filter Generator Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/css-filter-generator
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/css-filter-generator
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/css-filter-generator/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Acss-filter-generator
+@description Soothing pastel theme for CSS Filter Generator
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain('angel-rs.github.io') {
+  @media (prefers-color-scheme: light) {
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    background-color: @base;
+
+    body {
+      color: @text;
+      background-color: @base;
+    }
+
+    code {
+      color: @text;
+      background-color: @mantle;
+    }
+
+    label {
+      color: @text;
+      background-color: @crust;
+    }
+
+    input {
+      color: @text;
+      border-color: @surface0;
+      background-color: @crust;
+
+      &:is(:focus, :hover) + label {
+        color: @accent-color;
+      }
+
+      &:focus,
+      &:hover {
+        border-color: @accent-color;
+      }
+    }
+
+    h1,
+    h2,
+    li > strong {
+      color: @text;
+    }
+
+    a,
+    .copy {
+      &,
+      > strong {
+        color: @accent-color
+      }
+
+      small {
+        color: @subtext0;
+      }
+    }
+
+    section,
+    .site-footer {
+      border-color: @surface0;
+    }
+
+    .page-header {
+      background: @mantle;
+      color: @text;
+    }
+
+    .btn {
+      color: @text;
+      border-color: @surface0;
+      background-color: @crust;
+
+      &:hover {
+        background-color: @mantle;
+        border-color: @accent-color;
+      }
+
+      &:focus {
+        border-color: @accent-color;
+      }
+    }
+
+    .btn3d.btn-default {
+      box-shadow: 0 0 0 2px @surface0 inset, 0 8px 0 0 @crust;
+      color: @crust;
+      background: none; // Prevents a white flash when switching between enabled and disabled
+    }
+
+    .disabled {
+      background-color: @mantle !important;
+      color: @subtext0 !important;
+    }
+
+    .site-footer-credits {
+      color: @subtext0;
+    }
+
+    .colorwheel__input:hover {
+      outline-color: @accent-color;
+    }
+
+    .action-button::after {
+      background: @accent-color !important;
+    }
+
+    .copied::after {
+      background-color: @accent-color;
+      color: @crust;
+    }
+
+    .em-coffee {
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><ellipse fill="@{surface0}" cx="18" cy="26" rx="18" ry="10"/><ellipse fill="@{surface1}" cx="18" cy="24" rx="18" ry="10"/><path fill="@{surface2}" d="M18 31C3.042 31 1 16 1 12h34c0 2-1.958 19-17 19"/><path fill="@{surface1}" d="M34.385 9.644c2.442-10.123-9.781-7.706-12.204-5.799A38 38 0 0 0 18 3.611c-9.389 0-17 3.229-17 8.444S8.611 21.5 18 21.5s17-4.229 17-9.444c0-.863-.226-1.664-.615-2.412m-2.503-2.692c-1.357-.938-3.102-1.694-5.121-2.25 1.875-.576 4.551-.309 5.121 2.25"/><ellipse fill="@{peach}" cx="18" cy="13" rx="15" ry="7"/><path fill="@{text}" d="M20 17a1 1 0 0 1-.707-.293c-2.337-2.337-2.376-4.885-.125-8.262.739-1.109.9-2.246.478-3.377-.461-1.236-1.438-1.996-1.731-2.077-.553 0-.958-.443-.958-.996S17.448 1 18 1c.997 0 2.395 1.153 3.183 2.625 1.034 1.933.91 4.039-.351 5.929-1.961 2.942-1.531 4.332-.125 5.738A.999.999 0 0 1 20 17m-6-2a1 1 0 0 1-.707-.293c-2.337-2.337-2.376-4.885-.125-8.262.727-1.091.893-2.083.494-2.947-.444-.961-1.431-1.469-1.684-1.499a.99.99 0 0 1-.989-1c0-.552.458-1 1.011-1 .997 0 2.585.974 3.36 2.423.481.899 1.052 2.761-.528 5.131-1.961 2.942-1.531 4.332-.125 5.738a1 1 0 0 1 0 1.414A1 1 0 0 1 14 15"/></svg>'
+      );
+      background-image: url("data:image/svg+xml,@{svg}");
+    }
+
+    .em-heart {
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><path fill="@{red}" d="M35.885 11.833c0-5.45-4.418-9.868-9.867-9.868-3.308 0-6.227 1.633-8.018 4.129-1.791-2.496-4.71-4.129-8.017-4.129-5.45 0-9.868 4.417-9.868 9.868 0 .772.098 1.52.266 2.241C1.751 22.587 11.216 31.568 18 34.034c6.783-2.466 16.249-11.447 17.617-19.959.17-.721.268-1.469.268-2.242"/></svg>'
+      );
+      background-image: url("data:image/svg+xml,@{svg}");
+    }
+  }
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}
+
+// vim:ft=less

--- a/styles/css-filter-generator/preview.webp
+++ b/styles/css-filter-generator/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43c1da7027c302a04ea4ceece9a33d70edae970e0ca0fd26869f81c3f8630e95
+size 102728


### PR DESCRIPTION
## 🎉 Theme for CSS Filter Generator 🎉
officially endorsed by famous catppuccin userstyles staff "uncenter"
## 💬 Additional Comments 💬
i also themed other github pages websites that angel-rs has just to be thorough
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
