### PR TITLE
feat(dencode): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -291,6 +291,13 @@ userstyles:
     readme:
       app-link: "https://deepl.com"
     current-maintainers: [*watatomo]
+  dencode:
+    name: Dencode
+    categories: [development]
+    color: text
+    readme:
+      app-link: "https://dencode.com"
+    current-maintainers: [*trinkey]
   docs.rs:
     name: docs.rs
     categories: [development]

--- a/styles/dencode/catppuccin.user.css
+++ b/styles/dencode/catppuccin.user.css
@@ -1,0 +1,160 @@
+/* ==UserStyle==
+@name Dencode Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/dencode
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/dencode
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/dencode/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Adencode
+@description Soothing pastel theme for Dencode
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain('dencode.com') {
+  :root[data-bs-theme="light"] {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+  :root[data-bs-theme="dark"] {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    color-scheme: if(@lookup = latte, light, dark);
+
+    #rgbify(@color) {
+      @rgb-raw: red(@color), green(@color), blue(@color);
+    }
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    --ctp-accent: #rgbify(@accent-color) [];
+
+    --bs-body-bg: @base;
+    --bs-body-color: @text;
+    --bs-border-color-translucent: @surface0;
+    --bs-border-color: @surface0;
+    --bs-emphasis-color-rgb: var(--ctp-accent);
+    --bs-emphasis-color: @accent-color;
+    --bs-link-color-rgb: var(--ctp-accent);
+    --bs-link-hover-color-rgb: var(--ctp-accent);
+    --bs-navbar-brand-color: @accent-color;
+    --bs-secondary-bg: @mantle;
+    --bs-secondary-rgb: var(--ctp-accent);
+    --bs-tertiary-bg: @mantle;
+    --dc-btn-active-bg: @mantle;
+    --dc-btn-active-box-shadow: none;
+    --dc-btn-bg-image: linear-gradient(@crust, @crust);
+    --dc-btn-border-color: @surface0;
+    --dc-dencoded-list-active-bg: @mantle;
+    --dc-dencoded-list-border-color: @surface0;
+    --dc-dencoded-list-invalid-color: @surface2;
+    --dc-follow-box-shadow: 0 2px 6px @crust;
+    --dc-footer-bg: @mantle;
+    --dc-footer-border-color: @surface0;
+    --dc-footer-color: @text;
+    --dc-header-bg: @mantle;
+    --dc-header-border-color: @surface0;
+    --dc-icon-active-rgb: var(--ctp-accent);
+    --dc-input-highlight-bg: @crust;
+    --dc-nav-link-active-bg: @crust;
+    --dc-nav-link-active-color: @text;
+    --dc-pre-bg: @mantle;
+    --dc-pre-border-color: @surface0;
+
+    hr {
+      border-color: @surface0;
+    }
+
+    .badge {
+      --bs-badge-color: @mantle;
+    }
+
+    .dropdown-menu {
+      --bs-dropdown-link-active-bg: @accent-color;
+      --bs-dropdown-link-active-color: @crust;
+    }
+
+    .table {
+      --bs-table-color: @text;
+    }
+
+    .btn.active {
+      --bs-btn-active-bg: @surface0;
+    }
+
+    .btn-close {
+      @svg: escape(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="@{text}"><path d="M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414"/></svg>'
+      );
+
+      --bs-btn-close-bg: url("data:image/svg+xml,@{svg}");
+      --bs-btn-close-white-filter: none;
+      --bs-btn-close-focus-shadow: none;
+      --bs-btn-close-hover-opacity: 1;
+      --bs-btn-close-opacity: 1;
+    };
+
+    .navbar {
+      --bs-navbar-color: @text;
+      --bs-navbar-active-color: @text;
+      --bs-navbar-hover-color: @text;
+    }
+
+    .form-control:focus {
+      border-color: @accent-color;
+      box-shadow: none;
+    }
+  }
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}
+
+// vim:ft=less

--- a/styles/dencode/preview.webp
+++ b/styles/dencode/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6722d4099efa586b48d8c5717036296a51e3e18ca1f02f8428df3807006bca0
+size 167418


### PR DESCRIPTION
## 🎉 Theme for Dencode 🎉
a website that allows you to easily encode/decode strings in many different formats
## 💬 Additional Comments 💬
this is the second result on duckduckgo (for me) when i search encode decode online so that means it passes the popularity check that might get implemented
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
