### PR TITLE
fix(duckduckgo): unthemed variables

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -191,6 +191,7 @@
     --sds-color-background-02: @mantle !important;
     --sds-color-palette-red-40: @red !important;
     --sds-color-border-01: @surface0 !important;
+    --col-blue-30: @blue !important;
 
     .footer,
     .footer--mobile,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -193,6 +193,13 @@
     --sds-color-palette-red-40: @red !important;
     --sds-color-border-01: @surface0 !important;
     --col-blue-30: @blue !important;
+    --sds-color-palette-green-60: @green !important;
+    
+    .address-detail {
+        background-color: @mantle;
+        color: @text;
+        border-color: @surface0;
+    }
 
     .footer,
     .footer--mobile,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -78,6 +78,7 @@
     }
 
     --sds-color-text-02: @text !important;
+    --sds-color-text-disabled: @overlay0 !important;
     --theme-col-txt-page-separator: @text!important;
     --theme-col-page-separator: @text !important;
     --theme-col-txt-url: @text !important;

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.2.9
+@version 0.3.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo
@@ -186,6 +186,11 @@
     --theme-dc-color-llama-main: @pink !important;
     --theme-dc-color-mixtral-main: @peach !important;
     --theme-dc-color-anchor-sleep: @subtext0 !important;
+    /* maps */
+    --sds-color-background-01: @base !important;
+    --sds-color-background-02: @mantle !important;
+    --sds-color-palette-red-40: @red !important;
+    --sds-color-border-01: @surface0 !important;
 
     .footer,
     .footer--mobile,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -194,6 +194,7 @@
     --sds-color-border-01: @surface0 !important;
     --col-blue-30: @blue !important;
     --sds-color-palette-green-60: @green !important;
+    --sds-color-background-utility: @surface0 !important;
     
     .address-detail {
         background-color: @mantle;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
adds variables which fixes maps, aswell as disabled text

<details>
<summary>before & after</summary>
<img src="https://github.com/user-attachments/assets/68f9362d-011e-452f-89c7-1acb61e38d35">
<img src="https://github.com/user-attachments/assets/7fd9f729-a010-41a0-b7be-7eab3300bb32">
</details>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
