### PR TITLE
fix(chess.com): search bar

### DIFF
--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Chess.com Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chess.com
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chess.com
-@version 0.2.0
+@version 0.2.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chess.com/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achess.com
 @description Soothing pastel theme for Chess.com
@@ -327,6 +327,9 @@
       }
       .nav-menu-area:last-of-type {
         color: @text !important;
+      }
+      .nav-popover.nav-search {
+        --search-bg-color: @surface0;
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes the unthemed search bar

<details>
<summary>before & after</summary>
<img src="https://github.com/user-attachments/assets/c28b2ffa-98ba-41d2-aa8d-8760b03f61b7">
<img src="https://github.com/user-attachments/assets/68348fe7-880d-42eb-9c37-0122ce6588d5">
</details>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
