### PR TITLE
fix(linkedin): hover buttons

### DIFF
--- a/styles/linkedin/catppuccin.user.css
+++ b/styles/linkedin/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name LinkedIn Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/linkedin
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/linkedin
-@version 0.0.6
+@version 0.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/linkedin/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Alinkedin
 @description Soothing pastel theme for LinkedIn
@@ -466,6 +466,9 @@
     --color-checked: @accent-color;
     --color-checked-hover: @accent-color;
     --color-checked-active: @accent-color;
+
+    /* fix for hover buttons */
+    --artdeco-button-secondary-default-hover-background-color: fadeout(@blue, 80);
 
     /* text on dark */
     --color-text-on-dark: @text;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

I elected to do this rather then change the root var `--blue-60-a15` since chaning that var lead to breakages elsewhere.

closes https://github.com/catppuccin/userstyles/issues/1364#event-14544975805

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
