### PR TITLE
fix(youtube): live ring

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.12
+@version 4.2.13
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -906,6 +906,17 @@
         &::before {
           background: @overlay0;
         }
+      }
+
+      /* youtube live ring */
+      .yt-spec-avatar-shape__badge-text {
+        color: @crust;
+      }
+      .yt-spec-avatar-shape--live-ring {
+        border-color: @accent-color;
+      }
+      .yt-spec-avatar-shape__live-badge {
+        background-color: @accent-color;
       }
 
       .ytp-button,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

fixes new youtube live ring
![image](https://github.com/user-attachments/assets/28727747-6d97-4f25-8384-b06f45e416cc)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
