### PR TITLE
fix(wikipedia): missing infobox classes

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.22
+@version 0.0.23
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -731,7 +731,9 @@
       background-color: @surface1;
     }
 
-    .infobox-header {
+    .infobox-header,
+    .infobox-subheader,
+    .infobox-full-data {
       background-color: @surface1 !important;
       color: @text !important;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Hello,
this pr fixes unthemed infobox subheaders, as the heading's text wasn't readable before

Here is an example site that has these classes: https://en.wikipedia.org/wiki/Flying_Witch

before:
![wikipedia_before](https://github.com/user-attachments/assets/ebc5f7f1-d886-45c0-a80a-5f5aca0c997d)

now:
![wikipedia_after](https://github.com/user-attachments/assets/6c92d79b-1fea-43e5-8566-1641cb09461e)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
