### PR TITLE
fix(reddit): text color on brand background

### DIFF
--- a/styles/reddit/catppuccin.user.css
+++ b/styles/reddit/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Reddit Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/reddit
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/reddit
-@version 2.0.12
+@version 2.0.13
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/reddit/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Areddit
 @description Soothing pastel theme for Reddit
@@ -157,6 +157,7 @@
     --color-favorite: @accent-color !important;
     --color-brand-background: @accent-color !important;
     --color-brand-background-hover: darken(@accent-color, 5%) !important;
+    --color-brand-onBackground: @crust !important;
     --color-global-orangered: @accent-color !important;
     --color-action-upvote: @accent-color !important;
     --color-action-downvote: @blue;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

fixing the foreground color on some ui elements that use the brand color as background.

before:
![before-image](https://github.com/user-attachments/assets/e4cc7d6c-09d6-4092-989f-1adddbeea640)

after:
![after-image](https://github.com/user-attachments/assets/ee5ec4ee-6a4f-454e-9a2d-26d26621cd3d)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
