### PR TITLE
fix(tuta): application of accent color

### DIFF
--- a/styles/tuta/catppuccin.user.css
+++ b/styles/tuta/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Tuta Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/tuta
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/tuta
-@version 0.0.9
+@version 0.0.10
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/tuta/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atuta
 @description Soothing pastel theme for Tuta
@@ -93,8 +93,18 @@
       background-color: @base !important;
     }
 
-    .ionicon {
-      fill: @text !important;
+    .icon {
+      &[style*="fill: rgb(78, 78, 78);"] {
+        fill: @text !important;
+      }
+
+      &[style*="fill: rgb(174, 174, 174);"] {
+        fill: @subtext0 !important;
+      }
+
+      &[style*="fill: rgb(255, 83, 83);"] {
+        fill: @accent-color !important;
+      }
     }
 
     .h2 {
@@ -142,10 +152,6 @@
     .sidebar-section.mb {
       color: @subtext0 !important;
     }
-    .icon.icon-large,
-    .nav-button .icon {
-      fill: @subtext0 !important;
-    }
 
     .bubble {
       background-color: @base;
@@ -186,10 +192,11 @@
       color: @mantle;
     }
 
-    [style*="border: 2px solid rgb(0, 210, 167);"] {
+    [style*="border: 2px solid rgb(255, 83, 83);"] {
       border-color: @accent-color !important;
     }
-    [style*="color: rgb(0, 210, 167);"] {
+    [style*="color: rgb(255, 83, 83);"],
+    .content-accent-fg {
       color: @accent-color !important;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Tuta now uses their actual brand colors in their app. This fixes the application of our accent colors.
I also adjusted the application to icons: The selected icon in the navbar now also uses the accent color.

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
