### PR TITLE
fix(deepl): poor contrast on certain elements

### DIFF
--- a/styles/deepl/catppuccin.user.css
+++ b/styles/deepl/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DeepL Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/deepl
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/deepl
-@version 1.0.2
+@version 1.0.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/deepl/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Adeepl
 @description Soothing pastel theme for DeepL
@@ -92,6 +92,10 @@
 
     .pageFooterV2-module--footerOuterContainer--0b055 {
       background-color: @mantle !important;
+    }
+
+    .scrollablePopiverListRoot-module--root--588fe {
+      background-color: @base !important;
     }
 
     /* text color */
@@ -188,6 +192,15 @@
       ):hover {
       color: @accent-color;
       border-color: @accent-color;
+    }
+
+    .hover\:bg-\[\#B4DAE8\]:hover {
+      background-color: @surface2 !important;
+    }
+
+    /* highlight */
+    .bg-\[\#E1F0F5\] {
+      background-color: @surface1 !important;
     }
 
     /* buttons */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes poor contrast on highlighted text, hovered word and dictionary popout.

Closes #1149.

Before:

![image](https://github.com/user-attachments/assets/7fc1807a-dcd8-4792-b8b5-390e1d81d942)

After:

![image](https://github.com/user-attachments/assets/a3c53876-7aee-42b5-b64f-7d03df322a2a)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
