### PR TITLE
fix(mastodon): getting-started links background colors

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -751,6 +751,14 @@ domain("fosstodon.org") {
     .getting-started, .getting-started__wrapper {
       background: @surface0;
     }
+
+    .column-link {
+      color: @text;
+
+      &:hover {
+        color: @accent-color;
+      }
+    }
   }
 }
 

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Mastodon Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version 2.0.0
+@version 2.0.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amastodon
 @description Soothing pastel theme for Mastodon
@@ -746,6 +746,10 @@ domain("fosstodon.org") {
 
     .reply-indicator {
       background: @surface1;
+    }
+
+    .getting-started, .getting-started__wrapper {
+      background: @surface0;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

fixed the background color on the getting started link items not matching the rest of the column.

before:
![before-image](https://github.com/user-attachments/assets/0880ef19-cf43-4977-91f8-e9fc80b3ea49)

after:
![after-image](https://github.com/user-attachments/assets/4dadffe8-a01b-497e-90c3-10c8b8b9a879)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.