### PR TITLE
fix(mastodon): column-header background contrast issues

### DIFF
--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Mastodon Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/mastodon
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/mastodon
-@version 2.0.1
+@version 2.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/mastodon/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Amastodon
 @description Soothing pastel theme for Mastodon
@@ -452,9 +452,16 @@ domain("fosstodon.org") {
       }
     }
 
+    .column-header__button {
+      background: @base;
+
+      &:hover {
+        background: @surface0;
+      }
+    }
+
     .search-popout,
     .drawer__header a:hover,
-    .column-header__button:hover,
     .account__section-headline button:hover,
     .account__section-headline a:hover {
       background: @surface2;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

fixed the contrast issues between the column-header and the column-header buttons.

###### screenshots

(left header button is hovered)

before:
![before-image](https://github.com/user-attachments/assets/ea2f0079-d26b-4c9b-9629-91058cc62077)

after:
![after-image](https://github.com/user-attachments/assets/f2ba80ea-7f71-4974-a597-ba7ac3a0e226)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.