### PR TITLE
fix(github): jupyter notebook editor background

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.7.6
+@version      1.7.7
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -795,6 +795,7 @@
     --jp-info-color1: var(--color-scale-blue-5);
     --jp-info-color2: var(--color-scale-blue-3);
     --jp-info-color3: var(--color-scale-blue-1);
+    --jp-cell-editor-background: @mantle;
     --jp-cell-editor-border-color: var(--color-scale-gray-7);
     --jp-cell-editor-box-shadow: inset 0 0 2px var(--color-scale-blue-3);
     --jp-cell-prompt-not-active-font-color: fadeout(@text, 50%);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Jupyter notebook editor background is unthemed and codes are unreadable.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/2ee04b1f-3383-44a9-8f3b-41d0c5f36480)|![image](https://github.com/user-attachments/assets/b8dcbbea-6e2e-49e5-924c-8ade8490b00c)|

This fix works for other 3 flavors as well.

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [ ] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
