### PR TITLE
fix(stack-overflow): notices low contrast issue

### DIFF
--- a/styles/stack-overflow/catppuccin.user.css
+++ b/styles/stack-overflow/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stack Overflow Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stack-overflow
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stack-overflow
-@version 0.2.0
+@version 0.2.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stack-overflow/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astack-overflow
 @description Soothing pastel theme for Stack Overflow
@@ -306,7 +306,7 @@ domain('superuser.com'), domain('mathoverflow.net'), domain('askubuntu.com'), do
     .s-notice {
       &,
       .s-notice--btn {
-        color: @mantle !important;
+        color: @text !important;
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

fixes #1363 

fixed the contrast issue of notices on stack overflow

## Screenshots

### Before

![373975512-8aeb7427-ca82-451b-a84d-121bca8957b9](https://github.com/user-attachments/assets/bcda4392-7593-4db7-88c0-17a3d7b3c817) 
<p align="center">latte</p>

![373975511-f5db817f-5b48-49b5-9630-77d41703a379](https://github.com/user-attachments/assets/13aed0da-1ce5-48d7-9801-7ebf6ffe5a3f)
<p align="center">mocha</p>

### After

![Screenshot 2024-10-23 at 00-45-49 html - RegEx match open tags except XHTML self-contained tags - Stack Overflow](https://github.com/user-attachments/assets/739243bb-d14e-4f89-bd62-8a73dcfe00c7)
<p align="center">latte</p>

![Screenshot 2024-10-23 at 00-45-26 html - RegEx match open tags except XHTML self-contained tags - Stack Overflow](https://github.com/user-attachments/assets/8466c699-a4c7-4330-aae9-8f9963fbc4b9)
<p align="center">mocha</p>

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.