### PR TITLE
fix(inoreader): sidebar contrast issues

### DIFF
--- a/styles/inoreader/catppuccin.user.css
+++ b/styles/inoreader/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name inoreader Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/inoreader
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/inoreader
-@version 0.0.6
+@version 0.0.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/inoreader/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ainoreader
 @description Soothing pastel theme for inoreader
@@ -186,8 +186,9 @@
 
     #tree_pane .plus_img,
     #tabs_pane .nav-item a i,
+    #tabs_pane .nav-item a span,
     #tabs_pane #bottom_tabs .nav-item a i {
-      color: @text;
+      color: @crust;
     }
 
     #hint-pref {

--- a/styles/inoreader/catppuccin.user.css
+++ b/styles/inoreader/catppuccin.user.css
@@ -194,10 +194,10 @@
       color: @crust;
     }
 
-  #tabs_pane .tabs-counter {
-    color: @text !important;
-    background-color: @base !important;
-  }
+    #tabs_pane .tabs-counter {
+      color: @text !important;
+      background-color: @base !important;
+    }
 
     #hint-pref {
       fill: @accent-color;

--- a/styles/inoreader/catppuccin.user.css
+++ b/styles/inoreader/catppuccin.user.css
@@ -184,6 +184,10 @@
       color: @accent-color !important;
     }
 
+    .icon-logo_circle {
+      color: @crust !important;
+    }
+
     #tabs_pane .nav-item a i,
     #tabs_pane .nav-item a span,
     #tabs_pane #bottom_tabs .nav-item a i {

--- a/styles/inoreader/catppuccin.user.css
+++ b/styles/inoreader/catppuccin.user.css
@@ -194,6 +194,11 @@
       color: @crust;
     }
 
+  #tabs_pane .tabs-counter {
+    color: @text !important;
+    background-color: @base !important;
+  }
+
     #hint-pref {
       fill: @accent-color;
     }
@@ -228,8 +233,8 @@
     }
 
     .tabs-counter {
-      background-color: @blue !important;
-      outline-color: @blue !important;
+      background-color: @accent-color !important;
+      outline-color: @accent-color !important;
       color: @mantle;
     }
 

--- a/styles/inoreader/catppuccin.user.css
+++ b/styles/inoreader/catppuccin.user.css
@@ -124,12 +124,12 @@
     .inno_tabs_wrapper .inno_tabs_header .inno_tabs_tab a:link,
     .inno_tabs_wrapper .inno_tabs_header .inno_tabs_tab a:active,
     .inno_tabs_wrapper .inno_tabs_header .inno_tabs_tab a:visited,
-    #tabs_pane .nav-item a i,
-    #tabs_pane .nav-item a {
+    #tree_pane .plus_img {
       color: @text;
     }
     a.text-color,
-    a.nav-item-btn {
+    a.nav-item-btn,
+    .icon-arrow_collapse {
       color: @text !important;
     }
 
@@ -184,7 +184,6 @@
       color: @accent-color !important;
     }
 
-    #tree_pane .plus_img,
     #tabs_pane .nav-item a i,
     #tabs_pane .nav-item a span,
     #tabs_pane #bottom_tabs .nav-item a i {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Closes #1380 

Fixes the contrast issues of the sidebar on Inoreader

## Screenshots

### Before

![377200399-66a2386f-1685-4fa1-9609-30c93bc288ec](https://github.com/user-attachments/assets/f1bd82f8-9b1e-4001-86fe-a48a73df3d8d)
Latte + Mauve

![377200716-f0d53331-2e14-4c56-94d8-27d486c796a7](https://github.com/user-attachments/assets/d5e9f6ed-a9b2-4d4c-be2f-76e2ca98e28e)
Macchiato + Mauve

![377200816-cb925d34-273f-4b84-a627-c00c5619fb8e](https://github.com/user-attachments/assets/a1f9aa3c-4e66-402f-abb9-c14ee338102e)
Macchiato + Sky

### After

![Screenshot 2024-10-23 at 15-54-53 Build your own newsfeed Inoreader](https://github.com/user-attachments/assets/3f2f9503-6f42-498a-846e-5ac3fc829ee6)
Latte + Mauve

![Screenshot 2024-10-23 at 15-56-47 Build your own newsfeed Inoreader](https://github.com/user-attachments/assets/2a99d637-67e8-4381-b264-4d4c64fc570a)
Macchiato + Mauve

![Screenshot 2024-10-23 at 15-58-32 Build your own newsfeed Inoreader](https://github.com/user-attachments/assets/71eb3690-b809-4469-af47-d0d967c28a37)
Macchiato + Sky


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.