### PR TITLE
fix(github): pull request check in progress indicator

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.7.7
+@version      1.7.8
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub
@@ -583,6 +583,14 @@
     .subnav-link.selected {
       border-bottom-color: @accent-color;
     }
+      
+    /* Pull request check in progress indicator */
+      [stroke="#DBAB0A"] {
+          stroke: fade(@yellow, 70%) !important;
+      }
+      [fill="#DBAB0A"] {
+          fill: @yellow !important;
+      }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes these loading throbbers:

![image](https://github.com/user-attachments/assets/9e1a4bbb-41e4-4163-92b3-c73a679b90b1)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
