### PR TITLE
fix(keybr.com): darken lesson keys colors

### DIFF
--- a/styles/keybr.com/catppuccin.user.css
+++ b/styles/keybr.com/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name keybr.com Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/keybr.com
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/keybr.com
-@version 0.0.1
+@version 0.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/keybr.com/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Akeybr.com
 @description Soothing pastel theme for keybr.com
@@ -118,7 +118,9 @@
     --Value--less__color: @red;
     --KeyboardKey-button--depressed__color: @accent-color;
     --LessonKey--included__color: @crust;
-    --LessonKey--excluded__color: @crust;
+    --LessonKey--uncalibrated__background-color: @surface0;
+    --LessonKey--excluded__background-color: @surface0;
+    --LessonKey--excluded__color: @overlay0;
     --DailyGoal-bar__color: @accent-color;
     --KeyboardKey-button__color: @accent-color;
     --textinput__color: @text;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

darken lesson key background colors

before:
![before-image](https://github.com/user-attachments/assets/b54c9bfa-2771-4694-8ade-02539ec0a6ed)

after:
![after-image](https://github.com/user-attachments/assets/82271248-f7db-4950-a9a9-409dcb179ab3)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.