### PR TITLE
fix(chess.com): hovered toolbar icons, coach nudge modal

### DIFF
--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Chess.com Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chess.com
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chess.com
-@version 0.2.1
+@version 0.2.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chess.com/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achess.com
 @description Soothing pastel theme for Chess.com

--- a/styles/chess.com/catppuccin.user.css
+++ b/styles/chess.com/catppuccin.user.css
@@ -300,8 +300,14 @@
       }
     }
 
-    #tb .toolbar-action-icon {
-      color: @subtext1;
+    #tb {
+      .toolbar-action-icon {
+        color: @subtext1;
+      }
+
+      .toolbar-action-wrapper:hover .toolbar-action-icon {
+        color: @text !important;
+      }
     }
 
     #sb {
@@ -514,6 +520,10 @@
       .modal-trial-header-background {
         background-color: @accent-color;
       }
+    }
+
+    .coach-nudges-modal-component {
+      background: @mantle;
     }
 
     .ready-to-play-banner-component {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes the background of a random "coach nudge" modal that popped up,  and correctly themes the hover color of hovered icons in the toolbar.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
