### PR TITLE
fix(bsky): some broken stuff and missing selectors

### DIFF
--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Bluesky Social Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/bsky
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/bsky
-@version 0.0.7
+@version 0.0.8
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bsky/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Absky
 @description Soothing pastel theme for Bluesky Social
@@ -210,7 +210,6 @@
     }
 
     /* generic background color */
-    .css-175oi2r.r-13awgt0,
     [style*="background-color: rgb(255, 255, 255)"],
     [style*="background-color: rgb(0, 0, 0)"],
     [style*="background-color: rgb(22, 30, 39)"] {
@@ -347,7 +346,7 @@
     }
 
     // toast notifications (e.g. "copied to clipboard")
-    .r-17c3jg3 {
+    .r-17c3jg3:has(> div[dir="auto"]) {
       background-color: @crust !important;
 
       .r-jwli3a {
@@ -446,8 +445,9 @@
       fill: @subtext1;
     }
 
-    /* settings button at the top of the timeline */
-    path[fill="hsl(211, 24%, 70%)"] {
+    /* settings button at the top of the timeline, hashtag button/icon at top of timeline */
+    path[fill="hsl(211, 24%, 70%)"],
+    path[fill="hsl(211, 20%, 62.4%)"] {
       fill: @subtext1;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- themes the feeds/hashtag icon at the top of the timeline
- fix youtube/3rd party embeds being covered up
- fix image popout background not being transparent anymore

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
