### PR TITLE
fix(hackage): color the synopsis toggle and older Haddock pages

### DIFF
--- a/styles/hackage/catppuccin.user.css
+++ b/styles/hackage/catppuccin.user.css
@@ -103,7 +103,13 @@
     h4,
     h5,
     h6,
-    summary {
+    summary,
+    .section1,
+    .section2,
+    .section3,
+    .section4,
+    .section5,
+    .section6 {
       color: overlay(@accent-color, @surface0);
       filter: none;
     }
@@ -124,8 +130,21 @@
       border-color: @accent-color;
     }
 
-    .src {
+    .src,
+    .decl,
+    .declname,
+    .declbut,
+    .topdecl,
+    .arg {
       background-color: @mantle;
+      color: @text;
+    }
+
+    .declbut {
+      border-color: @overlay0 !important;
+      a {
+        color: @overlay2 !important;
+      }
     }
 
     /*
@@ -146,7 +165,8 @@
       color: @base !important;
     }
 
-    #module-header .caption {
+    #module-header .caption,
+    .modulebar {
       color: @accent-color;
       border-color: @surface1;
     }
@@ -181,6 +201,27 @@
       button {
         color: @base;
       }
+    }
+
+    .topbar {
+      background-color: @accent-color;
+
+      .topbut {
+        border-color: @overlay0;
+
+        a {
+          background-color: transparent;
+          color: @base;
+        }
+      }
+      .title {
+        color: @base;
+      }
+    }
+
+    .botbar {
+      background-color: @crust;
+      color: @text;
     }
 
     /*
@@ -367,6 +408,11 @@
       th {
         background-color: @mantle;
       }
+    }
+
+    .infohead,
+    .infoval {
+      color: @subtext1;
     }
 
     div#table_length.dataTables_length,
@@ -655,51 +701,55 @@
      * Sources
      */
 
-    /* Old */
+    span.definition,
+    .hs-identifier {
+      color: @blue;
+    }
 
-    .hs-keyglyph,
-    .hs-layout {
-      color: @overlay2;
+    .hs-identifier.hs-type {
+      color: @yellow;
     }
-    .hs-comment a {
-      color: @overlay0;
+
+    span.keyword,
+    .hs-keyword {
+      color: @mauve;
     }
+
+    span.str,
+    span.char,
+    .hs-string,
+    .hs-char,
     .hs-str,
     .hs-chr {
       color: @green;
     }
 
-    /* Modern */
-
-    .hs-identifier {
-      color: @blue;
-    }
-    .hs-identifier.hs-type {
-      color: @yellow;
-    }
-    .hs-keyword {
-      color: @mauve;
-    }
-    .hs-string,
-    .hs-char {
-      color: @green;
-    }
     .hs-number {
       color: @peach;
     }
+
     .hs-operator {
       color: @sky;
     }
+
+    span.keyglyph,
+    span.layout,
+    span.conop,
+    .hs-keyglyph,
+    .hs-layout,
     .hs-glyph,
     .hs-special {
       color: @overlay2;
     }
-    .hs-comment {
+
+    span.comment,
+    .hs-comment,
+    .hs-comment a {
       color: @overlay0;
     }
-    .hs-pragma {
-      color: @pink;
-    }
+
+    span.cpp,
+    .hs-pragma,
     .hs-cpp {
       color: @pink;
     }

--- a/styles/hackage/catppuccin.user.css
+++ b/styles/hackage/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hackage Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hackage
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hackage
-@version 0.1.2
+@version 0.1.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hackage/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahackage
 @description Soothing pastel theme for Hackage
@@ -55,6 +55,7 @@
     @mantle: @catppuccin[@@lookup][@mantle];
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
+    @text-filter: @catppuccin[@@lookup][@text-filter];
 
     color-scheme: if(@lookup = latte, light, dark);
 
@@ -642,8 +643,8 @@
       }
     }
 
-    span.mathjax img when not (@lookup = latte) {
-      filter: invert(100%);
+    span.mathjax img {
+      filter: @text-filter;
     }
 
     /*
@@ -727,10 +728,22 @@
 
 /* prettier-ignore */
 @catppuccin: {
-  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
-  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
-  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
-  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+  @latte: {
+    @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8;
+    @text-filter: brightness(0) saturate(100%) invert(30%) sepia(10%) saturate(1259%) hue-rotate(196deg) brightness(97%) contrast(91%);
+  };
+  @frappe: {
+    @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634;
+    @text-filter: brightness(0) saturate(100%) invert(84%) sepia(5%) saturate(1519%) hue-rotate(192deg) brightness(100%) contrast(93%);
+  };
+  @macchiato: {
+    @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926;
+    @text-filter: brightness(0) saturate(100%) invert(81%) sepia(9%) saturate(726%) hue-rotate(192deg) brightness(104%) contrast(92%);
+  };
+  @mocha: {
+    @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b;
+    @text-filter: brightness(0) saturate(100%) invert(85%) sepia(6%) saturate(1356%) hue-rotate(194deg) brightness(103%) contrast(91%);
+  };
 }
 
 // vim:ft=less

--- a/styles/hackage/catppuccin.user.css
+++ b/styles/hackage/catppuccin.user.css
@@ -56,6 +56,7 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
     @text-filter: @catppuccin[@@lookup][@text-filter];
+    @synopsis-filter: @catppuccin[@@lookup][@synopsis-filter];
 
     color-scheme: if(@lookup = latte, light, dark);
 
@@ -243,8 +244,9 @@
     }
 
     #synopsis {
-      summary {
-        color: transparent;
+      summary,
+      #control\.syn {
+        filter: @synopsis-filter;
       }
 
       ul {
@@ -388,8 +390,10 @@
 
     #interface {
       .src {
-        .selflink .link {
-          color: @overlay2;
+        .link,
+        .selflink {
+          color: @overlay2 !important;
+          background-color: transparent !important;
         }
       }
       p.src .link {
@@ -731,18 +735,22 @@
   @latte: {
     @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8;
     @text-filter: brightness(0) saturate(100%) invert(30%) sepia(10%) saturate(1259%) hue-rotate(196deg) brightness(97%) contrast(91%);
+    @synopsis-filter: sepia(100%) invert(100%) saturate(0) invert(94%) sepia(7%) saturate(345%) hue-rotate(188deg) brightness(91%) contrast(87%);
   };
   @frappe: {
     @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634;
     @text-filter: brightness(0) saturate(100%) invert(84%) sepia(5%) saturate(1519%) hue-rotate(192deg) brightness(100%) contrast(93%);
+    @synopsis-filter: sepia(100%) invert(100%) saturate(0) invert(25%) sepia(25%) saturate(486%) hue-rotate(193deg) brightness(90%) contrast(89%);
   };
   @macchiato: {
     @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926;
     @text-filter: brightness(0) saturate(100%) invert(81%) sepia(9%) saturate(726%) hue-rotate(192deg) brightness(104%) contrast(92%);
+    @synopsis-filter: sepia(100%) invert(100%) saturate(0) invert(19%) sepia(15%) saturate(979%) hue-rotate(193deg) brightness(101%) contrast(90%);
   };
   @mocha: {
     @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b;
     @text-filter: brightness(0) saturate(100%) invert(85%) sepia(6%) saturate(1356%) hue-rotate(194deg) brightness(103%) contrast(91%);
+    @synopsis-filter: sepia(100%) invert(100%) saturate(0) invert(17%) sepia(17%) saturate(874%) hue-rotate(198deg) brightness(90%) contrast(89%);
   };
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

* Colored the MathJax renders using proper filters instead of fully inverting the color.
* Fixed the synopsis toggle in Haddock using filters too.

![the synopsis toggle before the change](https://github.com/user-attachments/assets/56485834-5607-47ab-b0a8-3366dc8c0471)
![the synopsis toggle after the change](https://github.com/user-attachments/assets/548018f7-2bf4-4d18-917c-a2d9022cdd03)

* Themed older Haddock pages ([example](https://hackage.haskell.org/package/base-4.0.0.0/docs/Data-List.html)) and sources.

![old Haddock page before the change](https://github.com/user-attachments/assets/4afb1337-ae9a-404e-9680-f72fb64ae604)
![old Haddock page after the change](https://github.com/user-attachments/assets/f4cfccab-028a-4a67-8977-9d3d74c463e8)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
