### PR TITLE
fix(youtube): search bar

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.13
+@version 4.2.14
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -680,6 +680,40 @@
       border-color: @accent-color;
     }
 
+    .YtSearchboxComponentInputBox {
+      background: var(--ytd-searchbox-background);
+      color: var(--ytd-searchbox-text-color);
+      border-color: var(--ytd-searchbox-border-color);
+      box-shadow: none;
+    }
+
+    .YtSearchboxComponentInputBoxHasFocus {
+      border-color: @accent-color
+    }
+
+    .YtSearchboxComponentSuggestionsContainer {
+      background: var(--yt-spec-raised-background);
+      border-color: var(--yt-spec-raised-background);
+    }
+
+    .YtSuggestionComponentSuggestion {
+      color: var(--ytd-searchbox-text-color);
+    }
+
+    .YtSearchboxComponentSearchButton {
+      color: var(--ytd-searchbox-text-color);
+      background: @surface0;
+      border-color: var(--ytd-searchbox-border-color);
+    }
+
+    .YtSearchboxComponentClearButtonIcon {
+      color: var(--ytd-searchbox-text-color);
+    }
+
+    .YtSearchboxComponentReportButton {
+      color: @subtext0;
+    }
+
     .sbsb_a {
       background: @surface0;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes search bar styling
![image](https://github.com/user-attachments/assets/87958d7c-2d45-489b-bc75-f6f7d4c67300)
![image](https://github.com/user-attachments/assets/ab88a9d3-6794-4310-9303-268bffb5ca12)
![image](https://github.com/user-attachments/assets/3a4c705a-98ac-4a93-bd75-99b37001ef9e)
![image](https://github.com/user-attachments/assets/503753af-827b-451e-a55b-054ae292d07e)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
