### PR TITLE
fix(google-photos): assorted changes

### DIFF
--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -198,6 +198,13 @@
 .yERkJe {
   color: @subtext0;
 }
+/* grey popup in the bottom left corner */
+.zyTWof-YAxtVc {
+  background-color: @surface0;
+}
+.zyTWof-gIZMF {
+  color: @text;
+}
     /* search bar in the top bar */
     .Aul2T,
     .cI2tlc .jBmls {

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -178,6 +178,26 @@
 .JoLw2e {
   background-color: @base;
 }
+/* blue move to archive suggestion */
+.mVK51d {
+  background-color: @blue; }
+.FkI4sc
+{
+  color: @mantle;
+}
+.rtMuCd {
+  border-bottom-color: @blue;
+}
+/* don't miss a moment notif popup */
+.KG4Qee, .RODueb {
+  background-color: @surface0;
+}
+.R5XrWc {
+  color: @text;
+}
+.yERkJe {
+  color: @subtext0;
+}
     /* search bar in the top bar */
     .Aul2T,
     .cI2tlc .jBmls {

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -157,10 +157,26 @@
       background-color: @blue !important;
     }
     /* top bar */
-    .QtDoYb {
+   .fXq1Rc .QtDoYb {
       background-color: @crust;
       border-color: @crust;
     }
+    /* top bar when selected */
+    .KWdEHf.QtDoYb.CWVNI {
+      background-color: @crust;
+      border-color: @crust;
+    }
+    /* selected photo background */
+    .rtIMgb.WjVZdb {
+      background-color: @overlay0;
+    }
+    /* move to archive buttonn */
+    .QFDibd {
+      color: @text;
+    }
+.JoLw2e {
+  background-color: @base;
+}
     /* search bar in the top bar */
     .Aul2T,
     .cI2tlc .jBmls {

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -166,6 +166,7 @@
       background-color: @crust;
       border-color: @crust;
     }
+
     /* selected photo background */
     .rtIMgb.WjVZdb {
       background-color: @overlay0;
@@ -272,6 +273,13 @@
     .z3RRjd:not(:disabled) {
       color: @accent-color;
       border-color: @surface0;
+    }
+    /* locked photo dialog */
+    .uW2Fw-P5QLlc {
+      background-color: @base !important;
+    }
+    .uW2Fw-k2Wrsb {
+      color: @text;
     }
     /* search bar */
     .fXq1Rc:not(.A82uMb) .Aul2T.qs41qe {

--- a/styles/google-photos/catppuccin.user.css
+++ b/styles/google-photos/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Google Photos Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/google-photos
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-photos
-@version 0.0.5
+@version 0.0.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-photos/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-photos
 @description Soothing pastel theme for Google Photos


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
closes #1414 and themes the "move to archive" box
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
<img width="532" alt="image" src="https://github.com/user-attachments/assets/67c46343-1c80-47ef-a18e-c771ff149580">

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
