### PR TITLE
fix(twitch): use proper username color

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.3.1
+@version 1.3.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -603,6 +603,9 @@
     }
     [style="color: rgb(245, 0, 155);"] {
       color: @pink !important;
+    }
+    [style*="rgb(255, 255, 255)"] .chat-author__display-name {
+      color: #fff;
     }
     .fixed-prediction-button--blue,
     [style*="background-color: rgb(56, 122, 255);"],


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- custom username color #ffffff was displayed as Base color
![2024-11-06-215538_hyprshot](https://github.com/user-attachments/assets/ad0e92c8-a596-45d5-8801-3a73f00884c3)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
