### PR TITLE
fix(twitch): use proper username chat color

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.3.1
+@version 1.3.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -603,6 +603,11 @@
     }
     [style="color: rgb(245, 0, 155);"] {
       color: @pink !important;
+    }
+
+    [style*="rgb(255, 255, 255)"] .chat-author__display-name,
+    [style*="rgb(255, 255, 255)"] .message-author__display-name {
+      color: #fff !important;
     }
     .fixed-prediction-button--blue,
     [style*="background-color: rgb(56, 122, 255);"],

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -607,7 +607,7 @@
 
     [style*="rgb(255, 255, 255)"] .chat-author__display-name,
     [style*="rgb(255, 255, 255)"] .message-author__display-name {
-      color: #fff !important;
+      color: @text !important;
     }
     .fixed-prediction-button--blue,
     [style*="background-color: rgb(56, 122, 255);"],


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- custom username color #ffffff was displayed as Base color
![2024-11-06-215538_hyprshot](https://github.com/user-attachments/assets/fd51b277-d01a-47e0-8058-a0625c942bd4)
![2024-11-06-221842_hyprshot](https://github.com/user-attachments/assets/1e112a92-49df-40fb-96ea-81665d305fc8)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
