### PR TITLE
fix(twitch): use proper colors in mod logs, title and description

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.3.2
+@version 1.3.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -605,10 +605,12 @@
       color: @pink !important;
     }
 
+    [style*="rgb(255, 255, 255)"].channel-root,
     [style*="rgb(255, 255, 255)"] .chat-author__display-name,
-    [style*="rgb(255, 255, 255)"] .message-author__display-name {
+    [style*="rgb(255, 255, 255)"].message-author__display-name {
       color: @text !important;
     }
+
     .fixed-prediction-button--blue,
     [style*="background-color: rgb(56, 122, 255);"],
     [style*="background: rgb(56, 122, 255);"] {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- custom username color #ffffff was displayed as Base color in mod logs
![fix2](https://github.com/user-attachments/assets/15ef1fe3-b05b-4f6e-964b-9a23bbbfb9a3)
- wrong text color was used in stream title and channel description on some channels
![fix1](https://github.com/user-attachments/assets/f1b408ad-b5c4-4ae5-9592-5436ccdfa282)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
