### PR TITLE
fix(chatgpt): unthemed message surface

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.3.4
+@version 0.3.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -142,6 +142,7 @@
       --main-surface-primary: var(--gray-800) !important;
       --main-surface-secondary: var(--gray-700) !important;
       --main-surface-tertiary: var(--gray-600) !important;
+      --message-surface: var(--gray-700) !important;
       --sidebar-surface-primary: var(--gray-900);
       --sidebar-surface-secondary: var(--gray-800);
       --sidebar-surface-tertiary: var(--gray-700);
@@ -177,6 +178,7 @@
       --main-surface-primary: var(--gray-200);
       --main-surface-secondary: var(--gray-100);
       --main-surface-tertiary: var(--gray-50);
+      --message-surface: var(--gray-700) !important;
       --sidebar-surface-primary: var(--gray-100);
       --sidebar-surface-secondary: var(--gray-200);
       --sidebar-surface-tertiary: var(--gray-300);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Closes #1424

## Screenshot

![Screenshot 2024-11-09 at 16-38-56 ChatGPT](https://github.com/user-attachments/assets/fb8e97bf-b40a-46fa-b2b5-16cbdb0c6eaf)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
