### PR TITLE
fix(twitch): unthemed info boxes

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.3.3
+@version 1.3.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -609,6 +609,13 @@
     [style*="rgb(255, 255, 255)"] .chat-author__display-name,
     [style*="rgb(255, 255, 255)"].message-author__display-name {
       color: @text !important;
+    }
+
+    .info_box_row {
+      background: @crust;
+    }
+    .info_box_row_label {
+      color: @text;
     }
 
     .fixed-prediction-button--blue,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Fixes unthemed info boxes in Creator Dashboard.
![fix](https://github.com/user-attachments/assets/b5be5dc3-e9b1-44a5-acf0-bb288dcd169a)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
