### PR TITLE
fix(github): tooltip colors

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -502,8 +502,8 @@
     --data-red-color-emphasis: @red;
     --data-green-color-emphasis: @green;
 
-    --tooltip-fgColor: @text;
-    --tooltip-bgColor: @crust;
+    --tooltip-fgColor: @base;
+    --tooltip-bgColor: @overlay2;
 
     /* Refined GitHub */
     --rgh-heat-color: @peach;

--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name         GitHub Catppuccin
 @namespace    github.com/catppuccin/userstyles/styles/github
 @homepageURL  https://github.com/catppuccin/userstyles/tree/main/styles/github
-@version      1.7.8
+@version      1.7.9
 @updateURL    https://github.com/catppuccin/userstyles/raw/main/styles/github/catppuccin.user.css
 @supportURL   https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agithub
 @description  Soothing pastel theme for GitHub


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/user-attachments/assets/34751f7c-a390-4b61-93f6-15df1d6ea0e9)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
