### PR TITLE
fix(duckduckgo): unthemed elements

### DIFF
--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name DuckDuckGo Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/duckduckgo
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/duckduckgo
-@version 0.3.0
+@version 0.3.1
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/duckduckgo/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aduckduckgo
 @description Soothing pastel theme for DuckDuckGo

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -451,6 +451,10 @@
     .module__inner-toggle::after {
       background-color: @surface2 !important;
     }
+    .module--lyrics:not(.is-expanded)
+      .module--lyrics__footer.can-expand::after {
+      background: linear-gradient(rgba(0, 0, 0, 0), @surface0);
+    }
 
     // translation boxes
     .module--translations .dropdown--translation-select,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -332,7 +332,7 @@
     }
 
     .module__toggle--more::after {
-      background: linear-gradient(rgba(40, 40, 40, 0), @surface0);
+      background: linear-gradient(transparent, @surface0);
     }
 
     /* button on hover */
@@ -453,7 +453,7 @@
     }
     .module--lyrics:not(.is-expanded)
       .module--lyrics__footer.can-expand::after {
-      background: linear-gradient(rgba(0, 0, 0, 0), @surface0);
+      background: linear-gradient(transparent, @surface0);
     }
     .module--lyrics__explicit-tag {
       border-color: @subtext1;
@@ -879,11 +879,11 @@
     }
 
     .metabar__dropdowns-wrap::before {
-      background-image: linear-gradient(90deg, @base, rgba(255, 255, 255, 0));
+      background-image: linear-gradient(90deg, @base, transparent);
     }
 
     .metabar__dropdowns-wrap::after {
-      background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), @base);
+      background-image: linear-gradient(90deg, transparent, @base);
     }
 
     .nav-menu__item__badge {
@@ -898,14 +898,14 @@
     }
 
     .zcm--right-fade::before {
-      background: linear-gradient(90deg, rgba(255, 255, 255, 0), @mantle);
+      background: linear-gradient(90deg, transparent, @mantle);
     }
     .search-filters-wrap::before {
-      background: linear-gradient(90deg, @base, rgba(255, 255, 255, 0));
+      background: linear-gradient(90deg, @base, transparent);
     }
 
     .search-filters-wrap::after {
-      background: linear-gradient(90deg, rgba(255, 255, 255, 0), @base);
+      background: linear-gradient(90deg, transparent, @base);
     }
 
     .footer,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -186,6 +186,7 @@
     --sds-color-background-accent-01: @accent-color !important;
     --theme-col-txt-card-body-light: @text !important;
     --theme-col-bg-page-alt-2: @surface0 !important;
+    --theme-col-bg-ui-active: @surface1 !important;
     --theme-dc-color-llama-main: @pink !important;
     --theme-dc-color-mixtral-main: @peach !important;
     --theme-dc-color-anchor-sleep: @subtext0 !important;

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -162,6 +162,7 @@
     --theme-col-bg-header: @mantle !important;
     --theme-col-bg-header-modal: @surface0 !important;
     --theme-col-bg-button-primary: @blue !important;
+    --sds-color-background-dark: @crust !important;
     /* ai chat */
     --sds-color-text-link-02-hover: @text !important;
     --theme-dc-color-background-dark: @base !important;

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -831,6 +831,13 @@
       border-color: @surface1 !important;
     }
 
+    .modal__header,
+    .module__section,
+    .module__section:first-child.place-detail__section--tab,
+    .module__clickable-header {
+      border-color: @surface1 !important;
+    }
+
     .btn.is-disabled:hover,
     .frm__switch__label:hover,
     .feedback-modal__submit.is-disabled:hover,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -92,6 +92,7 @@
     --theme-col-border-ui: @surface1 !important;
     --theme-col-bg-expandcollapse: @surface0 !important;
     --sds-color-palette-gray-60: @accent-color !important;
+    --sds-color-text-accent-01: @accent-color !important;
     --theme-col-txt-msg: @text !important;
     --theme-col-txt-url-path: @subtext0 !important;
     --theme-col-border-expandcollapse: @surface1;

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -455,6 +455,10 @@
       .module--lyrics__footer.can-expand::after {
       background: linear-gradient(rgba(0, 0, 0, 0), @surface0);
     }
+    .module--lyrics__explicit-tag {
+      border-color: @subtext1;
+      color: @subtext0;
+    }
 
     // translation boxes
     .module--translations .dropdown--translation-select,

--- a/styles/duckduckgo/catppuccin.user.css
+++ b/styles/duckduckgo/catppuccin.user.css
@@ -503,7 +503,7 @@
       color: @text !important;
     }
     code {
-      background-color: @base !important;
+      background-color: @mantle !important;
     }
     .lit {
       color: @peach !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- new accent color variable
![image](https://github.com/user-attachments/assets/37f382f4-6c04-4f33-ba1b-8b0a77a23afe)
- tooltip background color
![image](https://github.com/user-attachments/assets/a7304181-5f8c-4e94-837a-f3d82cadc1c5)
- menu item hover background
![image](https://github.com/user-attachments/assets/d447ac5f-ad0c-4615-ab39-90ec9761da54)
- code background
[example page](https://duckduckgo.com/?q=python+how+to+split+a+string)
search page:
before:
![image](https://github.com/user-attachments/assets/49f1df88-2182-40dd-aa95-3e1a169c21f5)
after:
![image](https://github.com/user-attachments/assets/87bf8b28-ddd0-43e8-8853-c9deaa6c5d2d)

ai chat:
before:
![image](https://github.com/user-attachments/assets/13061a7a-0201-4a6d-aa98-ba3906f0320c)
after:
![image](https://github.com/user-attachments/assets/a887c008-00e2-4678-872e-46f0fbf026f5)

- this border
![image](https://github.com/user-attachments/assets/088bc74c-e3ad-46dc-9ecc-e3258e6dce65)
- unexpanded lyrics gradient and explicit tag
[example page](https://duckduckgo.com/?q=pride+kendrick+lyrics)
![image](https://github.com/user-attachments/assets/6a817979-0864-41cb-b0fd-05b78588fb76)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
