### PR TITLE
fix(twitch): video producer background and thumbnails

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.3.4
+@version 1.3.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -611,13 +611,6 @@
       color: @text !important;
     }
 
-    .info_box_row {
-      background: @crust;
-    }
-    .info_box_row_label {
-      color: @text;
-    }
-
     .fixed-prediction-button--blue,
     [style*="background-color: rgb(56, 122, 255);"],
     [style*="background: rgb(56, 122, 255);"] {
@@ -674,16 +667,34 @@
   }
 
   #catppuccin(@lookup) {
+    @text: @catppuccin[@@lookup][@text];
     @base: @catppuccin[@@lookup][@base];
     @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+
     .simplebar-content {
       background-color: @mantle;
     }
+
     .scrollable-area--suppress-scroll-x > .simplebar-scroll-content,
     .scrollable-area--suppress-scroll-x
       > .simplebar-scroll-content
       > .simplebar-content {
       background-color: @base;
+    }
+
+    .sunlight-page__content .simplebar-scroll-content .simplebar-content {
+      background-color: @base;
+    }
+    .info_box_row {
+      background: @crust;
+    }
+    .info_box_row_label {
+      color: @text;
+    }
+    .video-card-thumbnail__video-state-overlay {
+      color: @text !important;
+      background: fade(@mantle, 80%) !important;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Fixed wrong background color in video producer
- Fixed thumbnails in video producer
![fix](https://github.com/user-attachments/assets/f2b6c977-ef6e-492f-9c6d-0d2514aa7e09)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
