### PR TITLE
feat(twitch): twitch docs

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -801,13 +801,14 @@
       }
       .nav__links a {
         color: @text;
-      }
-      .nav__links a:hover {
-        color: @subtext0;
-      }
-      .nav__links a.active {
-        color: @accent-color;
-        border-color: @accent-color;
+        
+        &:hover {
+          color: @subtext0;
+        }
+        &.active {
+          color: @accent-color;
+          border-color: @accent-color;
+        }
       }
       .nav__logo svg path {
         fill: @text;

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -16,6 +16,8 @@
 ==/UserStyle== */
 
 @-moz-document domain("twitch.tv") {
+  @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
+
   .tw-root--theme-dark {
     #catppuccin(@darkFlavor, @accentColor);
   }
@@ -714,10 +716,14 @@
 @-moz-document domain("dev.twitch.tv"), url-prefix("https://discuss.dev.twitch.com/embed/topics")
 {
   @media (prefers-color-scheme: dark) {
-    #catppuccin(@darkFlavor, @accentColor);
+    :root {
+      #catppuccin(@darkFlavor, @accentColor);
+    }
   }
   @media (prefers-color-scheme: light) {
-    #catppuccin(@lightFlavor, @accentColor);
+    :root {
+      #catppuccin(@lightFlavor, @accentColor);
+    }
   }
 
   #catppuccin(@lookup, @accent) {
@@ -749,7 +755,34 @@
     @crust: @catppuccin[@@lookup][@crust];
     @accent-color: @catppuccin[@@lookup][@@accent];
 
-    html,
+    --ctp-rosewater: @rosewater;
+    --ctp-flamingo: @flamingo;
+    --ctp-pink: @pink;
+    --ctp-mauve: @mauve;
+    --ctp-red: @red;
+    --ctp-maroon: @maroon;
+    --ctp-peach: @peach;
+    --ctp-yellow: @yellow;
+    --ctp-green: @green;
+    --ctp-teal: @teal;
+    --ctp-sky: @sky;
+    --ctp-sapphire: @sapphire;
+    --ctp-blue: @blue;
+    --ctp-lavender: @lavender;
+    --ctp-text: @text;
+    --ctp-subtext1: @subtext1;
+    --ctp-subtext0: @subtext0;
+    --ctp-overlay2: @overlay2;
+    --ctp-overlay1: @overlay1;
+    --ctp-overlay0: @overlay0;
+    --ctp-surface2: @surface2;
+    --ctp-surface1: @surface1;
+    --ctp-surface0: @surface0;
+    --ctp-base: @base;
+    --ctp-mantle: @mantle;
+    --ctp-crust: @crust;
+
+    &,
     body {
       color: @text !important;
       background: @base;
@@ -801,7 +834,7 @@
       }
       .nav__links a {
         color: @text;
-        
+
         &:hover {
           color: @subtext0;
         }
@@ -927,53 +960,6 @@
       code {
         background: transparent !important;
         color: @text !important;
-        /* Syntax highlighting */
-        .c,
-        .c1 {
-          color: @surface1 !important;
-        }
-        .p,
-        .w,
-        .nv {
-          color: @text !important;
-        }
-        .nt,
-        .o {
-          color: @red !important;
-        }
-        .s1,
-        .s2 {
-          color: @yellow !important;
-        }
-        .se,
-        .mi {
-          color: @mauve !important;
-        }
-        .kc,
-        .kt,
-        .nb {
-          color: @sapphire !important;
-        }
-        .k,
-        .na,
-        .kn,
-        .kr,
-        .kd {
-          color: @blue !important;
-        }
-        .nn,
-        .m,
-        .bp {
-          color: @teal !important;
-        }
-        .nc,
-        .nf,
-        .cp {
-          color: @green !important;
-        }
-        .s {
-          color: @peach !important;
-        }
       }
     }
 

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -1074,6 +1074,11 @@
         border-color: @accent-color !important;
       }
 
+      .tag button {
+        background: @accent-color !important;
+        border-color: @accent-color !important;
+      }
+
       .author {
         color: @subtext0 !important;
       }

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -711,7 +711,7 @@
   }
 }
 
-@-moz-document url("https://dev.twitch.tv/"), url-prefix("https://dev.twitch.tv/docs"), url-prefix("https://dev.twitch.tv/code"), url-prefix("https://dev.twitch.tv/products"), url-prefix("https://dev.twitch.tv/showcase"), url-prefix("https://dev.twitch.tv/support"), url-prefix("https://discuss.dev.twitch.com/embed/topics")
+@-moz-document domain("dev.twitch.tv"), url-prefix("https://discuss.dev.twitch.com/embed/topics")
 {
   @media (prefers-color-scheme: dark) {
     #catppuccin(@darkFlavor, @accentColor);
@@ -758,15 +758,15 @@
       scrollbar-color: @surface0 @mantle;
     }
 
-    button,
-    a.btn {
+    a.btn,
+    button.btn {
       border-color: @accent-color;
       background: @accent-color !important;
       color: @base !important;
     }
 
-    button:hover,
-    a.btn:hover {
+    a.btn:hover,
+    button.btn:hover {
       background: fade(@accent-color, 80%) !important;
     }
 
@@ -783,8 +783,15 @@
     }
 
     /* Header */
-    .nav__container {
-      background: @crust;
+    .nav__container,
+    .dev-top-nav {
+      background: @crust !important;
+
+      .tw-link,
+      .dev-top-nav__nav-items-container {
+        color: @text !important;
+        background: @crust !important;
+      }
       .online {
         border-color: @crust !important;
       }
@@ -809,6 +816,7 @@
 
     /* Footers */
     .footer,
+    .dev-footer,
     .subscribe-footer {
       h5,
       p,

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.3.6
+@version 1.4.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -707,6 +707,382 @@
     .video-card-thumbnail__video-state-overlay {
       color: @text !important;
       background: fade(@mantle, 80%) !important;
+    }
+  }
+}
+
+@-moz-document url("https://dev.twitch.tv/"), url-prefix("https://dev.twitch.tv/docs"), url-prefix("https://dev.twitch.tv/code"), url-prefix("https://dev.twitch.tv/products"), url-prefix("https://dev.twitch.tv/showcase"), url-prefix("https://dev.twitch.tv/support"), url-prefix("https://discuss.dev.twitch.com/embed/topics")
+{
+  @media (prefers-color-scheme: dark) {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+  @media (prefers-color-scheme: light) {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    html,
+    body {
+      color: @text !important;
+      background: @base;
+      --primary-medium: @text;
+      --primary-low: @surface0;
+      scrollbar-color: @surface0 @mantle;
+    }
+
+    button,
+    a.btn {
+      border-color: @accent-color;
+      background: @accent-color !important;
+      color: @base !important;
+    }
+
+    button:hover,
+    a.btn:hover {
+      background: fade(@accent-color, 80%) !important;
+    }
+
+    /* Recent announcements */
+    .topics-list .topic-list-item .main-link a {
+      color: @accent-color;
+    }
+
+    .topic-created-at,
+    .topic-last-posted-at,
+    .topic-like-count,
+    .topic-post-count {
+      color: @subtext0 !important;
+    }
+
+    /* Header */
+    .nav__container {
+      background: @crust;
+      .online {
+        border-color: @crust !important;
+      }
+      a.btn.light {
+        background: fade(@accent-color, 10%) !important;
+        color: @text !important;
+      }
+      .nav__links a {
+        color: @text;
+      }
+      .nav__links a:hover {
+        color: @subtext0;
+      }
+      .nav__links a.active {
+        color: @accent-color;
+        border-color: @accent-color;
+      }
+      .nav__logo svg path {
+        fill: @text;
+      }
+    }
+
+    /* Footers */
+    .footer,
+    .subscribe-footer {
+      h5,
+      p,
+      a,
+      div {
+        color: @text !important;
+      }
+      a:hover {
+        color: @accent-color !important;
+      }
+
+      svg path {
+        fill: @text !important;
+      }
+
+      background: @crust;
+    }
+
+    .bright-cta {
+      * {
+        color: @mantle !important;
+      }
+      background: @accent-color;
+    }
+    .content-alternate-2 {
+      background: @base;
+    }
+
+    .sandbox-tab {
+      color: @text !important;
+    }
+
+    .why-twitch ul li {
+      background: @base;
+      border-color: @surface0 !important;
+    }
+
+    .sandbox-tab.active {
+      color: @accent-color !important;
+      border-color: @accent-color !important;
+    }
+
+    .hero,
+    .extension-cta,
+    .subscribe-footer {
+      background: @mantle;
+    }
+
+    thead tr th {
+      border-color: @surface0;
+      background: @mantle;
+    }
+
+    tbody tr td {
+      border-color: @surface0;
+    }
+
+    tbody tr:nth-child(odd) {
+      background: @base !important;
+    }
+    tbody tr:nth-child(even) {
+      background: @mantle !important;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    hr {
+      color: @text !important;
+      border-color: @surface0 !important;
+    }
+
+    .right-code {
+      p {
+        color: @subtext0;
+      }
+    }
+
+    blockquote {
+      border-color: @accent-color;
+      background: @mantle;
+    }
+
+    .content,
+    .main,
+    .topics-list,
+    .doc-content {
+      background: @base;
+      border-color: @base !important;
+    }
+
+    code {
+      border-color: @accent-color !important;
+      background: fade(@accent-color, 5%) !important;
+      color: @text !important;
+    }
+
+    /* Code */
+    .right-code pre,
+    pre.highlight,
+    pre {
+      border-color: @mantle !important;
+      background: @mantle !important;
+      code {
+        background: transparent !important;
+        color: @text !important;
+        /* Syntax highlighting */
+        .c,
+        .c1 {
+          color: @surface1 !important;
+        }
+        .p,
+        .w,
+        .nv {
+          color: @text !important;
+        }
+        .nt,
+        .o {
+          color: @red !important;
+        }
+        .s1,
+        .s2 {
+          color: @yellow !important;
+        }
+        .se,
+        .mi {
+          color: @mauve !important;
+        }
+        .kc,
+        .kt,
+        .nb {
+          color: @sapphire !important;
+        }
+        .k,
+        .na,
+        .kn,
+        .kr,
+        .kd {
+          color: @blue !important;
+        }
+        .nn,
+        .m,
+        .bp {
+          color: @teal !important;
+        }
+        .nc,
+        .nf,
+        .cp {
+          color: @green !important;
+        }
+        .s {
+          color: @peach !important;
+        }
+      }
+    }
+
+    /* Pills */
+    .pill-new {
+      color: @base !important;
+      background: @accent-color !important;
+    }
+    .pill-beta {
+      color: @base !important;
+      background: @yellow !important;
+    }
+
+    a {
+      color: @accent-color;
+    }
+
+    /* Navbar */
+    .sidebar {
+      background: @mantle !important;
+      dl {
+        border-color: @base !important;
+      }
+      dt a,
+      dl dd a {
+        color: @text !important;
+      }
+      dl dd a.active-highlight {
+        color: @accent-color !important;
+      }
+      dl dd a.active-highlight::before {
+        border-left-color: @accent-color !important;
+      }
+      dt a:hover {
+        background: @base !important;
+      }
+
+      /* Search */
+
+      input {
+        color: @text;
+      }
+      input::placeholder {
+        color: @subtext0;
+      }
+      input:focus {
+        background: @crust !important;
+        box-shadow: 0 0 3px 1px fade(@accent-color, 70%);
+        color: @text;
+      }
+
+      .search-icon svg path {
+        fill: @text !important;
+      }
+
+      .algolia-autocomplete {
+        .algolia-docsearch-suggestion--category-header {
+          color: @text !important;
+          background: @mantle !important;
+          border-color: @base !important;
+        }
+
+        .algolia-docsearch-suggestion--highlight {
+          background: @accent-color !important;
+          color: @base !important;
+        }
+
+        .algolia-docsearch-suggestion--content {
+          background: @mantle !important;
+        }
+
+        .algolia-docsearch-suggestion--title {
+          color: @text !important;
+        }
+
+        .algolia-docsearch-suggestion--text {
+          color: @subtext0 !important;
+        }
+
+        .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content {
+          .algolia-docsearch-suggestion--title,
+          .algolia-docsearch-suggestion--text {
+            background: @crust !important;
+            .algolia-docsearch-suggestion--highlight {
+              background: @base !important;
+            }
+          }
+        }
+      }
+    }
+
+    ul.grid li.story {
+      h4 a,
+      a.btn {
+        color: @text !important;
+      }
+      a {
+        color: @accent-color !important;
+      }
+      .story__links a {
+        color: @base !important;
+      }
+
+      border-color: @surface0;
+    }
+
+    .submission .relative .outer {
+      svg path {
+        fill: @text;
+      }
+      button {
+        border-color: @accent-color !important;
+      }
+
+      .author {
+        color: @subtext0 !important;
+      }
+      background: @mantle;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -1015,14 +1015,14 @@
 
       input {
         color: @text;
-      }
-      input::placeholder {
-        color: @subtext0;
-      }
-      input:focus {
-        background: @crust !important;
-        box-shadow: 0 0 3px 1px fade(@accent-color, 70%);
-        color: @text;
+        &::placeholder {
+          color: @subtext0;
+        }
+        &:focus {
+          background: @crust !important;
+          box-shadow: 0 0 3px 1px fade(@accent-color, 70%);
+          color: @text;
+        }
       }
 
       .search-icon svg path {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Themed [Twitch docs](https://dev.twitch.tv/docs/).
![2024-11-11-174443_hyprshot](https://github.com/user-attachments/assets/03aed654-9a2e-48a7-85c5-c550188aa991)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
