### PR TITLE
fix(twitch): link color, usercard and privacy center fixes

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -701,18 +701,6 @@
 
     /* Privacy center */
 
-    .evszEp,
-    .jTEslw {
-      background: @base !important;
-      svg path {
-        fill: @accent-color !important;
-        &[fill="#fff"],
-        &[fill="#FFF"] {
-          fill: none !important;
-        }
-      }
-    }
-
     .privacy-center-root__number-item {
       background: @accent-color;
       color: @base;
@@ -724,6 +712,33 @@
 
     .home-page__title {
       color: @text !important;
+    }
+  }
+}
+
+@-moz-document url("https://www.twitch.tv/privacy")
+{
+  .tw-root--theme-dark {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+  .tw-root--theme-light {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @base: @catppuccin[@@lookup][@base];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    #root {
+      --color-background-accent: @base;
+    }
+
+    svg path {
+      fill: @accent-color !important;
+      &[fill="#fff"],
+      &[fill="#FFF"] {
+        fill: none !important;
+      }
     }
   }
 }

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -689,6 +689,40 @@
     .modal__content {
       color: @text;
     }
+
+    /* Privacy center */
+
+    .evszEp {
+      background: @base !important;
+    }
+
+    .jTEslw {
+      background: @base !important;
+    }
+
+    .evszEp,
+    .jTEslw {
+      svg path {
+        fill: @accent-color !important;
+        &[fill="#fff"],
+        &[fill="#FFF"] {
+          fill: none !important;
+        }
+      }
+    }
+
+    .privacy-center-root__number-item {
+      background: @accent-color;
+      color: @base;
+    }
+
+    .privacy-center-accordion {
+      border-color: @accent-color;
+    }
+
+    .home-page__title {
+      color: @text !important;
+    }
   }
 }
 

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -248,9 +248,9 @@
     }
 
     --color-text-link: @accent-color;
-    --color-text-link-active: @accent-color;
-    --color-text-link-focus: @accent-color;
-    --color-text-link-hover: @accent-color;
+    --color-text-link-active: darken(@accent-color, 5%);
+    --color-text-link-focus: darken(@accent-color, 5%);
+    --color-text-link-hover: darken(@accent-color, 5%);
     --color-text-link-visited: @accent-color;
 
     &,
@@ -691,22 +691,19 @@
     }
 
     /* Leaderboard highlighted username */
-    .bits-leaderboard-expanded-top-three-entry__marquee-username .gRUYWI {
-      color: @base !important;
+    .bits-leaderboard-expanded-top-three-entry__marquee-username,
+    .channel-leaderboard-header-runner-up-entry__username,
+    .bits-leaderboard-expanded-top-three-entry__username {
+      div {
+        color: @base !important;
+      }
     }
 
     /* Privacy center */
 
-    .evszEp {
-      background: @base !important;
-    }
-
-    .jTEslw {
-      background: @base !important;
-    }
-
     .evszEp,
     .jTEslw {
+      background: @base !important;
       svg path {
         fill: @accent-color !important;
         &[fill="#fff"],

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -690,6 +690,11 @@
       color: @text;
     }
 
+    /* Leaderboard highlighted username */
+    .bits-leaderboard-expanded-top-three-entry__marquee-username .gRUYWI {
+      color: @base !important;
+    }
+
     /* Privacy center */
 
     .evszEp {

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.4.1
+@version 1.4.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -247,14 +247,11 @@
       --color-text-button-disabled: @subtext0;
     }
 
-    &,
-    [class*="ScTokenOverrideCSSVars"] {
-      --color-text-link: @blue;
-      --color-text-link-active: @sky;
-      --color-text-link-focus: @sky;
-      --color-text-link-hover: @sky;
-      --color-text-link-visited: @lavender;
-    }
+    --color-text-link: @accent-color;
+    --color-text-link-active: @accent-color;
+    --color-text-link-focus: @accent-color;
+    --color-text-link-hover: @accent-color;
+    --color-text-link-visited: @accent-color;
 
     &,
     [class*="ScAccentRegionCssVars"] {
@@ -461,6 +458,18 @@
 
     div[data-a-target="user-card-modal"] p {
       color: @text !important;
+    }
+
+    /* Usercard mod log tabs */
+
+    .viewer-card-mod-drawer-tab--active {
+      box-shadow: 0 calc(var(--border-width-default) * -3) 0 @accent-color inset !important;
+    }
+
+    /* Usercard header */
+
+    .viewer-card-header__overlay {
+      background-color: fade(@mantle, 60%) !important;
     }
 
     /* PiP username */

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -709,36 +709,31 @@
     .privacy-center-accordion {
       border-color: @accent-color;
     }
+    //ul[role="tablist"] li {
+    //   & > div div {
+    //     background: darken(, 10%) !important;
+    //   }
+    // }
+
+    .privacy-center-home-tabs {
+      color: @base !important;
+      &[aria-selected="true"] {
+        color: darken(@accent-color, 25%) !important;
+      }
+    }
+
+    .home-page__title-container,
+    .tw-responsive-wrapper {
+      svg path {
+        &[fill="#fff"],
+        &[fill="#FFF"] {
+          fill: transparent !important;
+        }
+      }
+    }
 
     .home-page__title {
-      color: @text !important;
-    }
-  }
-}
-
-@-moz-document url("https://www.twitch.tv/privacy")
-{
-  .tw-root--theme-dark {
-    #catppuccin(@darkFlavor, @accentColor);
-  }
-  .tw-root--theme-light {
-    #catppuccin(@lightFlavor, @accentColor);
-  }
-
-  #catppuccin(@lookup, @accent) {
-    @base: @catppuccin[@@lookup][@base];
-    @accent-color: @catppuccin[@@lookup][@@accent];
-
-    #root {
-      --color-background-accent: @base;
-    }
-
-    svg path {
-      fill: @accent-color !important;
-      &[fill="#fff"],
-      &[fill="#FFF"] {
-        fill: none !important;
-      }
+      color: @base !important;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -717,9 +717,7 @@
 
     .privacy-center-home-tabs {
       color: @base !important;
-      &[aria-selected="true"] {
-        color: @surface1 !important;
-      }
+      &[aria-selected="true"],
       &:hover {
         color: @surface1 !important;
       }

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -718,7 +718,10 @@
     .privacy-center-home-tabs {
       color: @base !important;
       &[aria-selected="true"] {
-        color: darken(@accent-color, 25%) !important;
+        color: @surface1 !important;
+      }
+      &:hover {
+        color: @surface1 !important;
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Changed link color to match accent color
![links](https://github.com/user-attachments/assets/26a72998-0f51-4b1c-a741-d23aa3c74138)
- Themed usercard tabs and added transparency to header overlay
![usercard](https://github.com/user-attachments/assets/ce8f0208-25ea-4581-a78b-7c7d980eb09c)
- Fixed unthemed parts in [privacy center](https://twitch.tv/privacy)
![2024-11-13-182417_hyprshot](https://github.com/user-attachments/assets/7fa8200f-9b3c-42bd-8df6-92828a5acab8)

- Fixed unreadable username highlight in top gifters/cheerers
![2024-11-12-230223_hyprshot](https://github.com/user-attachments/assets/a77a858c-3b94-46e6-ad0c-cec2a61f9e5a) ![2024-11-12-230420_hyprshot](https://github.com/user-attachments/assets/6b8ca08f-0209-47ff-9c6c-369438d2b13b) 



## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
