### PR TITLE
fix(searxng): default domains, additional tweaks

### DIFF
--- a/styles/searxng/catppuccin.user.css
+++ b/styles/searxng/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name SearXNG Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/searxng
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/searxng
-@version 0.3.2
+@version 0.3.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/searxng/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Asearxng
 @description Soothing pastel theme for SearXNG
@@ -181,7 +181,7 @@
       stroke: @accent-color;
     }
 
-    & when not(@additions = 0) {
+    & when(@additions = 1) {
       article.result {
         background-color: var(--color-result-background);
         border-radius: 0.75em;

--- a/styles/searxng/catppuccin.user.css
+++ b/styles/searxng/catppuccin.user.css
@@ -18,7 +18,7 @@
 ==/UserStyle== */
 
 /* Domains picked from https://searx.space/. */
-@-moz-document domain("https://search.bus-hit.me/"), domain("https://search.inetol.net/")
+@-moz-document url-prefix("https://search.bus-hit.me/"), url-prefix("https://search.inetol.net/")
 {
   @media (prefers-color-scheme: light) {
     :root.theme-auto {
@@ -181,7 +181,7 @@
       stroke: @accent-color;
     }
 
-    & when(@additions) {
+    & when not(@additions = 0) {
       article.result {
         background-color: var(--color-result-background);
         border-radius: 0.75em;

--- a/styles/searxng/catppuccin.user.css
+++ b/styles/searxng/catppuccin.user.css
@@ -18,7 +18,7 @@
 ==/UserStyle== */
 
 /* Domains picked from https://searx.space/. */
-@-moz-document url-prefix("https://search.bus-hit.me/"), url-prefix("https://search.inetol.net/")
+@-moz-document domain("search.bus-hit.me"), domain("search.inetol.net")
 {
   @media (prefers-color-scheme: light) {
     :root.theme-auto {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Fixes the default domains not being detected, since `domain()` should not have `https://` in it.
- Fixes additional tweaks not working by explicitly specifying `when (@additions = 1)`

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.