### PR TITLE
fix(hoppscotch): text selection color

### DIFF
--- a/styles/hoppscotch/catppuccin.user.css
+++ b/styles/hoppscotch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hoppscotch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hoppscotch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hoppscotch
-@version 1.0.1
+@version 1.0.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hoppscotch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahoppscotch
 @description Soothing pastel theme for Hoppscotch
@@ -62,7 +62,8 @@
     color-scheme: if(@lookup = latte, light, dark);
 
     ::selection {
-      background-color: fade(@accent-color, 30%);
+      background-color: fade(@accent-color, 30%) !important;
+      color: @text !important;
     }
 
     input,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #852 

Fixes the colors of text selection:

## Before
![Screenshot 2024-11-13 at 21-38-14 GraphQL • Hoppscotch](https://github.com/user-attachments/assets/2d4f870c-7810-4da3-b24d-1c2042211ae0)

## After
![Screenshot 2024-11-13 at 21-38-42 GraphQL • Hoppscotch](https://github.com/user-attachments/assets/43554872-488f-4b62-81e1-48bc7978dacf)


<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
