### PR TITLE
feat(pronouns.cc): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -806,6 +806,14 @@ userstyles:
     readme:
       app-link: https://porkbun.com
     current-maintainers: [*uncenter]
+  pronouns.cc:
+    name: pronouns.cc
+    categories: [social_networking]
+    color: mauve
+    readme:
+      app-link: "https://pronouns.cc/"
+    current-maintainers: [*comfysage]
+    past-maintainers: [*neongamerbot]
   pronouns.page:
     name: Pronouns.page
     categories: [social_networking]

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -236,13 +236,6 @@
       @svg: escape('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="@{surface1}"><path d="M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414"/></svg>');
       --bs-btn-close-bg: url("data:image/svg+xml,@{svg}");
       --bs-btn-close-opacity: 1.0;
-      --bs-btn-close-hover-opacity: .75;
-      --bs-btn-close-focus-shadow: 0 0 0 .25rem rgba(13, 110, 253, .25);
-      --bs-btn-close-focus-opacity: 1;
-      --bs-btn-close-disabled-opacity: .25;
-      --bs-btn-close-white-filter: none;
-      color: var(--bs-btn-close-color);
-      opacity: var(--bs-btn-close-opacity);
     }
     .navbar-toggler-icon {
       @svg: escape('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path stroke="@{surface1}" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M4 7h22M4 15h22M4 23h22"/></svg>');

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -189,11 +189,11 @@
       --bs-btn-disabled-border-color: @border;
     }
     #coloredButton(@color) {
-    	#colorizedButton(@crust, @color, @color, @hv-color: @crust, lighten(@color, 5%));
+      #colorizedButton(@crust, @color, @color, @hv-color: @crust, lighten(@color, 10%));
     }
     //buttons
     .btn-primary {
-      #colorizedButton(@base, @accent-color, @hv-bg: lighten(@accent-color, 5%));
+      #colorizedButton(@base, @accent-color, @hv-bg: lighten(@accent-color, 10%));
     }
     .btn-secondary {
       #colorizedButton(@text, @surface0, @hv-bg: @surface1);

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -94,6 +94,10 @@
       --bs-modal-header-border-color: var(--bs-border-color);
       --bs-modal-footer-border-color: var(--bs-border-color);
     }
+    .dropdown-menu {
+      --bs-dropdown-link-active-color: @crust;
+      --bs-dropdown-link-active-bg: @accent-color;
+    }
     .toast {
       --bs-toast-color: @text;
       background-color: darken(@surface0, 5%);

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -162,7 +162,7 @@
     }
     // navbar
     .navbar {
-      --bs-navbar-color: @text;
+      --bs-navbar-color: @subtext0;
       --bs-navbar-hover-color: @subtext0;
       --bs-navbar-disabled-color: @subtext1;
       --bs-navbar-active-color: @text !important;

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -213,6 +213,18 @@
     .btn-danger {
       #coloredButton(@red);
     }
+    .form-control {
+      &::-webkit-file-upload-button,
+      &::file-selector-button {
+        background-color: @base;
+      }
+	    &:hover:not(:disabled):not([readonly]) {
+        &::-webkit-file-upload-button,
+        &::file-selector-button {
+          background-color: @surface0;
+        }
+      }
+    }
   }
 }
 

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -1,0 +1,229 @@
+/* ==UserStyle==
+@name pronouns.cc Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/pronouns.cc
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pronouns.cc
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pronouns.cc/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apronouns.cc
+@description Soothing pastel theme for pronouns.cc
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain('pronouns.cc') {
+  :root[data-bs-theme="dark"] {
+    #catppuccin(@darkFlavor, @accentColor);
+    .bg-dark {
+      --bs-bg-opacity: 1;
+      background-color: rgba(
+        var(--bs-lightt-rgb),
+        var(--bs-bg-opacity)
+      ) !important;
+    }
+  }
+  :root[data-bs-theme="light"] {
+    #catppuccin(@lightFlavor, @accentColor);
+    .bg-light {
+      --bs-bg-opacity: 1;
+      background-color: rgba(
+        var(--bs-darkk-rgb),
+        var(--bs-bg-opacity)
+      ) !important;
+    }
+
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+    .form-floating input::placeholder {
+      color: transparent !important;
+    }
+    .form-control:focus {
+      border-color: @accent-color;
+      box-shadow: 0 0 0 .25rem fade(@accent-color, 25%);
+    }
+    --bs-border-color: @surface1;
+    a {
+      --bs-link-color-rgb: #rgbify(@blue) [] !important;
+    }
+    .modal {
+      --bs-modal-bg: @crust;
+      --bs-modal-border-color: var(--bs-border-color-translucent);
+      --bs-modal-header-border-color: var(--bs-border-color);
+      --bs-modal-footer-border-color: var(--bs-border-color);
+    }
+    .toast {
+      --bs-toast-color: @text;
+      background-color: darken(@surface0, 5%);
+    }
+    .toast-header {
+      color: @text;
+      background-color: @surface0;
+    }
+    .toast-body {
+      color: @text;
+    }
+    --bs-badge-color: @text;
+    --bs-body-color: @text;
+    --bs-body-color-rgb: #rgbify(@text) [];
+    --bs-body-bg: @crust;
+    --bs-darkk-rgb: #rgbify(@base);
+    --bs-lightt-rgb: #rgbify(@base);
+    --bs-emphasis-color: @accent-color;
+    --bs-emphasis-color-rgb: #rgbify(@accent-color) [];
+    --bs-secondary-color: @subtext0;
+    --bs-secondary-color-rgb: @subtext0;
+    --bs-secondary-bg: @base;
+    --bs-secondary-bg-rgb: #rgbify(@base) [];
+    --bs-tertiary-color: @subtext1;
+    --bs-tertiary-color-rgb: @subtext1;
+    --bs-tertiary-bg: @surface0;
+    --bs-tertiary-bg-rgb: #rgbify(@surface0) [];
+    --bs-primary-text-emphasis: @accent-color;
+    --bs-secondary-text-emphasis: @subtext1;
+    --bs-success-text-emphasis: @green;
+    --bs-info-text-emphasis: @teal;
+    --bs-warning-text-emphasis: @yellow;
+    --bs-danger-text-emphasis: @red;
+    --bs-light-text-emphasis: @subtext0;
+    --bs-primary-bg-subtle: @mantle;
+    --bs-secondary-bg-subtle: @base;
+    --bs-primary-border-subtle: @blue;
+    --bs-secondary-border-subtle: @overlay0;
+    --bs-success-border-subtle: @green;
+    --bs-info-border-subtle: @teal;
+    --bs-warning-border-subtle: @yellow;
+    --bs-danger-border-subtle: @red;
+    --bs-light-border-subtle: @overlay1;
+    --bs-dark-border-subtle: @surface1;
+    --bs-heading-color: inherit;
+    --bs-link-color: @blue;
+    --bs-link-color-rgb: #rgbify(@blue) [];
+    --bs-link-hover-color: @sky;
+
+    --bs-code-color: @pink;
+    --bs-highlight-color: @rosewater;
+    .list-group {
+      --bs-list-group-color: var(--bs-body-color);
+      --bs-list-group-bg: var(--bs-body-bg);
+      --bs-list-group-action-color: var(--bs-secondary-color);
+      --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+      --bs-list-group-action-hover-bg: var(--bs-tertiary-bg);
+      --bs-list-group-action-active-color: var(--bs-body-color);
+      --bs-list-group-action-active-bg: var(--bs-secondary-bg);
+      --bs-list-group-disabled-color: var(--bs-secondary-color);
+      --bs-list-group-disabled-bg: var(--bs-body-bg);
+      --bs-list-group-active-color: @base;
+      --bs-list-group-active-bg: @accent-color;
+      --bs-list-group-active-border-color: @accent-color;
+      border-radius: var(--bs-list-group-border-radius);
+    }
+    // navbar
+    .navbar {
+      --bs-navbar-color: @text;
+      --bs-navbar-hover-color: @subtext0;
+      --bs-navbar-disabled-color: @subtext1;
+      --bs-navbar-active-color: @text !important;
+      --bs-navbar-brand-color: @text !important;
+      --bs-navbar-brand-hover-color: @text !important;
+      --bs-navbar-toggler-border-color: @surface0;
+    }
+    #coloredButton(@color, @bg) {
+      --bs-btn-color: @color;
+      --bs-btn-bg: @bg;
+      --bs-btn-border-color: @bg;
+      --bs-btn-hover-color: @color;
+      --bs-btn-hover-bg: darken(@bg, 30%);
+      --bs-btn-hover-border-color: darken(@bg, 30%);
+      --bs-btn-focus-shadow-rgb: #rgbify(@bg) [];
+      --bs-btn-active-color: @color;
+      --bs-btn-active-bg: darken(@bg, 30%);
+      --bs-btn-active-border-color: darken(@bg, 30%);
+      --bs-btn-disabled-color: @color;
+      --bs-btn-disabled-bg: @bg;
+      --bs-btn-disabled-border-color: @bg;
+    }
+    //buttons
+    .btn-primary {
+      #coloredButton(@base, @accent-color);
+    }
+    .btn-outline-secondary {
+      #coloredButton(@base, @surface0);
+      --bs-btn-hover-bg: @overlay1 !important;
+      --bs-btn-color: @subtext0 !important;
+    }
+    .btn-secondary {
+      #coloredButton(@text, @surface0);
+    }
+    .btn-success {
+      #coloredButton(@crust,@green);
+    }
+    .btn-info {
+      #coloredButton(@crust,@teal);
+    }
+    .btn-warning {
+      #coloredButton(@crust,@yellow);
+    }
+    .btn-danger {
+      #coloredButton(@crust,@red);
+    }
+  }
+}
+
+#rgbify(@color) {
+  @rgb-raw: red(@color), green(@color), blue(@color);
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}
+
+// vim:ft=less

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -233,7 +233,7 @@
     .btn-close-white,
     .btn-close {
       --bs-btn-close-color: @surface0;
-      @svg: escape("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='@{surface1}'><path d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/></svg>");
+      @svg: escape('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="@{surface1}"><path d="M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414"/></svg>');
       --bs-btn-close-bg: url("data:image/svg+xml,@{svg}");
       --bs-btn-close-opacity: 1.0;
       --bs-btn-close-hover-opacity: .75;
@@ -245,7 +245,7 @@
       opacity: var(--bs-btn-close-opacity);
     }
     .navbar-toggler-icon {
-      @svg: escape("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='@{surface1}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>");
+      @svg: escape('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path stroke="@{surface1}" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M4 7h22M4 15h22M4 23h22"/></svg>');
       --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,@{svg}");
     }
   }

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -218,7 +218,7 @@
       &::file-selector-button {
         background-color: @base;
       }
-	    &:hover:not(:disabled):not([readonly]) {
+      &:hover:not(:disabled):not([readonly]) {
         &::-webkit-file-upload-button,
         &::file-selector-button {
           background-color: @surface0;

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -218,7 +218,7 @@
       &::file-selector-button {
         background-color: @base;
       }
-      &:hover:not(:disabled):not([readonly]) {
+      &:hover:not(:disabled, [readonly]) {
         &::-webkit-file-upload-button,
         &::file-selector-button {
           background-color: @surface0;

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -244,6 +244,10 @@
       color: var(--bs-btn-close-color);
       opacity: var(--bs-btn-close-opacity);
     }
+    .navbar-toggler-icon {
+      @svg: escape("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='@{surface1}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>");
+      --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,@{svg}");
+    }
   }
 }
 

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -170,44 +170,48 @@
       --bs-navbar-brand-hover-color: @text !important;
       --bs-navbar-toggler-border-color: @surface0;
     }
-    #coloredButton(@color, @bg) {
+    #colorizedButton(@color, @bg, @border: @bg, @hv-color: @color, @hv-bg: darken(@bg, 5%), @hv-border: @hv-bg) {
       --bs-btn-color: @color;
       --bs-btn-bg: @bg;
-      --bs-btn-border-color: @bg;
-      --bs-btn-hover-color: @color;
-      --bs-btn-hover-bg: darken(@bg, 30%);
-      --bs-btn-hover-border-color: darken(@bg, 30%);
+      --bs-btn-border-color: @border;
+
+      --bs-btn-hover-color: @hv-color;
+      --bs-btn-hover-bg: @hv-bg;
+      --bs-btn-hover-border-color: @hv-border;
+
+      --bs-btn-active-color: @hv-color;
+      --bs-btn-active-bg: @hv-bg;
+      --bs-btn-active-border-color: @hv-border;
+
       --bs-btn-focus-shadow-rgb: #rgbify(@bg) [];
-      --bs-btn-active-color: @color;
-      --bs-btn-active-bg: darken(@bg, 30%);
-      --bs-btn-active-border-color: darken(@bg, 30%);
       --bs-btn-disabled-color: @color;
       --bs-btn-disabled-bg: @bg;
-      --bs-btn-disabled-border-color: @bg;
+      --bs-btn-disabled-border-color: @border;
+    }
+    #coloredButton(@color) {
+    	#colorizedButton(@crust, @color, @color, @hv-color: @crust, lighten(@color, 5%));
     }
     //buttons
     .btn-primary {
-      #coloredButton(@base, @accent-color);
-    }
-    .btn-outline-secondary {
-      #coloredButton(@base, @surface0);
-      --bs-btn-hover-bg: @overlay1 !important;
-      --bs-btn-color: @subtext0 !important;
+      #colorizedButton(@base, @accent-color, @hv-bg: lighten(@accent-color, 5%));
     }
     .btn-secondary {
-      #coloredButton(@text, @surface0);
+      #colorizedButton(@text, @surface0, @hv-bg: @surface1);
+    }
+    .btn-outline-secondary {
+      #colorizedButton(@surface1, transparent, @surface1, @subtext0, @surface1);
     }
     .btn-success {
-      #coloredButton(@crust,@green);
+      #coloredButton(@green);
     }
     .btn-info {
-      #coloredButton(@crust,@teal);
+      #coloredButton(@teal);
     }
     .btn-warning {
-      #coloredButton(@crust,@yellow);
+      #coloredButton(@yellow);
     }
     .btn-danger {
-      #coloredButton(@crust,@red);
+      #coloredButton(@red);
     }
   }
 }

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -87,9 +87,6 @@
       box-shadow: 0 0 0 .25rem fade(@accent-color, 25%);
     }
     --bs-border-color: @surface1;
-    a {
-      --bs-link-color-rgb: #rgbify(@blue) [] !important;
-    }
     .modal {
       --bs-modal-bg: @crust;
       --bs-modal-border-color: var(--bs-border-color-translucent);
@@ -141,9 +138,10 @@
     --bs-light-border-subtle: @overlay1;
     --bs-dark-border-subtle: @surface1;
     --bs-heading-color: inherit;
-    --bs-link-color: @blue;
-    --bs-link-color-rgb: #rgbify(@blue) [];
-    --bs-link-hover-color: @sky;
+    --bs-link-color: @accent-color;
+    --bs-link-color-rgb: #rgbify(@accent-color) [];
+    --bs-link-hover-color: @accent-color;
+    --bs-link-hover-color-rgb: #rgbify(@accent-color) [];
 
     --bs-code-color: @pink;
     --bs-highlight-color: @rosewater;

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -87,6 +87,7 @@
       box-shadow: 0 0 0 .25rem fade(@accent-color, 25%);
     }
     --bs-border-color: @surface1;
+    --bs-border-color-translucent: @surface0;
     .modal {
       --bs-modal-bg: @crust;
       --bs-modal-border-color: var(--bs-border-color-translucent);

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -230,6 +230,20 @@
         }
       }
     }
+    .btn-close-white,
+    .btn-close {
+      --bs-btn-close-color: @surface0;
+      @svg: escape("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='@{surface1}'><path d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/></svg>");
+      --bs-btn-close-bg: url("data:image/svg+xml,@{svg}");
+      --bs-btn-close-opacity: 1.0;
+      --bs-btn-close-hover-opacity: .75;
+      --bs-btn-close-focus-shadow: 0 0 0 .25rem rgba(13, 110, 253, .25);
+      --bs-btn-close-focus-opacity: 1;
+      --bs-btn-close-disabled-opacity: .25;
+      --bs-btn-close-white-filter: none;
+      color: var(--bs-btn-close-color);
+      opacity: var(--bs-btn-close-opacity);
+    }
   }
 }
 

--- a/styles/pronouns.cc/preview.webp
+++ b/styles/pronouns.cc/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522b584f073a710cab61d48347a9eeeef62ece53d26dada020d2eb5ff716a6e3
+size 110470


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [pronouns.cc](https://pronouns.cc) 🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

![preview-image](https://github.com/user-attachments/assets/bb1b1abe-d9a6-4010-92eb-4bc31d9bb822)

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
