### PR TITLE
fix(twitch): dashboard, channel points and shield mode fixes

### DIFF
--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -239,7 +239,7 @@
       --color-background-tooltip: @text !important;
       --color-hinted-grey-2: @surface0;
       --color-hinted-grey-15: @text;
-      --color-background-overlay-alt: @mantle;
+      --color-background-overlay-alt: fade(@mantle, 60%);
       --color-background-button-overlay-primary-hover: @subtext1;
       --color-background-button-overlay-text-hover: @crust;
       --color-border-overlay: @surface0;
@@ -709,11 +709,6 @@
     .privacy-center-accordion {
       border-color: @accent-color;
     }
-    //ul[role="tablist"] li {
-    //   & > div div {
-    //     background: darken(, 10%) !important;
-    //   }
-    // }
 
     .privacy-center-home-tabs {
       color: @base !important;
@@ -736,22 +731,67 @@
     .home-page__title {
       color: @base !important;
     }
+
+    .tw-balloon {
+      .tw-callout-message__title {
+        color: var(--color-text-variable) !important;
+      }
+
+      .tw-callout__close div.tw-svg {
+        fill: var(--color-text-variable) !important;
+      }
+    }
+
+    .analytics-tip-card--blue {
+      color: @base !important;
+      button {
+        color: @base !important;
+      }
+    }
+
+    /* Shield mode tray */
+
+    .shield-mode-icon svg path {
+      fill: @peach;
+    }
+
+    .tray-highlight,
+    .chat-input-highlight,
+    .shield-mode-shortcut__btn {
+      border-color: @peach !important;
+    }
+
+    /* Shield mode mod view button */
+
+    .shield-mode-shortcut__inner,
+    .shield-mode-view-toggle--active {
+      color: @base;
+      background: @peach;
+    }
+
+    /* Channel points reward cost */
+
+    .reward-icon__cost {
+      color: @text !important;
+      background: fade(@mantle, 60%) !important;
+    }
   }
 }
 
 @-moz-document domain("dashboard.twitch.tv") {
   .tw-root--theme-dark {
-    #catppuccin(@darkFlavor);
+    #catppuccin(@darkFlavor, @accentColor);
   }
   .tw-root--theme-light {
-    #catppuccin(@lightFlavor);
+    #catppuccin(@lightFlavor, @accentColor);
   }
 
-  #catppuccin(@lookup) {
+  #catppuccin(@lookup, @accent) {
     @text: @catppuccin[@@lookup][@text];
     @base: @catppuccin[@@lookup][@base];
     @mantle: @catppuccin[@@lookup][@mantle];
     @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
 
     .simplebar-content {
       background-color: @mantle;
@@ -776,6 +816,38 @@
     .video-card-thumbnail__video-state-overlay {
       color: @text !important;
       background: fade(@mantle, 80%) !important;
+    }
+
+    /* Twitch alerts */
+
+    .alerts-home-main-wrapper {
+      color: @text !important;
+    }
+
+    .alerts-home-scrollable-area {
+      color: @text !important;
+      .simplebar-content {
+        background: @mantle !important;
+      }
+      .alert-set-card {
+        background: @crust !important;
+      }
+    }
+
+    /* Analytics */
+    .top-stats-tab--active {
+      color: @accent-color !important;
+      box-shadow: 0 calc(var(--border-width-default) * -3) 0 @accent-color inset;
+      .top-stats-tab__title {
+        color: @accent-color !important;
+      }
+    }
+
+    .top-stats-tab:hover {
+      box-shadow:
+        inset 0 -2px 0 @accent-color,
+        0 4px 6px -4px @accent-color;
+      background: @base !important;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.css
+++ b/styles/twitch/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Twitch Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/twitch
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/twitch
-@version 1.4.2
+@version 1.4.3
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/twitch/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atwitch
 @description Soothing pastel theme for Twitch
@@ -699,6 +699,10 @@
       }
     }
 
+    .channel-leaderboard-header-rotating__expand-grabber {
+      background: @surface0 !important;
+    }
+
     /* Privacy center */
 
     .privacy-center-root__number-item {
@@ -742,7 +746,8 @@
       }
     }
 
-    .analytics-tip-card--blue {
+    .analytics-tip-card--blue,
+    .analytics-tip-card--red {
       color: @base !important;
       button {
         color: @base !important;
@@ -848,6 +853,16 @@
         inset 0 -2px 0 @accent-color,
         0 4px 6px -4px @accent-color;
       background: @base !important;
+    }
+
+    /* Stream Manager */
+
+    .stream-manager--page-view {
+      .mosaic-tile .simplebar-content,
+      .stream-manager-edit-mode-item,
+      .stream-manager-edit-mode-stat-item {
+        background: @mantle !important;
+      }
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Fixed front page stream thumbnails
- Made channel points rewards cost more readable
![2024-11-14-193737_hyprshot](https://github.com/user-attachments/assets/7ebeb994-e98c-45a3-97b1-d2aea0d50d0a) ![2024-11-14-193710_hyprshot](https://github.com/user-attachments/assets/23bee367-fba2-4b18-969b-664a9428296a)
- Themed shield mode tray highlight and icon
![2024-11-14-194048_hyprshot](https://github.com/user-attachments/assets/c9825a18-351d-4c7b-93ef-b2cb71e8f9c4) ![2024-11-14-195333_hyprshot](https://github.com/user-attachments/assets/519e8eb2-a883-4eb3-8993-1423a9c297c9)
- Fixed wrong balloon title color
![2024-11-14-201232_hyprshot](https://github.com/user-attachments/assets/6b233cfe-2d51-4bbe-a085-c5be5e11475f) ![2024-11-14-201223_hyprshot](https://github.com/user-attachments/assets/51023c2c-954e-4fcf-b83e-8c0bef15be4b)
- Fixed wrong active color in [analytics](https://dashboard.twitch.tv/analytics)
![2024-11-14-203751_hyprshot](https://github.com/user-attachments/assets/a628af9c-929c-44ee-84bc-96969202663f) ![2024-11-14-203758_hyprshot](https://github.com/user-attachments/assets/43b60238-d6ed-4bf2-8af4-0d3d6fe337e5)
- Fixed [stream alerts page](https://dashboard.twitch.tv/stream-alerts) text color
- Changed [stream manager](https://dashboard.twitch.tv/stream-manager) background color to mantle

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
