### PR TITLE
feat(treewide): add require-color-op-func-percentage stylelint rule

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -5,10 +5,14 @@
  */
 export default {
   extends: "stylelint-config-standard",
-  plugins: ["./scripts/lint/stylelint-custom/optimized-svgs.js"],
+  plugins: [
+    "./scripts/lint/stylelint-custom/optimized-svgs.js",
+    "./scripts/lint/stylelint-custom/color-op-func-percentage.js",
+  ],
   customSyntax: "postcss-less",
   rules: {
     "catppuccin/optimized-svgs": true,
+    "catppuccin/require-color-op-func-percentage": true,
 
     "selector-class-pattern": null,
     "custom-property-pattern": null,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "[less]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "[typescript]": {
+  "[typescript][javascript]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -35,7 +35,7 @@
   },
   "nodeModulesDir": true,
   "fmt": {
-    "include": ["scripts/**/*.ts"]
+    "include": ["scripts/**/*.ts", "scripts/**/*.js"]
   },
   "lint": {
     "rules": {

--- a/scripts/lint/stylelint-custom/color-op-func-percentage.js
+++ b/scripts/lint/stylelint-custom/color-op-func-percentage.js
@@ -54,8 +54,9 @@ const ruleFunction = (primary, _secondary, context) => {
           func.nodes.length === numArgLoc + 1 &&
           !func.nodes[numArgLoc].value.endsWith("%")
         ) {
-          const value = func.nodes[numArgLoc].value;
+          let value = func.nodes[numArgLoc].value;
           if (!/^[\d.]+$/.test(value)) return;
+          if (value.includes(".")) value = Number.parseFloat(value) * 100;
 
           if (context.fix) {
             func.nodes[numArgLoc].value = value + "%";

--- a/scripts/lint/stylelint-custom/color-op-func-percentage.js
+++ b/scripts/lint/stylelint-custom/color-op-func-percentage.js
@@ -57,13 +57,8 @@ const ruleFunction = (primary, _secondary, context) => {
           const value = func.nodes[numArgLoc].value;
           if (!/^[\d.]+$/.test(value)) return;
 
-          let num = value;
-          if (value.includes(".")) {
-            num = Number.parseFloat(value);
-          }
-
           if (context.fix) {
-            func.nodes[numArgLoc].value = num + "%";
+            func.nodes[numArgLoc].value = value + "%";
             decl.value = parsed.toString();
           } else {
             report({

--- a/scripts/lint/stylelint-custom/color-op-func-percentage.js
+++ b/scripts/lint/stylelint-custom/color-op-func-percentage.js
@@ -1,0 +1,86 @@
+import stylelint from "stylelint";
+import valueParser from "postcss-value-parser";
+
+const {
+  createPlugin,
+  utils: { report, ruleMessages, validateOptions },
+} = stylelint;
+
+const ruleName = "catppuccin/require-color-op-func-percentage";
+
+const meta = {
+  fixable: true,
+};
+
+const messages = ruleMessages(ruleName, {
+  rejected: () =>
+    `Color operation function amount arguments must be percentages`,
+});
+
+/** @type {import('npm:stylelint').Rule} */
+const ruleFunction = (primary, _secondary, context) => {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [true],
+    });
+
+    if (!validOptions) return;
+
+    root.walkDecls((decl) => {
+      const parsed = valueParser(decl.value);
+
+      if (
+        parsed.nodes.length === 1 &&
+        parsed.nodes[0].type === "function" &&
+        [
+          "saturate",
+          "desaturate",
+          "lighten",
+          "darken",
+          "fadein",
+          "fadeout",
+          "fade",
+          "mix",
+          "tint",
+          "shade",
+        ].includes(parsed.nodes[0].value)
+      ) {
+        const func = parsed.nodes[0];
+
+        const numArgLoc = parsed.nodes[0].value === "mix" ? 4 : 2;
+
+        if (
+          func.nodes.length === numArgLoc + 1 &&
+          !func.nodes[numArgLoc].value.endsWith("%")
+        ) {
+          const value = func.nodes[numArgLoc].value;
+          if (!/^[\d.]+$/.test(value)) return;
+
+          let num = value;
+          if (value.includes(".")) {
+            num = Number.parseFloat(value) * 100;
+          }
+
+          if (context.fix) {
+            func.nodes[numArgLoc].value = num + "%";
+            decl.value = parsed.toString();
+          } else {
+            report({
+              result,
+              ruleName,
+              message: messages.rejected(),
+              node: decl,
+            });
+          }
+        }
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);

--- a/scripts/lint/stylelint-custom/color-op-func-percentage.js
+++ b/scripts/lint/stylelint-custom/color-op-func-percentage.js
@@ -59,7 +59,10 @@ const ruleFunction = (primary, _secondary, context) => {
 
           let num = value;
           if (value.includes(".")) {
-            num = Number.parseFloat(value) * 100;
+            num = Number.parseFloat(value);
+            if (num < 0) {
+              num *= 100;
+            }
           }
 
           if (context.fix) {

--- a/scripts/lint/stylelint-custom/color-op-func-percentage.js
+++ b/scripts/lint/stylelint-custom/color-op-func-percentage.js
@@ -60,9 +60,6 @@ const ruleFunction = (primary, _secondary, context) => {
           let num = value;
           if (value.includes(".")) {
             num = Number.parseFloat(value);
-            if (num < 0) {
-              num *= 100;
-            }
           }
 
           if (context.fix) {

--- a/scripts/lint/stylelint-custom/color-op-func-percentage.js
+++ b/scripts/lint/stylelint-custom/color-op-func-percentage.js
@@ -56,7 +56,10 @@ const ruleFunction = (primary, _secondary, context) => {
         ) {
           let value = func.nodes[numArgLoc].value;
           if (!/^[\d.]+$/.test(value)) return;
-          if (value.includes(".")) value = Number.parseFloat(value) * 100;
+          if (value.includes(".")) {
+            value = Number.parseFloat(value);
+            if (value < 1) value *= 100;
+          }
 
           if (context.fix) {
             func.nodes[numArgLoc].value = value + "%";

--- a/styles/advent-of-code/catppuccin.user.css
+++ b/styles/advent-of-code/catppuccin.user.css
@@ -175,13 +175,13 @@
             color: @subtext1;
           }
           .calendar-color-g3 {
-            color: darken(@green, 3);
+            color: darken(@green, 3%);
           }
           .calendar-color-g2 {
             color: @green;
           }
           .calendar-color-g4 {
-            color: darken(@green, 3.5);
+            color: darken(@green, 3.5%);
           }
           .calendar-color-u {
             color: @sky;
@@ -190,10 +190,10 @@
             color: @subtext0;
           }
           .calendar-color-g1 {
-            color: darken(@green, 2.5);
+            color: darken(@green, 2.5%);
           }
           .calendar-color-g0 {
-            color: darken(@green, 2);
+            color: darken(@green, 2%);
           }
           .calendar-color-l {
             color: @red;

--- a/styles/anilist/catppuccin.user.css
+++ b/styles/anilist/catppuccin.user.css
@@ -206,7 +206,7 @@
       background-color: @mantle;
     }
     .nav-unscoped.transparent when not (@lookup =latte) {
-      background-color: fade(@mantle, 50);
+      background-color: fade(@mantle, 50%);
     }
     .nav-unscoped.transparent:hover when not (@lookup =latte) {
       background-color: @mantle;

--- a/styles/canvas-lms/catppuccin.user.css
+++ b/styles/canvas-lms/catppuccin.user.css
@@ -97,7 +97,7 @@
 
     a,
     .page-title {
-      color: fadeout(@text, 0.8) !important;
+      color: fadeout(@text, 80%) !important;
     }
 
     * {
@@ -120,7 +120,7 @@
 
     .ic-app-header__menu-list-item.ic-app-header__menu-list-item--active
       .ic-app-header__menu-list-link {
-      background-color: fadeout(@crust, 0.8);
+      background-color: fadeout(@crust, 80%);
     }
 
     body {
@@ -146,9 +146,9 @@
 
     :root {
       --ic-brand-global-nav-avatar-border: @accent-color;
-      --ic-brand-font-color-dark: fadeout(@accent-color, 0.8);
+      --ic-brand-font-color-dark: fadeout(@accent-color, 80%);
       --ic-brand-primary: @accent-color;
-      --ic-brand-global-nav-ic-icon-svg-fill: fadeout(@accent-color, 0.5);
+      --ic-brand-global-nav-ic-icon-svg-fill: fadeout(@accent-color, 50%);
       --eMdva-color: @base !important;
       --ccWIh-color: @crust;
     }
@@ -156,7 +156,7 @@
     .menu-item-icon-container,
     .menu-item__badge,
     .nav-badge {
-      color: fadeout(@text, 0.8);
+      color: fadeout(@text, 80%);
     }
 
     .list-view a.active {

--- a/styles/formative/catppuccin.user.css
+++ b/styles/formative/catppuccin.user.css
@@ -369,16 +369,16 @@
     }
     .FormativeCardScore__PercentageSpan-sc-p5mc30-1 {
       &[style*="rgba(32, 213, 171, 0.2)"] {
-        background: fade(@green, 50) !important;
+        background: fade(@green, 50%) !important;
       }
       &[style*="rgba(255, 222, 51, 0.2)"] {
-        background: fade(@yellow, 50) !important;
+        background: fade(@yellow, 50%) !important;
       }
       &[style*="rgba(0, 165, 251, 0.2)"] {
-        background: fade(@blue, 50) !important;
+        background: fade(@blue, 50%) !important;
       }
       &[style*="rgba(255, 76, 77, 0.2)"] {
-        background: fade(@red, 50) !important;
+        background: fade(@red, 50%) !important;
       }
     }
 
@@ -483,7 +483,7 @@
       }
     }
     .Modal__Overlay-sc-1uf7odj-0 {
-      background: fade(@crust, 80);
+      background: fade(@crust, 80%);
     }
     .Modal__Content-sc-1uf7odj-1 {
       background: @base;
@@ -519,7 +519,7 @@
       }
     }
     .ReactModal__Overlay {
-      background: fade(@crust, 80);
+      background: fade(@crust, 80%);
       .ReactModal__ActualContent {
         background: @base !important;
         .ModalBody-sc-1lg094f-0 > * {
@@ -1064,7 +1064,7 @@
       }
       math-field {
         --caret-color: @accent-color;
-        --selection-background-color: fade(@accent-color, 50);
+        --selection-background-color: fade(@accent-color, 50%);
         --selection-color: @text;
         --correct-color: @text;
         --incorrect-color: @red;
@@ -1495,7 +1495,7 @@
         .MatchingSessionSummary__SessionDiv-sc-d3unim-13 {
           border-color: @overlay0;
           &.highlight {
-            background: fade(@yellow, 25);
+            background: fade(@yellow, 25%);
           }
         }
       }

--- a/styles/hoppscotch/catppuccin.user.css
+++ b/styles/hoppscotch/catppuccin.user.css
@@ -86,7 +86,7 @@
     --tooltip-color: @text;
     --popover-color: @crust;
     --editor-theme: "vscode-esque";
-    --editor-type-color: fade(@mauve, 0.9);
+    --editor-type-color: fade(@mauve, 90%);
     --editor-name-color: @blue;
     --editor-operator-color: @mauve;
     --editor-invalid-color: @maroon;
@@ -94,7 +94,7 @@
     --editor-meta-color: @overlay0;
     --editor-variable-color: @green;
     --editor-link-color: @sapphire;
-    --editor-constant-color: fade(@lavender, 1.2);
+    --editor-constant-color: fade(@lavender, 1.2%);
     --editor-keyword-color: @red;
     --accent-color: @accent-color;
     --accent-light-color: fade(@accent-color, @accent-color-light-alpha);

--- a/styles/ichi.moe/catppuccin.user.css
+++ b/styles/ichi.moe/catppuccin.user.css
@@ -86,11 +86,11 @@
     }
 
     .panel-error {
-      background-color: fadeout(@red, 0.2);
+      background-color: fadeout(@red, 20%);
     }
 
     .highlight {
-      background-color: fadeout(@yellow, 0.2);
+      background-color: fadeout(@yellow, 20%);
     }
 
     .gloss {
@@ -165,16 +165,16 @@
 
     .reading-table tr:nth-of-type(2n) {
       & when (@lookup ="latte") {
-        background: fadeout(@surface0, 0.5);
+        background: fadeout(@surface0, 50%);
       }
-      background: fadeout(@surface1, 0.5);
+      background: fadeout(@surface1, 50%);
     }
 
     table.kanji-match tr:nth-of-type(2n) {
       & when (@lookup ="latte") {
-        background: fadeout(@surface0, 0.5);
+        background: fadeout(@surface0, 50%);
       }
-      background: fadeout(@surface1, 0.5);
+      background: fadeout(@surface1, 50%);
     }
 
     .kanji-big a {
@@ -345,9 +345,9 @@
     table tr.alt,
     table tr:nth-of-type(2n) {
       & when (@lookup ="latte") {
-        background: fadeout(@surface0, 0.5);
+        background: fadeout(@surface0, 50%);
       }
-      background: fadeout(@surface1, 0.5);
+      background: fadeout(@surface1, 50%);
     }
 
     .reading-table tr ~ tr > td {

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -80,7 +80,7 @@
       --ig-primary-icon: #rgbify(@text) [];
       --web-always-white: #rgbify(@light-color) [];
       --always-white: #rgbify(@light-color) [];
-      --overlay-alpha-80: fadeout(@dark-color, 50);
+      --overlay-alpha-80: fadeout(@dark-color, 50%);
       --grey-9: #rgbify(@crust) [];
       --ig-primary-background: #rgbify(@base) [];
       --ig-secondary-background: #rgbify(@surface0) [];
@@ -89,11 +89,11 @@
       --ig-elevated-background: #rgbify(@crust) [];
       --ig-elevated-highlight-background: #rgbify(@surface0) [];
       --ig-hover-overlay: #rgbify(@text) [], 0.1;
-      --hover-overlay: fadeout(@surface0, 80);
+      --hover-overlay: fadeout(@surface0, 80%);
       --ig-text-on-color: #rgbify(@crust) [];
       --ig-badge: #rgbify(@accent-color) [];
       --ig-primary-button: #rgbify(@accent-color) [];
-      --ig-primary-button-hover: fadeout(@accent-color, 20);
+      --ig-primary-button-hover: fadeout(@accent-color, 20%);
       --ig-secondary-button-background: #rgbify(@surface0) [];
       --ig-secondary-button-hover: #rgbify(@surface1) [];
       --ig-secondary-button: #rgbify(@text) [];

--- a/styles/lastfm/catppuccin.user.css
+++ b/styles/lastfm/catppuccin.user.css
@@ -914,7 +914,7 @@
 
     .shout {
       &--active {
-        background-color: fadeout(@surface1, 0.3);
+        background-color: fadeout(@surface1, 30%);
       }
 
       &,
@@ -1194,7 +1194,7 @@
     }
 
     .listener-trend .highcharts-area {
-      fill: fadeout(@red, 0.1);
+      fill: fadeout(@red, 10%);
     }
 
     .listener-trend .highcharts-graph {
@@ -1202,11 +1202,11 @@
     }
 
     .Colored-cta {
-      background-color: fadeout(@surface2, 0.3);
+      background-color: fadeout(@surface2, 30%);
     }
     .Colored-cta:not(.cta--inactive):focus,
     .Colored-cta:not(.cta--inactive):hover {
-      background-color: fadeout(@surface2, 0.7);
+      background-color: fadeout(@surface2, 70%);
     }
     .similar-items-sidebar-item-name {
       color: @text;
@@ -1588,7 +1588,7 @@
     }
     /* ---------CHARTS FIX--------- */
     .globalchart .globalchart-item:first-child {
-      background-color: fadeout(@mantle, 0.8);
+      background-color: fadeout(@mantle, 80%);
     }
     .globalchart-item:first-child .globalchart-rank {
       color: @accent-color !important;

--- a/styles/linkedin/catppuccin.user.css
+++ b/styles/linkedin/catppuccin.user.css
@@ -69,7 +69,7 @@
     --black: @crust;
     --black-a90: @crust;
     --black-a75: @crust;
-    --black-a60: fadeout(@crust, 40);
+    --black-a60: fadeout(@crust, 40%);
     --black-a45: @crust;
     --black-a30: @crust;
     --black-a15: @crust;
@@ -104,21 +104,21 @@
     --blue-80: @blue;
     --blue-90: @blue;
     --blue-100: @blue;
-    --blue-50-a20: fadeout(@blue, 80);
-    --blue-50-a25: fadeout(@blue, 75);
-    --blue-50-a30: fadeout(@blue, 70);
-    --blue-50-a40: fadeout(@blue, 60);
-    --blue-60-a10: fadeout(@blue, 90);
-    --blue-60-a15: fadeout(@blue, 15);
-    --blue-60-a20: fadeout(@blue, 80);
-    --blue-60-a25: fadeout(@blue, 75);
-    --blue-60-a30: fadeout(@blue, 70);
-    --blue-60-a35: fadeout(@blue, 65);
-    --blue-60-a40: fadeout(@blue, 60);
-    --blue-60-a45: fadeout(@blue, 55);
-    --blue-70-a30: fadeout(@sapphire, 70);
-    --blue-70-a40: fadeout(@sapphire, 60);
-    --blue-70-a50: fadeout(@sapphire, 50);
+    --blue-50-a20: fadeout(@blue, 80%);
+    --blue-50-a25: fadeout(@blue, 75%);
+    --blue-50-a30: fadeout(@blue, 70%);
+    --blue-50-a40: fadeout(@blue, 60%);
+    --blue-60-a10: fadeout(@blue, 90%);
+    --blue-60-a15: fadeout(@blue, 15%);
+    --blue-60-a20: fadeout(@blue, 80%);
+    --blue-60-a25: fadeout(@blue, 75%);
+    --blue-60-a30: fadeout(@blue, 70%);
+    --blue-60-a35: fadeout(@blue, 65%);
+    --blue-60-a40: fadeout(@blue, 60%);
+    --blue-60-a45: fadeout(@blue, 55%);
+    --blue-70-a30: fadeout(@sapphire, 70%);
+    --blue-70-a40: fadeout(@sapphire, 60%);
+    --blue-70-a50: fadeout(@sapphire, 50%);
 
     --cool-gray-10: @mantle;
     --cool-gray-20: @surface0;
@@ -131,12 +131,12 @@
     --cool-gray-85: @mantle;
     --cool-gray-90: @mantle;
     --cool-gray-100: @mantle;
-    --cool-gray-60-a10: fadeout(@mantle, 90);
-    --cool-gray-60-a15: fadeout(@mantle, 85);
-    --cool-gray-60-a20: fadeout(@mantle, 80);
-    --cool-gray-60-a25: fadeout(@mantle, 75);
-    --cool-gray-60-a30: fadeout(@mantle, 70);
-    --cool-gray-60-a35: fadeout(@mantle, 65);
+    --cool-gray-60-a10: fadeout(@mantle, 90%);
+    --cool-gray-60-a15: fadeout(@mantle, 85%);
+    --cool-gray-60-a20: fadeout(@mantle, 80%);
+    --cool-gray-60-a25: fadeout(@mantle, 75%);
+    --cool-gray-60-a30: fadeout(@mantle, 70%);
+    --cool-gray-60-a35: fadeout(@mantle, 65%);
 
     --warm-gray-10: @overlay1;
     --warm-gray-20: @overlay1;
@@ -148,12 +148,12 @@
     --warm-gray-80: @overlay1;
     --warm-gray-90: @overlay1;
     --warm-gray-100: @overlay1;
-    --warm-gray-60-a10: fadeout(@overlay1, 90);
-    --warm-gray-60-a15: fadeout(@overlay1, 85);
-    --warm-gray-60-a20: fadeout(@overlay1, 80);
-    --warm-gray-60-a25: fadeout(@overlay1, 75);
-    --warm-gray-60-a30: fadeout(@overlay1, 70);
-    --warm-gray-60-a35: fadeout(@overlay1, 65);
+    --warm-gray-60-a10: fadeout(@overlay1, 90%);
+    --warm-gray-60-a15: fadeout(@overlay1, 85%);
+    --warm-gray-60-a20: fadeout(@overlay1, 80%);
+    --warm-gray-60-a25: fadeout(@overlay1, 75%);
+    --warm-gray-60-a30: fadeout(@overlay1, 70%);
+    --warm-gray-60-a35: fadeout(@overlay1, 65%);
 
     --warm-red-10: @maroon;
     --warm-red-20: @maroon;
@@ -165,12 +165,12 @@
     --warm-red-80: @maroon;
     --warm-red-90: @maroon;
     --warm-red-100: @maroon;
-    --warm-red-60-a10: fadeout(@maroon, 90);
-    --warm-red-60-a15: fadeout(@maroon, 85);
-    --warm-red-60-a20: fadeout(@maroon, 80);
-    --warm-red-60-a25: fadeout(@maroon, 75);
-    --warm-red-60-a30: fadeout(@maroon, 70);
-    --warm-red-60-a35: fadeout(@maroon, 65);
+    --warm-red-60-a10: fadeout(@maroon, 90%);
+    --warm-red-60-a15: fadeout(@maroon, 85%);
+    --warm-red-60-a20: fadeout(@maroon, 80%);
+    --warm-red-60-a25: fadeout(@maroon, 75%);
+    --warm-red-60-a30: fadeout(@maroon, 70%);
+    --warm-red-60-a35: fadeout(@maroon, 65%);
 
     --teal-10: @teal;
     --teal-20: @teal;
@@ -182,13 +182,13 @@
     --teal-80: @teal;
     --teal-90: @teal;
     --teal-100: @teal;
-    --teal-50-a30: fadein(@teal, 70);
-    --teal-60-a10: fadeout(@teal, 90);
-    --teal-60-a15: fadeout(@teal, 85);
-    --teal-60-a20: fadeout(@teal, 80);
-    --teal-60-a25: fadeout(@teal, 75);
-    --teal-60-a30: fadeout(@teal, 70);
-    --teal-60-a35: fadeout(@teal, 65);
+    --teal-50-a30: fadein(@teal, 70%);
+    --teal-60-a10: fadeout(@teal, 90%);
+    --teal-60-a15: fadeout(@teal, 85%);
+    --teal-60-a20: fadeout(@teal, 80%);
+    --teal-60-a25: fadeout(@teal, 75%);
+    --teal-60-a30: fadeout(@teal, 70%);
+    --teal-60-a35: fadeout(@teal, 65%);
 
     --purple-10: @lavender;
     --purple-20: @lavender;
@@ -200,14 +200,14 @@
     --purple-80: @lavender;
     --purple-90: @lavender;
     --purple-100: @lavender;
-    --purple-40-a15: fadeout(@lavender, 85);
-    --purple-60-a10: fadeout(@lavender, 90);
-    --purple-60-a15: fadeout(@lavender, 85);
-    --purple-60-a20: fadeout(@lavender, 80);
-    --purple-60-a25: fadeout(@lavender, 75);
-    --purple-60-a30: fadeout(@lavender, 70);
-    --purple-60-a35: fadeout(@lavender, 65);
-    --purple-70-a15: fadeout(@lavender, 85);
+    --purple-40-a15: fadeout(@lavender, 85%);
+    --purple-60-a10: fadeout(@lavender, 90%);
+    --purple-60-a15: fadeout(@lavender, 85%);
+    --purple-60-a20: fadeout(@lavender, 80%);
+    --purple-60-a25: fadeout(@lavender, 75%);
+    --purple-60-a30: fadeout(@lavender, 70%);
+    --purple-60-a35: fadeout(@lavender, 65%);
+    --purple-70-a15: fadeout(@lavender, 85%);
 
     --system-red-10: @red;
     --system-red-20: @red;
@@ -219,29 +219,29 @@
     --system-red-80: @red;
     --system-red-90: @red;
     --system-red-100: @red;
-    --system-red-60-a10: fadeout(@red, 90);
-    --system-red-60-a15: fadeout(@red, 85);
-    --system-red-60-a20: fadeout(@red, 80);
-    --system-red-60-a25: fadeout(@red, 75);
-    --system-red-60-a30: fadeout(@red, 70);
-    --system-red-60-a35: fadeout(@red, 65);
+    --system-red-60-a10: fadeout(@red, 90%);
+    --system-red-60-a15: fadeout(@red, 85%);
+    --system-red-60-a20: fadeout(@red, 80%);
+    --system-red-60-a25: fadeout(@red, 75%);
+    --system-red-60-a30: fadeout(@red, 70%);
+    --system-red-60-a35: fadeout(@red, 65%);
 
-    --system-green-10: darken(@green, 20);
-    --system-green-20: darken(@green, 20);
-    --system-green-30: darken(@green, 20);
-    --system-green-40: darken(@green, 20);
-    --system-green-50: darken(@green, 20);
-    --system-green-60: darken(@green, 20);
-    --system-green-70: darken(@green, 20);
-    --system-green-80: darken(@green, 20);
-    --system-green-90: darken(@green, 20);
-    --system-green-100: darken(@green, 20);
-    --system-green-60-a10: fadeout(darken(@green, 20), 90);
-    --system-green-60-a15: fadeout(darken(@green, 20), 85);
-    --system-green-60-a20: fadeout(darken(@green, 20), 80);
-    --system-green-60-a25: fadeout(darken(@green, 20), 75);
-    --system-green-60-a30: fadeout(darken(@green, 20), 70);
-    --system-green-60-a35: fadeout(darken(@green, 20), 65);
+    --system-green-10: darken(@green, 20%);
+    --system-green-20: darken(@green, 20%);
+    --system-green-30: darken(@green, 20%);
+    --system-green-40: darken(@green, 20%);
+    --system-green-50: darken(@green, 20%);
+    --system-green-60: darken(@green, 20%);
+    --system-green-70: darken(@green, 20%);
+    --system-green-80: darken(@green, 20%);
+    --system-green-90: darken(@green, 20%);
+    --system-green-100: darken(@green, 20%);
+    --system-green-60-a10: fadeout(darken(@green, 20), 90%);
+    --system-green-60-a15: fadeout(darken(@green, 20), 85%);
+    --system-green-60-a20: fadeout(darken(@green, 20), 80%);
+    --system-green-60-a25: fadeout(darken(@green, 20), 75%);
+    --system-green-60-a30: fadeout(darken(@green, 20), 70%);
+    --system-green-60-a35: fadeout(darken(@green, 20), 65%);
 
     --pink-10: @pink;
     --pink-20: @pink;
@@ -253,12 +253,12 @@
     --pink-80: @pink;
     --pink-90: @pink;
     --pink-100: @pink;
-    --pink-60-a10: fadeout(@pink, 90);
-    --pink-60-a15: fadeout(@pink, 85);
-    --pink-60-a20: fadeout(@pink, 80);
-    --pink-60-a25: fadeout(@pink, 75);
-    --pink-60-a30: fadeout(@pink, 70);
-    --pink-60-a35: fadeout(@pink, 65);
+    --pink-60-a10: fadeout(@pink, 90%);
+    --pink-60-a15: fadeout(@pink, 85%);
+    --pink-60-a20: fadeout(@pink, 80%);
+    --pink-60-a25: fadeout(@pink, 75%);
+    --pink-60-a30: fadeout(@pink, 70%);
+    --pink-60-a35: fadeout(@pink, 65%);
 
     --amber-10: @yellow;
     --amber-20: @yellow;
@@ -270,13 +270,13 @@
     --amber-80: @yellow;
     --amber-90: @yellow;
     --amber-100: @yellow;
-    --amber-30-a50: fadein(@yellow, 50);
-    --amber-60-a10: fadeout(@yellow, 90);
-    --amber-60-a15: fadeout(@yellow, 85);
-    --amber-60-a20: fadeout(@yellow, 80);
-    --amber-60-a25: fadeout(@yellow, 75);
-    --amber-60-a30: fadeout(@yellow, 70);
-    --amber-60-a35: fadeout(@yellow, 65);
+    --amber-30-a50: fadein(@yellow, 50%);
+    --amber-60-a10: fadeout(@yellow, 90%);
+    --amber-60-a15: fadeout(@yellow, 85%);
+    --amber-60-a20: fadeout(@yellow, 80%);
+    --amber-60-a25: fadeout(@yellow, 75%);
+    --amber-60-a30: fadeout(@yellow, 70%);
+    --amber-60-a35: fadeout(@yellow, 65%);
 
     --copper-10: @rosewater;
     --copper-20: @rosewater;
@@ -288,12 +288,12 @@
     --copper-80: @rosewater;
     --copper-90: @rosewater;
     --copper-100: @rosewater;
-    --copper-60-a10: fadeout(@rosewater, 90);
-    --copper-60-a15: fadeout(@rosewater, 85);
-    --copper-60-a20: fadeout(@rosewater, 80);
-    --copper-60-a25: fadeout(@rosewater, 75);
-    --copper-60-a30: fadeout(@rosewater, 70);
-    --copper-60-a35: fadeout(@rosewater, 65);
+    --copper-60-a10: fadeout(@rosewater, 90%);
+    --copper-60-a15: fadeout(@rosewater, 85%);
+    --copper-60-a20: fadeout(@rosewater, 80%);
+    --copper-60-a25: fadeout(@rosewater, 75%);
+    --copper-60-a30: fadeout(@rosewater, 70%);
+    --copper-60-a35: fadeout(@rosewater, 65%);
 
     --green-10: @green;
     --green-20: @green;
@@ -305,46 +305,46 @@
     --green-80: @green;
     --green-90: @green;
     --green-100: @green;
-    --green-60-a10: fadeout(@green, 90);
-    --green-60-a15: fadeout(@green, 85);
-    --green-60-a20: fadeout(@green, 80);
-    --green-60-a25: fadeout(@green, 75);
-    --green-60-a30: fadeout(@green, 70);
-    --green-60-a35: fadeout(@green, 65);
+    --green-60-a10: fadeout(@green, 90%);
+    --green-60-a15: fadeout(@green, 85%);
+    --green-60-a20: fadeout(@green, 80%);
+    --green-60-a25: fadeout(@green, 75%);
+    --green-60-a30: fadeout(@green, 70%);
+    --green-60-a35: fadeout(@green, 65%);
 
-    --sage-10: darken(@green, 40);
-    --sage-20: darken(@green, 40);
-    --sage-30: darken(@green, 40);
-    --sage-40: darken(@green, 40);
-    --sage-50: darken(@green, 40);
-    --sage-60: darken(@green, 40);
-    --sage-70: darken(@green, 40);
-    --sage-80: darken(@green, 40);
-    --sage-90: darken(@green, 40);
-    --sage-100: darken(@green, 40);
-    --sage-60-a10: fadeout(darken(@green, 40), 90);
-    --sage-60-a15: fadeout(darken(@green, 40), 85);
-    --sage-60-a20: fadeout(darken(@green, 40), 80);
-    --sage-60-a25: fadeout(darken(@green, 40), 75);
-    --sage-60-a30: fadeout(darken(@green, 40), 70);
-    --sage-60-a35: fadeout(darken(@green, 40), 65);
+    --sage-10: darken(@green, 40%);
+    --sage-20: darken(@green, 40%);
+    --sage-30: darken(@green, 40%);
+    --sage-40: darken(@green, 40%);
+    --sage-50: darken(@green, 40%);
+    --sage-60: darken(@green, 40%);
+    --sage-70: darken(@green, 40%);
+    --sage-80: darken(@green, 40%);
+    --sage-90: darken(@green, 40%);
+    --sage-100: darken(@green, 40%);
+    --sage-60-a10: fadeout(darken(@green, 40), 90%);
+    --sage-60-a15: fadeout(darken(@green, 40), 85%);
+    --sage-60-a20: fadeout(darken(@green, 40), 80%);
+    --sage-60-a25: fadeout(darken(@green, 40), 75%);
+    --sage-60-a30: fadeout(darken(@green, 40), 70%);
+    --sage-60-a35: fadeout(darken(@green, 40), 65%);
 
-    --lime-10: lighten(@green, 20);
-    --lime-20: lighten(@green, 20);
-    --lime-30: lighten(@green, 20);
-    --lime-40: lighten(@green, 20);
-    --lime-50: lighten(@green, 20);
-    --lime-60: lighten(@green, 20);
-    --lime-70: lighten(@green, 20);
-    --lime-80: lighten(@green, 20);
-    --lime-90: lighten(@green, 20);
-    --lime-100: lighten(@green, 20);
-    --lime-60-a10: fadeout(lighten(@green, 20), 90);
-    --lime-60-a15: fadeout(lighten(@green, 20), 85);
-    --lime-60-a20: fadeout(lighten(@green, 20), 80);
-    --lime-60-a25: fadeout(lighten(@green, 20), 75);
-    --lime-60-a30: fadeout(lighten(@green, 20), 70);
-    --lime-60-a35: fadeout(lighten(@green, 20), 65);
+    --lime-10: lighten(@green, 20%);
+    --lime-20: lighten(@green, 20%);
+    --lime-30: lighten(@green, 20%);
+    --lime-40: lighten(@green, 20%);
+    --lime-50: lighten(@green, 20%);
+    --lime-60: lighten(@green, 20%);
+    --lime-70: lighten(@green, 20%);
+    --lime-80: lighten(@green, 20%);
+    --lime-90: lighten(@green, 20%);
+    --lime-100: lighten(@green, 20%);
+    --lime-60-a10: fadeout(lighten(@green, 20), 90%);
+    --lime-60-a15: fadeout(lighten(@green, 20), 85%);
+    --lime-60-a20: fadeout(lighten(@green, 20), 80%);
+    --lime-60-a25: fadeout(lighten(@green, 20), 75%);
+    --lime-60-a30: fadeout(lighten(@green, 20), 70%);
+    --lime-60-a35: fadeout(lighten(@green, 20), 65%);
 
     --camo-10: @accent-color;
     --camo-20: @accent-color;
@@ -356,12 +356,12 @@
     --camo-80: @accent-color;
     --camo-90: @accent-color;
     --camo-100: @accent-color;
-    --camo-60-a10: fadeout(@accent-color, 90);
-    --camo-60-a15: fadeout(@accent-color, 85);
-    --camo-60-a20: fadeout(@accent-color, 80);
-    --camo-60-a25: fadeout(@accent-color, 75);
-    --camo-60-a30: fadeout(@accent-color, 70);
-    --camo-60-a35: fadeout(@accent-color, 65);
+    --camo-60-a10: fadeout(@accent-color, 90%);
+    --camo-60-a15: fadeout(@accent-color, 85%);
+    --camo-60-a20: fadeout(@accent-color, 80%);
+    --camo-60-a25: fadeout(@accent-color, 75%);
+    --camo-60-a30: fadeout(@accent-color, 70%);
+    --camo-60-a35: fadeout(@accent-color, 65%);
 
     --smoke-10: @surface1;
     --smoke-20: @surface1;
@@ -373,12 +373,12 @@
     --smoke-80: @surface1;
     --smoke-90: @surface1;
     --smoke-100: @surface1;
-    --smoke-60-a10: fadeout(@surface1, 90);
-    --smoke-60-a15: fadeout(@surface1, 85);
-    --smoke-60-a20: fadeout(@surface1, 80);
-    --smoke-60-a25: fadeout(@surface1, 75);
-    --smoke-60-a30: fadeout(@surface1, 70);
-    --smoke-60-a35: fadeout(@surface1, 65);
+    --smoke-60-a10: fadeout(@surface1, 90%);
+    --smoke-60-a15: fadeout(@surface1, 85%);
+    --smoke-60-a20: fadeout(@surface1, 80%);
+    --smoke-60-a25: fadeout(@surface1, 75%);
+    --smoke-60-a30: fadeout(@surface1, 70%);
+    --smoke-60-a35: fadeout(@surface1, 65%);
 
     --lavender-10: @lavender;
     --lavender-20: @lavender;
@@ -390,12 +390,12 @@
     --lavender-80: @lavender;
     --lavender-90: @lavender;
     --lavender-100: @lavender;
-    --lavender-60-a10: fadeout(@lavender, 90);
-    --lavender-60-a15: fadeout(@lavender, 85);
-    --lavender-60-a20: fadeout(@lavender, 80);
-    --lavender-60-a25: fadeout(@lavender, 75);
-    --lavender-60-a30: fadeout(@lavender, 70);
-    --lavender-60-a35: fadeout(@lavender, 65);
+    --lavender-60-a10: fadeout(@lavender, 90%);
+    --lavender-60-a15: fadeout(@lavender, 85%);
+    --lavender-60-a20: fadeout(@lavender, 80%);
+    --lavender-60-a25: fadeout(@lavender, 75%);
+    --lavender-60-a30: fadeout(@lavender, 70%);
+    --lavender-60-a35: fadeout(@lavender, 65%);
 
     --mauve-10: @mauve;
     --mauve-20: @mauve;
@@ -407,13 +407,13 @@
     --mauve-80: @mauve;
     --mauve-90: @mauve;
     --mauve-100: @mauve;
-    --mauve-60-a10: fadeout(@mauve, 90);
-    --mauve-60-a15: fadeout(@mauve, 85);
-    --mauve-60-a20: fadeout(@mauve, 80);
-    --mauve-60-a25: fadeout(@mauve, 75);
-    --mauve-60-a30: fadeout(@mauve, 70);
-    --mauve-60-a35: fadeout(@mauve, 65);
-    --mauve-80-a50: fadeout(@mauve, 50);
+    --mauve-60-a10: fadeout(@mauve, 90%);
+    --mauve-60-a15: fadeout(@mauve, 85%);
+    --mauve-60-a20: fadeout(@mauve, 80%);
+    --mauve-60-a25: fadeout(@mauve, 75%);
+    --mauve-60-a30: fadeout(@mauve, 70%);
+    --mauve-60-a35: fadeout(@mauve, 65%);
+    --mauve-80-a50: fadeout(@mauve, 50%);
 
     --system-gray-10: @surface0;
     --system-gray-20: @surface0;
@@ -425,14 +425,14 @@
     --system-gray-80: @surface0;
     --system-gray-90: @surface0;
     --system-gray-100: @surface0;
-    --system-gray-60-a10: fadeout(@surface0, 90);
-    --system-gray-60-a15: fadeout(@surface0, 85);
-    --system-gray-60-a20: fadeout(@surface0, 80);
-    --system-gray-60-a25: fadeout(@surface0, 75);
-    --system-gray-60-a30: fadeout(@surface0, 70);
-    --system-gray-60-a35: fadeout(@surface0, 65);
-    --system-gray-60-a40: fadeout(@surface0, 60);
-    --system-gray-60-a45: fadeout(@surface0, 55);
+    --system-gray-60-a10: fadeout(@surface0, 90%);
+    --system-gray-60-a15: fadeout(@surface0, 85%);
+    --system-gray-60-a20: fadeout(@surface0, 80%);
+    --system-gray-60-a25: fadeout(@surface0, 75%);
+    --system-gray-60-a30: fadeout(@surface0, 70%);
+    --system-gray-60-a35: fadeout(@surface0, 65%);
+    --system-gray-60-a40: fadeout(@surface0, 60%);
+    --system-gray-60-a45: fadeout(@surface0, 55%);
 
     --system-orange-10: @peach;
     --system-orange-20: @peach;
@@ -444,12 +444,12 @@
     --system-orange-80: @peach;
     --system-orange-90: @peach;
     --system-orange-100: @peach;
-    --system-orange-60-a10: fadeout(@peach, 90);
-    --system-orange-60-a15: fadeout(@peach, 85);
-    --system-orange-60-a20: fadeout(@peach, 80);
-    --system-orange-60-a25: fadeout(@peach, 75);
-    --system-orange-60-a30: fadeout(@peach, 70);
-    --system-orange-60-a35: fadeout(@peach, 65);
+    --system-orange-60-a10: fadeout(@peach, 90%);
+    --system-orange-60-a15: fadeout(@peach, 85%);
+    --system-orange-60-a20: fadeout(@peach, 80%);
+    --system-orange-60-a25: fadeout(@peach, 75%);
+    --system-orange-60-a30: fadeout(@peach, 70%);
+    --system-orange-60-a35: fadeout(@peach, 65%);
 
     /* quality of life changes */
     --color-border-low-emphasis: @surface0;
@@ -470,7 +470,7 @@
     /* fix for hover buttons */
     --artdeco-button-secondary-default-hover-background-color: fadeout(
       @blue,
-      80
+      80%
     );
 
     /* text on dark */
@@ -520,12 +520,12 @@
       --warm-gray-80: @base;
       --warm-gray-90: @base;
       --warm-gray-100: @base;
-      --warm-gray-60-a10: fadeout(@base, 90);
-      --warm-gray-60-a15: fadeout(@base, 85);
-      --warm-gray-60-a20: fadeout(@base, 80);
-      --warm-gray-60-a25: fadeout(@base, 75);
-      --warm-gray-60-a30: fadeout(@base, 70);
-      --warm-gray-60-a35: fadeout(@base, 65);
+      --warm-gray-60-a10: fadeout(@base, 90%);
+      --warm-gray-60-a15: fadeout(@base, 85%);
+      --warm-gray-60-a20: fadeout(@base, 80%);
+      --warm-gray-60-a25: fadeout(@base, 75%);
+      --warm-gray-60-a30: fadeout(@base, 70%);
+      --warm-gray-60-a35: fadeout(@base, 65%);
     }
 
     .share-promoted-detour-button-legacy {

--- a/styles/mastodon/catppuccin.user.css
+++ b/styles/mastodon/catppuccin.user.css
@@ -354,7 +354,7 @@ domain("fosstodon.org") {
 
     .account__domain-pill {
       color: @accent-color;
-      background: fadeout(@accent-color, 80);
+      background: fadeout(@accent-color, 80%);
     }
 
     .drawer__header,

--- a/styles/reddit/catppuccin.user.css
+++ b/styles/reddit/catppuccin.user.css
@@ -97,7 +97,7 @@
     --color-neutral-border-weak: @surface0 !important;
     --color-neutral-border-strong: @surface2 !important;
     --color-primary: @accent-color !important;
-    --color-primary-hover: lighten(@accent-color, 10) !important;
+    --color-primary-hover: lighten(@accent-color, 10%) !important;
     --color-primary-visited: @lavender !important;
     --color-primary-background: @accent-color !important;
     --color-primary-background-hover: darken(@accent-color, 5%) !important;
@@ -114,22 +114,22 @@
     --color-secondary-plain: @subtext0 !important;
     --color-secondary-plain-hover: @subtext1 !important;
     --color-danger-background: @red !important;
-    --color-danger-background-disabled: fadeout(@red, 80) !important;
-    --color-danger-background-hover: fadeout(@red, 2) !important;
+    --color-danger-background-disabled: fadeout(@red, 80%) !important;
+    --color-danger-background-hover: fadeout(@red, 2%) !important;
     --color-danger-onBackground: @text !important;
     --color-danger-content: @red !important;
     --color-danger-content-default: @crust;
-    --color-danger-content-hover: darken(@red, 2) !important;
+    --color-danger-content-hover: darken(@red, 2%) !important;
     --color-success-content: @green !important;
-    --color-success-hover: darken(@green, 2) !important;
+    --color-success-hover: darken(@green, 2%) !important;
     --color-success-onBackground: @crust;
     --color-success-background: @green !important;
-    --color-success-background-hover: darken(@green, 2) !important;
+    --color-success-background-hover: darken(@green, 2%) !important;
     --color-warning-content: @yellow !important;
-    --color-warning-content-hover: darken(@yellow, 2) !important;
+    --color-warning-content-hover: darken(@yellow, 2%) !important;
     --color-warning-onBackground: @base !important;
     --color-warning-background: @yellow !important;
-    --color-warning-background-hover: darken(@yellow, 2) !important;
+    --color-warning-background-hover: darken(@yellow, 2%) !important;
     --color-upvote-content: @accent-color !important;
     --color-upvote-disabled: @subtext0 !important;
     --color-upvote-onBackground: @text !important;
@@ -151,8 +151,8 @@
     --color-tone-6: @surface2 !important;
     --color-tone-7: @base !important;
     --color-avatar-gradient: @accent-color !important;
-    --color-transparent-background-hover: fadeout(@surface0, 70) !important;
-    --color-opacity-50: fadeout(@base, 50) !important;
+    --color-transparent-background-hover: fadeout(@surface0, 70%) !important;
+    --color-opacity-50: fadeout(@base, 50%) !important;
     --color-online: @accent-color !important;
     --color-favorite: @accent-color !important;
     --color-brand-background: @accent-color !important;
@@ -179,14 +179,14 @@
     div[class^="subredditvars"] {
       --color-online: @green !important;
       --newCommunityTheme-actionIcon: @subtext0 !important;
-      --newCommunityTheme-actionIconAlpha20: fadeout(@crust, 20) !important;
-      --newCommunityTheme-actionIconAlpha50: fadeout(@crust, 20) !important;
+      --newCommunityTheme-actionIconAlpha20: fadeout(@crust, 20%) !important;
+      --newCommunityTheme-actionIconAlpha50: fadeout(@crust, 20%) !important;
       --newCommunityTheme-actionIconShaded80: @subtext0 !important;
       --newCommunityTheme-actionIconTinted80: @subtext1 !important;
       --newCommunityTheme-active: @accent-color !important;
-      --newCommunityTheme-activeAlpha10: fadeout(@crust, 20) !important;
-      --newCommunityTheme-activeAlpha20: fadeout(@crust, 20) !important;
-      --newCommunityTheme-activeAlpha50: fadeout(@crust, 20) !important;
+      --newCommunityTheme-activeAlpha10: fadeout(@crust, 20%) !important;
+      --newCommunityTheme-activeAlpha20: fadeout(@crust, 20%) !important;
+      --newCommunityTheme-activeAlpha50: fadeout(@crust, 20%) !important;
       --newCommunityTheme-activeLight60: @accent-color !important;
       --newCommunityTheme-activeShaded80: @accent-color !important;
       --newCommunityTheme-activeShaded90: @accent-color !important;
@@ -207,9 +207,9 @@
       --newCommunityTheme-bodyTinted50: @overlay1 !important;
       --newCommunityTheme-bodyTinted80: @overlay0 !important;
       --newCommunityTheme-button: @text !important;
-      --newCommunityTheme-buttonAlpha05: fadeout(@crust, 20) !important;
-      --newCommunityTheme-buttonAlpha10: fadeout(@crust, 20) !important;
-      --newCommunityTheme-buttonAlpha20: fadeout(@crust, 20) !important;
+      --newCommunityTheme-buttonAlpha05: fadeout(@crust, 20%) !important;
+      --newCommunityTheme-buttonAlpha10: fadeout(@crust, 20%) !important;
+      --newCommunityTheme-buttonAlpha20: fadeout(@crust, 20%) !important;
       --newCommunityTheme-buttonAlpha40: @subtext0 !important;
       --newCommunityTheme-buttonAlpha50: @subtext1 !important;
       --newCommunityTheme-buttonAlpha80: @subtext1 !important;
@@ -221,16 +221,16 @@
       --newCommunityTheme-checkbox: @text !important;
       --newCommunityTheme-errorText: @red !important;
       --newCommunityTheme-field: @surface0 !important;
-      --newCommunityTheme-fieldFade: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-fieldFade: fadeout(@surface1, 30%) !important;
       --newCommunityTheme-flair: @accent-color !important;
       --newCommunityTheme-highlight: @base !important;
       --newCommunityTheme-inactive: @subtext0 !important;
       --newCommunityTheme-lightText: @text !important;
       --newCommunityTheme-lightTextAlpha75: @subtext1 !important;
-      --newCommunityTheme-line: fadeout(@surface1, 30) !important;
-      --newCommunityTheme-lineShaded80: fadeout(@surface1, 30) !important;
-      --newCommunityTheme-lineShaded90: fadeout(@surface1, 30) !important;
-      --newCommunityTheme-lineShadedNinety: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-line: fadeout(@surface1, 30%) !important;
+      --newCommunityTheme-lineShaded80: fadeout(@surface1, 30%) !important;
+      --newCommunityTheme-lineShaded90: fadeout(@surface1, 30%) !important;
+      --newCommunityTheme-lineShadedNinety: fadeout(@surface1, 30%) !important;
       --newCommunityTheme-linkText: @accent-color !important;
       --newCommunityTheme-linkTextAlpha80: @accent-color !important;
       --newCommunityTheme-linkTextShaded80: @accent-color !important;
@@ -258,7 +258,7 @@
       --newCommunityTheme-navIcon: @text !important;
 
       /* upvote/downvote focus */
-      --newCommunityTheme-navIconFaded10: fadeout(@crust, 20) !important;
+      --newCommunityTheme-navIconFaded10: fadeout(@crust, 20%) !important;
 
       --newCommunityTheme-nsfw: @red !important;
       --newCommunityTheme-nsfwBlocking-bgcolor: @crust !important;
@@ -271,9 +271,9 @@
       --newCommunityTheme-postError: @red !important;
       --newCommunityTheme-postFlairText: @crust !important;
       --newCommunityTheme-postIcon: @accent-color !important;
-      --newCommunityTheme-postLine: fadeout(@surface1, 30) !important;
-      --newCommunityTheme-postLineShaded80: fadeout(@surface1, 30) !important;
-      --newCommunityTheme-postLineShaded90: fadeout(@surface1, 30) !important;
+      --newCommunityTheme-postLine: fadeout(@surface1, 30%) !important;
+      --newCommunityTheme-postLineShaded80: fadeout(@surface1, 30%) !important;
+      --newCommunityTheme-postLineShaded90: fadeout(@surface1, 30%) !important;
       --newCommunityTheme-postTinted20: @base !important;
       --newCommunityTheme-postTransparent20: @base !important;
       --newCommunityTheme-primaryButtonShadedEighty: @overlay1 !important;
@@ -288,7 +288,7 @@
       --newCommunityTheme-upsell-appleIcon: @subtext1 !important;
       --newCommunityTheme-upsell-ssoButtonBorderColor: fadeout(
         @surface1,
-        30
+        30%
       ) !important;
       --newCommunityTheme-upsell-ssoButtonTextColor: @text !important;
       --newCommunityTheme-voteText-base: @subtext0 !important;
@@ -301,14 +301,14 @@
       --newCommunityTheme-widgetColors-appleIcon: @overlay0 !important;
       --newCommunityTheme-widgetColors-lineColor: fadeout(
         @surface1,
-        30
+        30%
       ) !important;
 
       /* sidebar widgets */
       --newCommunityTheme-widgetColors-sidebarWidgetBackgroundColor: @mantle !important;
       --newCommunityTheme-widgetColors-sidebarWidgetBorderColor: fadeout(
         @surface1,
-        30
+        30%
       ) !important;
       --newCommunityTheme-widgetColors-sidebarWidgetHeaderColor: @crust !important;
       --newCommunityTheme-widgetColors-sidebarWidgetHeaderColorAlpha60: @mantle !important;
@@ -317,14 +317,14 @@
       --newCommunityTheme-widgetColors-sidebarWidgetTitleColor: @text !important;
 
       --newRedditTheme-actionIcon: @subtext0 !important;
-      --newRedditTheme-actionIconAlpha20: fadeout(@crust, 20) !important;
-      --newRedditTheme-actionIconAlpha50: fadeout(@crust, 20) !important;
+      --newRedditTheme-actionIconAlpha20: fadeout(@crust, 20%) !important;
+      --newRedditTheme-actionIconAlpha50: fadeout(@crust, 20%) !important;
       --newRedditTheme-actionIconShaded80: @subtext0 !important;
       --newRedditTheme-actionIconTinted80: @subtext1 !important;
       --newRedditTheme-active: @accent-color !important;
-      --newRedditTheme-activeAlpha10: fadeout(@crust, 20) !important;
-      --newRedditTheme-activeAlpha20: fadeout(@crust, 20) !important;
-      --newRedditTheme-activeAlpha50: fadeout(@crust, 20) !important;
+      --newRedditTheme-activeAlpha10: fadeout(@crust, 20%) !important;
+      --newRedditTheme-activeAlpha20: fadeout(@crust, 20%) !important;
+      --newRedditTheme-activeAlpha50: fadeout(@crust, 20%) !important;
       --newRedditTheme-activeLight60: @accent-color !important;
       --newRedditTheme-activeShaded80: @accent-color !important;
       --newRedditTheme-activeShaded90: @accent-color !important;
@@ -335,19 +335,19 @@
       --newRedditTheme-bodyAlpha50: @surface0 !important;
       --newRedditTheme-bodyAlpha70: @surface1 !important;
       --newRedditTheme-bodyAlpha80: @surface2 !important;
-      --newRedditTheme-bodyFade: fadeout(@crust, 20) !important;
+      --newRedditTheme-bodyFade: fadeout(@crust, 20%) !important;
       --newRedditTheme-bodyShaded80: @mantle !important;
       --newRedditTheme-bodyText: @text !important;
-      --newRedditTheme-bodyTextAlpha03: fadeout(@crust, 20) !important;
+      --newRedditTheme-bodyTextAlpha03: fadeout(@crust, 20%) !important;
       --newRedditTheme-bodyTextAlpha20: @surface1 !important;
       --newRedditTheme-bodyTextShaded20: @surface0 !important;
       --newRedditTheme-bodyTextTinted20: @subtext1 !important;
       --newRedditTheme-bodyTinted50: @overlay0 !important;
       --newRedditTheme-bodyTinted80: @overlay1 !important;
       --newRedditTheme-button: @text !important;
-      --newRedditTheme-buttonAlpha05: fadeout(@crust, 20) !important;
-      --newRedditTheme-buttonAlpha10: fadeout(@crust, 20) !important;
-      --newRedditTheme-buttonAlpha20: fadeout(@crust, 20) !important;
+      --newRedditTheme-buttonAlpha05: fadeout(@crust, 20%) !important;
+      --newRedditTheme-buttonAlpha10: fadeout(@crust, 20%) !important;
+      --newRedditTheme-buttonAlpha20: fadeout(@crust, 20%) !important;
       --newRedditTheme-buttonAlpha40: @subtext0 !important;
       --newRedditTheme-buttonAlpha50: @subtext1 !important;
       --newRedditTheme-buttonAlpha80: @subtext1 !important;
@@ -368,10 +368,10 @@
       --newRedditTheme-inactive: @surface0 !important;
       --newRedditTheme-lightText: @text !important;
       --newRedditTheme-lightTextAlpha75: @subtext1 !important;
-      --newRedditTheme-line: fadeout(@surface1, 30) !important;
-      --newRedditTheme-lineShaded80: fadeout(@surface1, 30) !important;
-      --newRedditTheme-lineShaded90: fadeout(@surface1, 30) !important;
-      --newRedditTheme-lineShadedNinety: fadeout(@surface1, 30) !important;
+      --newRedditTheme-line: fadeout(@surface1, 30%) !important;
+      --newRedditTheme-lineShaded80: fadeout(@surface1, 30%) !important;
+      --newRedditTheme-lineShaded90: fadeout(@surface1, 30%) !important;
+      --newRedditTheme-lineShadedNinety: fadeout(@surface1, 30%) !important;
 
       /* links */
       --newRedditTheme-linkText: @accent-color !important;
@@ -389,7 +389,7 @@
       --newRedditTheme-menuInactiveText: @text !important;
 
       --newRedditTheme-metaText: @subtext0 !important;
-      --newRedditTheme-metaTextAlpha50: fadeout(@crust, 20) !important;
+      --newRedditTheme-metaTextAlpha50: fadeout(@crust, 20%) !important;
       --newRedditTheme-metaTextShaded80: @subtext1 !important;
       --newRedditTheme-monospaceColor: @accent-color !important;
       --newRedditTheme-navBar-activeLink: @text !important;
@@ -402,7 +402,7 @@
       --newRedditTheme-navBar-inactiveSubmenuLink: @text !important;
       --newRedditTheme-navBar-submenuBackgroundColor: @mantle !important;
       --newRedditTheme-navIcon: @text !important;
-      --newRedditTheme-navIconFaded10: fadeout(@crust, 20) !important;
+      --newRedditTheme-navIconFaded10: fadeout(@crust, 20%) !important;
       --newRedditTheme-nsfw: @red !important;
       --newRedditTheme-nsfwBlocking-bgcolor: @crust !important;
       --newRedditTheme-nsfwBlocking-color: @text !important;
@@ -414,11 +414,11 @@
       --newRedditTheme-postError: @red !important;
       --newRedditTheme-postFlairText: @text !important;
       --newRedditTheme-postIcon: @accent-color !important;
-      --newRedditTheme-postLine: fadeout(@surface1, 30) !important;
-      --newRedditTheme-postLineShaded80: fadeout(@surface1, 30) !important;
-      --newRedditTheme-postLineShaded90: fadeout(@surface1, 30) !important;
+      --newRedditTheme-postLine: fadeout(@surface1, 30%) !important;
+      --newRedditTheme-postLineShaded80: fadeout(@surface1, 30%) !important;
+      --newRedditTheme-postLineShaded90: fadeout(@surface1, 30%) !important;
       --newRedditTheme-postTinted20: @base !important;
-      --newRedditTheme-postTransparent20: fadeout(@crust, 20) !important;
+      --newRedditTheme-postTransparent20: fadeout(@crust, 20%) !important;
       --newRedditTheme-primaryButtonShadedEighty: @surface1 !important;
       --newRedditTheme-primaryButtonTintedEighty: @surface2 !important;
       --newRedditTheme-primaryButtonTintedFifty: @surface1 !important;
@@ -441,17 +441,17 @@
       --newRedditTheme-widgetColors-appleIcon: @overlay0 !important;
       --newRedditTheme-widgetColors-lineColor: fadeout(
         @surface1,
-        30
+        30%
       ) !important;
       --newRedditTheme-widgetColors-sidebarWidgetBackgroundColor: @mantle !important;
       --newRedditTheme-widgetColors-sidebarWidgetBorderColor: fadeout(
         @surface1,
-        30
+        30%
       ) !important;
       --newRedditTheme-widgetColors-sidebarWidgetHeaderColor: @crust !important;
       --newRedditTheme-widgetColors-sidebarWidgetHeaderColorAlpha60: fadeout(
         @crust,
-        20
+        20%
       ) !important;
       --newRedditTheme-widgetColors-sidebarWidgetTextColor: @text !important;
       --newRedditTheme-widgetColors-sidebarWidgetTextColorShaded80: @subtext1 !important;
@@ -484,7 +484,7 @@
       --activity-icon-nsfw-text: @text !important;
       --activity-icon-subIcon-backgroundColor: @text !important;
       --activity-icon-toaster: @crust !important;
-      --activity-input-background: fadeout(@crust, 20) !important;
+      --activity-input-background: fadeout(@crust, 20%) !important;
       --activity-input-border: @surface1 !important;
       --activity-input-channelRename: @subtext0 !important;
       --activity-input-color: @subtext1 !important;
@@ -512,8 +512,8 @@
       --activity-text-warning: @red !important;
       --addReaction-backgroundColor: @surface0 !important;
       --addReaction-iconFill: @surface1 !important;
-      --boxShadow: fadeout(@crust, 20) !important;
-      --bubble-border: fadeout(@surface1, 30) !important;
+      --boxShadow: fadeout(@crust, 20%) !important;
+      --bubble-border: fadeout(@surface1, 30%) !important;
       --bubble-channelsFilter-background: @crust !important;
       --bubble-channelsFilter-selected: @overlay0 !important;
       --bubble-color: @text !important;
@@ -521,13 +521,13 @@
       --bubbleActions-hover: @surface0 !important;
       --editName: @surface1 !important;
       --layout-body: @mantle !important;
-      --layout-colsBorder: fadeout(@surface1, 30) !important;
-      --layout-controlsBorder: fadeout(@surface1, 30) !important;
-      --layout-dropdown-border: fadeout(@surface1, 30) !important;
+      --layout-colsBorder: fadeout(@surface1, 30%) !important;
+      --layout-controlsBorder: fadeout(@surface1, 30%) !important;
+      --layout-dropdown-border: fadeout(@surface1, 30%) !important;
       --layout-header-counterBg: @red !important;
       --layout-header-counterText: @text !important;
-      --layout-overlayBackground: fadeout(@crust, 20) !important;
-      --layout-overlayReportFlow: fadeout(@crust, 20) !important;
+      --layout-overlayBackground: fadeout(@crust, 20%) !important;
+      --layout-overlayReportFlow: fadeout(@crust, 20%) !important;
       --layout-scrollbar: @text !important;
       --layout-scrollbarHover: @accent-color !important;
       --layout-timeStamp-tooltip-background: @surface0 !important;
@@ -535,12 +535,12 @@
       --message-list-item-onlineIndicator: @green !important;
       --message-list-item-ownerBg: @surface1 !important;
       --message-list-item-richItem: @overlay0 !important;
-      --message-list-item-richItemBorder: fadeout(@surface1, 30) !important;
+      --message-list-item-richItemBorder: fadeout(@surface1, 30%) !important;
       --message-list-item-white: @text !important;
       --modal-buttonsBackground: @text !important;
       --modal-primaryButtonWarning: @red !important;
       --modal-secondaryButton: @text !important;
-      --newChat-inviteLink-borderColor: fadeout(@surface1, 30) !important;
+      --newChat-inviteLink-borderColor: fadeout(@surface1, 30%) !important;
       --overlay-backgroundColor: @mantle !important;
       --overlay-headerColor: @text !important;
       --overlay-inputBackground: @crust !important;
@@ -552,7 +552,7 @@
       --settings-panelBackground: @crust !important;
       --settings-panelItemHoverBackground: @surface0 !important;
       --settings-panelItemSelectedBackground: @surface1 !important;
-      --sidebar-background: fadeout(@surface1, 30) !important;
+      --sidebar-background: fadeout(@surface1, 30%) !important;
       --sidebar-basic-background-active: @accent-color !important;
       --sidebar-basic-background-hover: @mantle !important;
       --sidebar-footer-background: @crust !important;
@@ -1066,7 +1066,7 @@
     /* shade applied to background when clicking on a post with "open in new tab" disabled */
     div._2DJXORCrmcNpPTSq0LqL6i,
     div._1DK52RbaamLOWw5UPaht_S {
-      background: fadeout(@crust, 20) !important;
+      background: fadeout(@crust, 20%) !important;
     }
 
     /* gold award gradient */
@@ -1087,7 +1087,7 @@
 
     /* image gallery image count */
     div._61i6grM3um1yuw4GrN97P {
-      background: fadeout(@crust, 20) !important;
+      background: fadeout(@crust, 20%) !important;
       color: @text !important;
     }
 

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -85,8 +85,8 @@
       --sigBackgroundMessageHover: @surface1;
       --sigBackgroundMessageSaved: @surface0;
       --sigBackgroundMessageSavedHover: @surface2;
-      --sigOverlay: fade(@overlay0, 0.4);
-      --sigOverlayHover: fade(@overlay0, 0.35);
+      --sigOverlay: fade(@overlay0, 40%);
+      --sigOverlayHover: fade(@overlay0, 35%);
       --sigBrandSecondary: @accent-color;
 
       --sigTextPrimary: @text;

--- a/styles/trinket/catppuccin.user.css
+++ b/styles/trinket/catppuccin.user.css
@@ -722,11 +722,11 @@
       box-shadow:
         -4px 0 4px @surface0,
         4px 0 4px @surface0 !important;
-      background-color: fade(@base, 0.5) !important;
+      background-color: fade(@base, 50%) !important;
     }
 
     #trinket-gallery #trinketDetails .spotlight {
-      background-color: fade(@base, 0.5) !important;
+      background-color: fade(@base, 50%) !important;
     }
 
     .right-off-canvas-menu,

--- a/styles/whatsapp-web/catppuccin.user.css
+++ b/styles/whatsapp-web/catppuccin.user.css
@@ -328,7 +328,7 @@
     --media-gallery-thumb-background: @crust !important;
 
     /* Group info/Contact info */
-    --photopicker-overlay-background: fadeout(@mantle, 0.8) !important;
+    --photopicker-overlay-background: fadeout(@mantle, 80%) !important;
     --photopicker-overlay-background-rgb: #rgbify(@base) [];
     --media-viewer-background-rgb: #rgbify(@base) [];
     --drawer-background-deep: @crust !important;
@@ -369,7 +369,7 @@
 
     /* Forward message popup */
     --panel-background-colored-deeper: @crust !important;
-    --modal-backdrop: fadeout(@mantle, 0.8) !important;
+    --modal-backdrop: fadeout(@mantle, 80%) !important;
 
     /* Forward media caption */
     --forward-caption-preview-background: @mantle !important;
@@ -633,7 +633,7 @@
     --drawer-header-title: @text !important;
     /* buttons such as create community */
     --button-primary-background: @accent-color !important;
-    --button-primary-background-hover: fadeout(@accent-color, 0.8) !important;
+    --button-primary-background-hover: fadeout(@accent-color, 80%) !important;
     /* keyboard shortcuts background */
     --panel-background-lighter: @mantle !important;
     /* active input in modals and drawers */

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -109,32 +109,32 @@
       --yt-spec-yellow: @peach !important;
       --yt-spec-black-pure-alpha-5: @subtext0 !important;
       --yt-spec-black-pure-alpha-10: @overlay2 !important;
-      --yt-spec-black-pure-alpha-15: fadeout(@crust, 0.15) !important;
-      --yt-spec-black-pure-alpha-30: fadeout(@crust, 0.3) !important;
-      --yt-spec-black-pure-alpha-60: fadeout(@crust, 0.6) !important;
-      --yt-spec-black-pure-alpha-80: fadeout(@crust, 0.8) !important;
-      --yt-spec-black-1-alpha-98: fadeout(@crust, 0.98) !important;
-      --yt-spec-black-1-alpha-95: fadeout(@crust, 0.95) !important;
-      --yt-spec-white-1-alpha-10: fadeout(@text, 0.1) !important;
-      --yt-spec-white-1-alpha-20: fadeout(@text, 0.2) !important;
-      --yt-spec-white-1-alpha-25: fadeout(@text, 0.25) !important;
-      --yt-spec-white-1-alpha-30: fadeout(@text, 0.3) !important;
-      --yt-spec-white-1-alpha-70: fadeout(@text, 0.7) !important;
-      --yt-spec-white-1-alpha-95: fadeout(@text, 0.95) !important;
-      --yt-spec-white-1-alpha-98: fadeout(@text, 0.98) !important;
-      --yt-brand-medium-red-alpha-90: fadeout(@accent-color, 0.9) !important;
-      --yt-brand-medium-red-alpha-30: fadeout(@accent-color, 0.3) !important;
-      --yt-brand-light-red-alpha-30: fadeout(@accent-color, 0.3) !important;
-      --yt-spec-light-blue-alpha-30: fadeout(@sapphire, 0.3) !important;
-      --yt-spec-dark-blue-alpha-30: fadeout(@sapphire, 0.3) !important;
+      --yt-spec-black-pure-alpha-15: fadeout(@crust, 15%) !important;
+      --yt-spec-black-pure-alpha-30: fadeout(@crust, 30%) !important;
+      --yt-spec-black-pure-alpha-60: fadeout(@crust, 60%) !important;
+      --yt-spec-black-pure-alpha-80: fadeout(@crust, 80%) !important;
+      --yt-spec-black-1-alpha-98: fadeout(@crust, 98%) !important;
+      --yt-spec-black-1-alpha-95: fadeout(@crust, 95%) !important;
+      --yt-spec-white-1-alpha-10: fadeout(@text, 10%) !important;
+      --yt-spec-white-1-alpha-20: fadeout(@text, 20%) !important;
+      --yt-spec-white-1-alpha-25: fadeout(@text, 25%) !important;
+      --yt-spec-white-1-alpha-30: fadeout(@text, 30%) !important;
+      --yt-spec-white-1-alpha-70: fadeout(@text, 70%) !important;
+      --yt-spec-white-1-alpha-95: fadeout(@text, 95%) !important;
+      --yt-spec-white-1-alpha-98: fadeout(@text, 98%) !important;
+      --yt-brand-medium-red-alpha-90: fadeout(@accent-color, 90%) !important;
+      --yt-brand-medium-red-alpha-30: fadeout(@accent-color, 30%) !important;
+      --yt-brand-light-red-alpha-30: fadeout(@accent-color, 30%) !important;
+      --yt-spec-light-blue-alpha-30: fadeout(@sapphire, 30%) !important;
+      --yt-spec-dark-blue-alpha-30: fadeout(@sapphire, 30%) !important;
 
       --yt-spec-base-background: @base !important;
       --yt-spec-raised-background: @base !important;
       --yt-spec-menu-background: @mantle !important;
       --yt-spec-inverted-background: @text !important;
-      --yt-spec-additive-background: fadeout(@surface1, 0.1) !important;
+      --yt-spec-additive-background: fadeout(@surface1, 10%) !important;
       --yt-spec-outline: @surface0 !important;
-      --yt-spec-shadow: fadeout(@crust, 0.25) !important;
+      --yt-spec-shadow: fadeout(@crust, 25%) !important;
       --yt-spec-text-primary: @text !important;
       --yt-spec-text-secondary: @subtext0 !important;
       --yt-spec-text-disabled: @subtext1 !important;
@@ -156,13 +156,13 @@
       --yt-spec-themed-blue: @accent-color !important;
       --yt-spec-themed-green: @green !important;
       --yt-spec-ad-indicator: @teal !important;
-      --yt-spec-themed-overlay-background: fadeout(@crust, 0.8) !important;
+      --yt-spec-themed-overlay-background: fadeout(@crust, 80%) !important;
       --yt-spec-commerce-badge-background: @green !important;
       --yt-spec-static-brand-red: @accent-color !important;
       --yt-spec-static-brand-white: @text !important;
       --yt-spec-static-brand-black: @base !important;
-      --yt-spec-static-clear-color: fadeout(@crust, 0) !important;
-      --yt-spec-static-clear-black: fadeout(@crust, 0) !important;
+      --yt-spec-static-clear-color: fadeout(@crust, 0%) !important;
+      --yt-spec-static-clear-black: fadeout(@crust, 0%) !important;
       --yt-spec-static-ad-yellow: @peach !important;
       --yt-spec-static-grey: @subtext0 !important;
       --yt-spec-static-overlay-background-solid: @crust !important;
@@ -170,20 +170,20 @@
       --yt-spec-static-overlay-background-medium: fade(@crust, 50%) !important;
       --yt-spec-static-overlay-background-medium-light: fadeout(
         @crust,
-        0.3
+        30%
       ) !important;
       --yt-spec-static-overlay-background-light: fadeout(
         @crust,
-        0.1
+        10%
       ) !important;
       --yt-spec-static-overlay-text-primary: @text !important;
       --yt-spec-static-overlay-text-secondary: fadeout(
         @subtext0,
-        0.7
+        70%
       ) !important;
       --yt-spec-static-overlay-text-disabled: fadeout(
         @subtext0,
-        0.3
+        30%
       ) !important;
       --yt-spec-static-overlay-call-to-action: @accent-color !important;
       --yt-spec-static-overlay-icon-active-other: @crust !important;
@@ -213,12 +213,12 @@
         @surface0
       ) !important;
       --yt-spec-verified-badge-background: @overlay0 !important;
-      --yt-spec-call-to-action-fadeoutd: fadeout(@sapphire, 0.3) !important;
+      --yt-spec-call-to-action-fadeoutd: fadeout(@sapphire, 30%) !important;
       --yt-spec-call-to-action-hover: @accent-color !important;
       --yt-spec-brand-button-background-hover: @accent-color !important;
       --yt-spec-brand-link-text-fadeoutd: fadeout(
         @accent-color,
-        0.3
+        30%
       ) !important;
       --yt-spec-filled-button-focus-outline: @surface0 !important;
       --yt-spec-static-overlay-button-hover: @surface1 !important;
@@ -228,7 +228,7 @@
       --yt-spec-commerce-tonal-hover: @surface2 !important;
       --yt-spec-static-overlay-filled-hover: @overlay1 !important;
       --yt-spec-static-overlay-tonal-hover: @surface1 !important;
-      --yt-spec-paper-tab-ink: fadeout(@text, 0.3);
+      --yt-spec-paper-tab-ink: fadeout(@text, 30%);
       --yt-spec-filled-button-text: @text !important;
       --yt-spec-selected-nav-text: @text !important;
       --iron-icon-fill-color: @text !important;
@@ -236,7 +236,7 @@
       /* Search bar */
       --ytd-searchbox-border-color: @surface0 !important;
       --ytd-searchbox-legacy-border-color: @surface0 !important;
-      --ytd-searchbox-legacy-border-shadow-color: fadeout(@crust, 0) !important;
+      --ytd-searchbox-legacy-border-shadow-color: fadeout(@crust, 0%) !important;
       --ytd-searchbox-legacy-button-color: @mantle !important;
       --ytd-searchbox-legacy-button-border-color: @surface0 !important;
       --ytd-searchbox-legacy-button-focus-color: @accent-color !important;
@@ -258,7 +258,7 @@
       --yt-live-chat-toast-background-color: @surface2 !important;
       --yt-live-chat-mode-change-background-color: @base !important;
       --yt-live-chat-secondary-text-color: @subtext0 !important;
-      --yt-live-chat-tertiary-text-color: fadeout(@text, 0.54) !important;
+      --yt-live-chat-tertiary-text-color: fadeout(@text, 54%) !important;
       --yt-live-chat-text-input-field-inactive-underline-color: @subtext0 !important;
       --yt-live-chat-text-input-field-placeholder-color: @subtext0 !important;
       --yt-live-chat-enabled-send-button-color: @text !important;
@@ -276,12 +276,12 @@
       --yt-live-chat-owner-color: @peach !important;
       --yt-live-chat-message-highlight-background-color: @base !important;
       --yt-live-chat-sponsor-color: @green !important;
-      --yt-live-chat-overlay-color: fadeout(@mantle, 0.5);
+      --yt-live-chat-overlay-color: fadeout(@mantle, 50%);
       --yt-live-chat-dialog-background-color: @base !important;
       --yt-emoji-picker-variant-selector-bg-color: @base !important;
       --yt-live-chat-moderation-mode-hover-background-color: fadeout(
         @mantle,
-        0.3
+        30%
       ) !important;
       --yt-grey: @subtext0 !important;
       --yt-live-chat-text-input-field-suggestion-background-color: @subtext0 !important;
@@ -303,13 +303,13 @@
       ) !important;
       --yt-live-chat-automod-button-background-color-hover: fadeout(
         @crust,
-        0.5
+        50%
       ) !important;
       --yt-live-chat-automod-button-explanation-color: fadeout(
         @accent-color,
-        0.7
+        70%
       ) !important;
-      --yt-live-chat-shimmer-background-color: fadeout(@crust, 0.4) !important;
+      --yt-live-chat-shimmer-background-color: fadeout(@crust, 40%) !important;
       --yt-live-chat-shimmer-linear-gradient: linear-gradient(
         0deg,
         fadeout(@text, 0.1) 40%,
@@ -317,11 +317,11 @@
         fadeout(@text, 0.1) 60%
       ) !important;
       --yt-live-chat-vem-background-color: @mantle !important;
-      --yt-live-chat-product-picker-icon-color: fadeout(@text, 0.5) !important;
+      --yt-live-chat-product-picker-icon-color: fadeout(@text, 50%) !important;
       --yt-live-chat-product-picker-hover-color: @overlay0 !important;
       --yt-live-chat-product-picker-disabled-icon-color: fadeout(
         @text,
-        0.3
+        30%
       ) !important;
       --yt-live-chat-action-panel-background-color-transparent: (
         null


### PR DESCRIPTION
Adds a new rule, `require-color-op-func-percentage`, that requires the "amount" argument to [color operation](https://lesscss.org/functions/#color-operations) functions (e.g. `fade(<color>, <amount>)`) to be in percentage format - `<float or int>%`. This consistency makes these functions more readable, and can catch bugs. As you can see in the diff, there are many cases of `fadeout(@text, 0.8)`; people may think this 0.8 is out of 1, meaning 80%, but it is really just 0.8% (https://lesscss.org/less-preview/#eyJjb2RlIjoiYSB7XG4gIGNvbG9yOiBmYWRlb3V0KCMwMDAwMDAsIDAuOCk7XG59IiwiYWN0aXZlVmVyc2lvbiI6IjQuMi4wIiwibWF0aCI6InBhcmVucy1kaXZpc2lvbiIsInN0cmljdFVuaXRzIjpmYWxzZX0=). These very very tiny percentages should be corrected at some point as well.