### PR TITLE
fix(bsky): unthemed colors and switches 

### DIFF
--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Bluesky Social Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/bsky
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/bsky
-@version 0.0.8
+@version 0.0.9
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bsky/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Absky
 @description Soothing pastel theme for Bluesky Social

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -129,6 +129,13 @@
     {
       color: @accent-color !important;
     }
+    /* generic blue inline underline (links) */
+    [style*="text-decoration-color: rgb(16, 131, 254)"], // dark
+    [style*="text-decoration-color: rgb(32, 139, 254)"] // dim
+    {
+      text-decoration-color: @accent-color !important;
+    }
+
     /* generic blue inline bg color (e.g. notification count) */
     [style*="background-color: rgb(16, 131, 254)"], // dark
     [style*="background-color: rgb(32, 139, 254)"] // dim

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -153,7 +153,8 @@
       stroke: @accent-color;
     }
 
-    [fill="hsl(211, 99%, 53%)"],
+    [fill="hsl(211, 99%, 53%)"],  
+    [fill="hsl(211, 99%, 56%)"],
     [fill="#0085ff"] {
       fill: @accent-color;
     }
@@ -374,7 +375,8 @@
     }
 
     /* blue text only button (e.g. cancel post button) */
-    div[style*="color: rgb(52, 150, 254)"] {
+    div[style*="color: rgb(52, 150, 254)"],
+    div[style*="color: rgb(76, 162, 254)"] {
       color: @accent-color !important;
     }
 
@@ -385,7 +387,8 @@
     }
 
     /* some button background color (when hovering) */
-    [style*="background-color: rgb(0, 44, 91)"] {
+    [style*="background-color: rgb(0, 44, 91)"],
+    [style*="background-color: rgb(19, 63, 109)"] {
       background-color: fade(@accent-color, 30%) !important;
     }
 
@@ -517,7 +520,7 @@
     div[style*="background-color: rgb(240, 247, 255)"] // light
     {
       background-color: fadeout(@accent-color, 70%) !important;
-      .css-175oi2r {
+      .css-175oi2r:not([role="checkbox"] *) {
         background-color: transparent !important;
       }
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- fixed unthemed "cancel" button and icon buttons in create post modal
- fixed switches

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
