### PR TITLE
fix(picrew): unthemed elements

### DIFF
--- a/styles/picrew/catppuccin.user.css
+++ b/styles/picrew/catppuccin.user.css
@@ -366,7 +366,11 @@
     }
     /* search page */
     .search-Form > fieldset {
-      background: @base !important;
+        background: @base !important;
+
+        .search-Form_Keyword .search-Form_KeywordInput:focus {
+          box-shadow: 0 0 0 1px @accent-color !important;
+        }
     }
     .search-Form_Keyword {
       .search-iconBox {

--- a/styles/picrew/catppuccin.user.css
+++ b/styles/picrew/catppuccin.user.css
@@ -141,6 +141,14 @@
     .header_bg[data-v-2537399f] {
       background: linear-gradient(90deg, @surface0, @base);
     }
+    /* MOBILE ONLY: ad for downloading the app */
+    .sitetop-appDL {
+      background: @mantle !important;
+
+      .sitetop-appDL_Header .sitetop-appDL_Title .fa {
+        color: @accent-color !important;
+      }
+    }
     /* "Featured Tags" section - directly above Discovery */
     .sitetop-tags {
       background: @mantle !important;

--- a/styles/picrew/catppuccin.user.css
+++ b/styles/picrew/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Picrew Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/picrew
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/picrew
-@version 0.0.4
+@version 0.0.5
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/picrew/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apicrew
 @description Soothing pastel theme for Picrew
@@ -140,6 +140,22 @@
     /* "welcome creator" page (main page) */
     .header_bg[data-v-2537399f] {
       background: linear-gradient(90deg, @surface0, @base);
+    }
+    /* "Featured Tags" section - directly above Discovery */
+    .sitetop-tags {
+      background: @mantle !important;
+
+      .sitetop-tags_Header .sitetop-tags_Title .fa {
+        color: @accent-color !important;
+      }
+      .recommended-tag-list .recommended-tag-list-item a {
+        border-color: @accent-color !important;
+
+        /* tag icon before tag name */
+        &::before {
+          color: @accent-color !important;
+        }
+      }
     }
     /* "Discovery" section (image is lightbulb) */
     .sitetop-Discovery {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes a couple unthemed elements on the homepage (one of them only visible on mobile), and one on the search page.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
