### PR TITLE
fix(chatgpt): auth page background

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.3.5
+@version 0.3.6
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT
@@ -1032,6 +1032,7 @@
     }
 
     color: @text;
+    background-color: @base;
     caret-color: @text;
 
     a {
@@ -1040,7 +1041,9 @@
 
     body,
     .oai-header,
-    .login-container {
+    .oai-footer,
+    .login-container,
+    .main-container {
       background-color: @base;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Fixes the background of the auth page

## Before

![Screenshot 2024-11-20 at 23-50-27 Login - ChatGPT](https://github.com/user-attachments/assets/ae58511f-7342-4d70-b1e4-f2dbf9a9bf7b)

## After

![Screenshot 2024-11-20 at 23-50-52 Login - ChatGPT](https://github.com/user-attachments/assets/96b95ba3-bf7d-468f-967c-b1ef26b8ff12)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
