### PR TITLE
feat(microsoft-word): add apply to document option

### DIFF
--- a/styles/microsoft-word/catppuccin.user.less
+++ b/styles/microsoft-word/catppuccin.user.less
@@ -13,7 +13,8 @@
 @var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
-@var checkbox pageTheme "Enable Theme on Actual Page" 0
+
+@var checkbox applyToDocument "Apply Theme to Document" 0
 ==/UserStyle== */
 
 @-moz-document domain("live.com") {
@@ -179,10 +180,15 @@
       background-color: @mantle !important;
     }
 
-    & when (@pageTheme = 1) {
+    & when (@applyToDocument = 1) {
       .Page {
         background-color: @base !important;
         border-color: @surface1 !important;
+      }
+      span.NormalTextRun,
+      .FileMenuButtonPrimaryText,
+      [class="NewDocumentTemplateLabel"] {
+        color: @text !important;
       }
     }
 
@@ -381,14 +387,6 @@
     #GetAddins-label,
     #Editor-label {
       color: @subtext0 !important;
-    }
-
-    & when (@pageTheme = 1) {
-      span.NormalTextRun,
-      .FileMenuButtonPrimaryText,
-      [class="NewDocumentTemplateLabel"] {
-        color: @text !important;
-      }
     }
 
     svg {

--- a/styles/microsoft-word/catppuccin.user.less
+++ b/styles/microsoft-word/catppuccin.user.less
@@ -13,6 +13,7 @@
 @var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+@var checkbox pageTheme "Enable Theme on Actual Page" 0
 ==/UserStyle== */
 
 @-moz-document domain("live.com") {
@@ -178,9 +179,11 @@
       background-color: @mantle !important;
     }
 
-    .Page {
-      background-color: @base !important;
-      border-color: @surface1 !important;
+    & when (@pageTheme = 1) {
+      .Page {
+        background-color: @base !important;
+        border-color: @surface1 !important;
+      }
     }
 
     .Paragraph,
@@ -380,10 +383,12 @@
       color: @subtext0 !important;
     }
 
-    span.NormalTextRun,
-    .FileMenuButtonPrimaryText,
-    [class="NewDocumentTemplateLabel"] {
-      color: @text !important;
+    & when (@pageTheme = 1) {
+      span.NormalTextRun,
+      .FileMenuButtonPrimaryText,
+      [class="NewDocumentTemplateLabel"] {
+        color: @text !important;
+      }
     }
 
     svg {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
This adds an option to toggle the theme on the actual page.
Closes #1466 

![image](https://github.com/user-attachments/assets/86d397b2-f676-4597-86c8-264c9f5977d7)

Disabled:

![newoption](https://github.com/user-attachments/assets/e9a9a9f7-b148-4a5b-a05f-d9ee6da3c341)

Enabled:

![image](https://github.com/user-attachments/assets/d2dcd03e-8771-4c32-9bf7-483e19a89b71)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
