### PR TITLE
feat(vencord.dev): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -1030,6 +1030,13 @@ userstyles:
         > [!NOTE]
         > Set Twitter's built-in theme to **Lights out** with the blue accent. Also requires the [:has()](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) selector.
     current-maintainers: [*watatomo]
+  vencord.dev:
+    name: Vencord
+    categories: [social_networking]
+    color: pink
+    readme:
+      app-link: "https://vencord.dev/"
+    current-maintainers: [*comfysage]
   vercel:
     name: ["Vercel", "Next.js"]
     categories: [development]

--- a/styles/vencord.dev/catppuccin.user.css
+++ b/styles/vencord.dev/catppuccin.user.css
@@ -1,0 +1,124 @@
+/* ==UserStyle==
+@name Vencord Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/vencord.dev
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/vencord.dev
+@version 0.0.1
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/vencord.dev/catppuccin.user.css
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Avencord.dev
+@description Soothing pastel theme for Vencord
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain('vencord.dev') {
+  .dark[data-astro-cid-sckkx6r4] {
+    #catppuccin(@darkFlavor, @accentColor);
+  }
+  .light[data-astro-cid-sckkx6r4] {
+    #catppuccin(@lightFlavor, @accentColor);
+  }
+
+  #catppuccin(@lookup, @accent) {
+    @rosewater: @catppuccin[@@lookup][@rosewater];
+    @flamingo: @catppuccin[@@lookup][@flamingo];
+    @pink: @catppuccin[@@lookup][@pink];
+    @mauve: @catppuccin[@@lookup][@mauve];
+    @red: @catppuccin[@@lookup][@red];
+    @maroon: @catppuccin[@@lookup][@maroon];
+    @peach: @catppuccin[@@lookup][@peach];
+    @yellow: @catppuccin[@@lookup][@yellow];
+    @green: @catppuccin[@@lookup][@green];
+    @teal: @catppuccin[@@lookup][@teal];
+    @sky: @catppuccin[@@lookup][@sky];
+    @sapphire: @catppuccin[@@lookup][@sapphire];
+    @blue: @catppuccin[@@lookup][@blue];
+    @lavender: @catppuccin[@@lookup][@lavender];
+    @text: @catppuccin[@@lookup][@text];
+    @subtext1: @catppuccin[@@lookup][@subtext1];
+    @subtext0: @catppuccin[@@lookup][@subtext0];
+    @overlay2: @catppuccin[@@lookup][@overlay2];
+    @overlay1: @catppuccin[@@lookup][@overlay1];
+    @overlay0: @catppuccin[@@lookup][@overlay0];
+    @surface2: @catppuccin[@@lookup][@surface2];
+    @surface1: @catppuccin[@@lookup][@surface1];
+    @surface0: @catppuccin[@@lookup][@surface0];
+    @base: @catppuccin[@@lookup][@base];
+    @mantle: @catppuccin[@@lookup][@mantle];
+    @crust: @catppuccin[@@lookup][@crust];
+    @accent-color: @catppuccin[@@lookup][@@accent];
+
+    color-scheme: if(@lookup = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent-color, 30%);
+    }
+
+    --bg0: @crust;
+    --bg1: @base;
+    --bg2: @base;
+    --bg3: @surface0;
+    --bg4: @surface0;
+    --bg5: @surface1;
+    --bgDim: @mantle;
+    --bgCurrentWord: @base;
+    --bgDiffGreen: darken(@green, 5%);
+    --bgDiffBlue: darken(@blue, 5%);
+    --bgDiffRed: darken(@red, 5%);
+    --bgVisualYellow: darken(@yellow, 5%);
+    --bgVisualGreen: darken(@green, 5%);
+    --bgVisualBlue: darken(@blue, 5%);
+    --bgVisualRed: darken(@red, 5%);
+    --bgAccentYellow: darken(@yellow, 5%);
+    --bgAccentGreen: darken(@green, 5%);
+    --bgAccentRed: darken(@red, 5%);
+    --accentRed: @red;
+    --accentOrange: @peach;
+    --accentYellow: @yellow;
+    --accentGreen: @green;
+    --accentAqua: @teal;
+    --accentBlue: @blue;
+    --accentPurple: @mauve;
+    --accentPurpleRgb: #rgbify(@mauve) [];
+    --fg0: @text;
+    --fg0-muted: @subtext0;
+    --fg0-muted2: @subtext1;
+    --fg1: @text;
+    --grey0: @overlay0;
+    --grey1: @overlay1;
+    --grey2: @overlay2;
+
+    img[src="/assets/cute-logo.avif"] when (@lookup = latte) {
+      filter: saturate(210%) hue-rotate(120deg) brightness(82%) invert(110%);
+    }
+    img[src="/assets/cute-logo.avif"] when (@lookup=frappe) {
+      filter: saturate(58%) hue-rotate(-50deg) brightness(128%) contrast(70%)
+        sepia(15%) invert(2%);
+    }
+    img[src="/assets/cute-logo.avif"] when (@lookup=macchiato) {
+      filter: saturate(72%) hue-rotate(-55deg) brightness(110%) contrast(80%)
+        sepia(10%);
+    }
+    img[src="/assets/cute-logo.avif"] when (@lookup=mocha) {
+      filter: saturate(88%) hue-rotate(-65deg) brightness(105%) sepia(6%);
+    }
+  }
+}
+
+#rgbify(@color) {
+  @rgb-raw: red(@color), green(@color), blue(@color);
+}
+
+/* prettier-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+}
+
+// vim:ft=less

--- a/styles/vencord.dev/preview.webp
+++ b/styles/vencord.dev/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc23c38067574bffa59d96708e3c841c54bc1ec177debcd6149555ca9b08909c
+size 91734


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [Vencord](https://vencord.dev/) 🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

![preview-image](https://github.com/user-attachments/assets/6458cffa-a9bd-4885-b5eb-06862671d687)

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the
      [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml)
      file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.css` - all the CSS for the userstyle, based on the
        template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
