### PR TITLE
bsky: unthemed colors and some fixes

### DIFF
--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Bluesky Social Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/bsky
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/bsky
-@version 0.0.10
+@version 0.1.0
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bsky/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Absky
 @description Soothing pastel theme for Bluesky Social

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -2,8 +2,7 @@
 @name Bluesky Social Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/bsky
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/bsky
-@version 0.0.9
-@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bsky/catppuccin.user.css
+@version 0.0.10
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Absky
 @description Soothing pastel theme for Bluesky Social
 @author Catppuccin
@@ -95,9 +94,9 @@
       }
     }
 
-    /* some background color of follow button */
+    /* some background color of follow button + hover */
     [style*="background-color: rgb(241, 243, 245)"] {
-      background-color: @text !important;
+      background-color: if(@lookup = latte, @crust, @text) !important;
     }
 
     [style*="color: rgb(11, 15, 20)"] {
@@ -144,8 +143,15 @@
 
       /* notification count contrast fix, also chat message contrast fix (> div) */
       &[style*="color: rgb(241, 243, 245)"],
+      &[style*="color: rgb(255, 255, 255)"],
       > div {
         color: @crust !important;
+      }
+      
+      /* icon color fix */
+      path[fill="#ffffff"],
+      path[fill="hsl(211, 20%, 95.3%)"] {
+        fill: @crust!important;
       }
     }
 
@@ -170,6 +176,12 @@
     .r-wzwllv,
     div[style*="background-color: rgb(0, 133, 255)"] {
       background-color: @accent-color !important;
+      
+      /* notification count contrast fix, also chat message contrast fix (> div) */
+      &[style*="color: rgb(241, 243, 245)"],
+      > div {
+        color: @crust !important;
+      }
     }
 
     /* subscribe to labeler button */
@@ -564,6 +576,26 @@
     /* toggle circle */
     [style*="background-color: rgb(185, 185, 193)"] {
       background-color: @overlay2 !important;
+    }
+    
+    /* skeletons */
+    .r-kdyh1x, .r-cpet4d {
+      &[style*="background-color: rgb(20, 27, 35);"] {
+        background-color: @surface0 !important;
+      }
+    }
+    
+    /* thread lines */
+    div[style*="background-color: rgb(46, 63, 81)"].r-m5arl1 {
+      background: @surface1 !important;
+    }
+    
+    line[stroke="hsl(211, 28%, 24.8%)"][stroke-width="2"] {
+      stroke: @surface1 !important;
+    }
+
+    circle[fill="hsl(211, 28%, 24.8%)"][r="1.5"] {
+      fill: @surface1 !important;
     }
   }
 }

--- a/styles/bsky/catppuccin.user.css
+++ b/styles/bsky/catppuccin.user.css
@@ -3,6 +3,7 @@
 @namespace github.com/catppuccin/userstyles/styles/bsky
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/bsky
 @version 0.0.10
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/bsky/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Absky
 @description Soothing pastel theme for Bluesky Social
 @author Catppuccin


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- inappropriate hover in latte
- invisible text in latte
- icon contrast fix in mobile layout
- unthemed skeletons and thread lines

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
