### PR TITLE
fix(github): apply on image diffs

### DIFF
--- a/styles/github/catppuccin.user.css
+++ b/styles/github/catppuccin.user.css
@@ -15,7 +15,7 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document regexp("https:\/\/(gist\.)*github\.com(?!((\/.+?\/.+?\/commit\/[A-Fa-f0-9]+\.(patch|diff)$)|\/home$|\/features($|\/.*)|\/marketplace($|\?.*|\/.*)|\/organizations\/plan)).*$") {
+@-moz-document regexp("https:\/\/(gist\.)*github\.com(?!((\/.+?\/.+?\/commit\/[A-Fa-f0-9]+\.(patch|diff)$)|\/home$|\/features($|\/.*)|\/marketplace($|\?.*|\/.*)|\/organizations\/plan)).*$"), url-prefix("https://viewscreen.githubusercontent.com/diff/img") {
   [data-color-mode="auto"] {
     @media (prefers-color-scheme: light) {
       &[data-light-theme="light"] {


### PR DESCRIPTION
Closes #1477. Applies the theme on the image diff iframes, which is in light mode by default FYI. Could add a separate toggle if warranted to change the theme for this part specifically?