### PR TITLE
fix(wikipedia): text color of citation pop-up

### DIFF
--- a/styles/wikipedia/catppuccin.user.css
+++ b/styles/wikipedia/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 0.0.23
+@version 0.0.24
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -186,6 +186,7 @@
     .frb-form-wrapper,
     .mw-echo-ui-notificationItemWidget-content-message-header,
     .oo-ui-labelElement,
+    .reference-text,
     #contentSub:not(:empty) {
       color: @text !important;
     }


### PR DESCRIPTION
added `.reference-text` to color the text that appears when you hover a citation link

## 🔧 What does this fix? 🔧

Before:
![Screenshot from 2024-12-08 09-09-34](https://github.com/user-attachments/assets/71e51bc0-b5b5-48f9-9f17-42b69ce1db07)

After:
![Screenshot from 2024-12-08 09-09-50](https://github.com/user-attachments/assets/eb256856-fae7-4dfc-9f3c-addcc5c24360)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
