### PR TITLE
fix(youtube): texts of Live chat replay and AI-generated video summary

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.13
+@version 4.2.14
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -1125,6 +1125,22 @@
     /* Horizontal list arrows */
     .arrow.yt-horizontal-list-renderer {
       background: @surface0;
+    }
+
+    /* Live chat replay */
+    .YtVideoMetadataCarouselViewModelHost {
+      background-color: @surface0;
+
+      .YtCarouselTitleViewModelTitle,
+      .yt-core-attributed-string,
+      .yt-icon-shape {
+        color: @text;
+      }
+    }
+
+    /* AI-generated video summary */
+    .video-summary-content-view-model-wiz__paragraph {
+      color: @text;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Live chat replay
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/daaa1c36-d598-45c0-a7c3-f88d3c41b48d)|![image](https://github.com/user-attachments/assets/8d3fb978-aa16-4e37-8ae1-f0a076496263)|

reproduction link: https://www.youtube.com/watch?v=khCQSqv6380

AI-generated video summary
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/de5399bb-9139-4720-8cf5-da6112b44ff7)|![image](https://github.com/user-attachments/assets/f11bc17d-fb22-4f27-afdf-929cb1b6cc1b)|

reproduction link: https://www.youtube.com/watch?v=JTRs1hSoclY
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
