### PR TITLE
fix(stack-overflow): background image on crypto.stackexchange

### DIFF
--- a/styles/stack-overflow/catppuccin.user.css
+++ b/styles/stack-overflow/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Stack Overflow Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/stack-overflow
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/stack-overflow
-@version 0.2.1
+@version 0.2.2
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/stack-overflow/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Astack-overflow
 @description Soothing pastel theme for Stack Overflow
@@ -115,6 +115,10 @@ domain('superuser.com'), domain('mathoverflow.net'), domain('askubuntu.com'), do
       }
     }
 
+    & {
+      background-image: if(not (@lookup = latte), none);
+    }
+    
     &,
     * {
       --theme-background-color: @mantle;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Fixes the background image coming through on crypto.stackexchange.com: for Latte, we keep it, else set it to `none`.

| before |
|:-:|
|![image](https://github.com/user-attachments/assets/630bb466-e386-4907-9667-18f9ebabe673)|
| latte |
|![image](https://github.com/user-attachments/assets/405eff99-9c21-46f7-b30e-3bcabafd203e)|
| mocha |

| after |
|:-:|
|![image](https://github.com/user-attachments/assets/f291ecd2-e32c-42aa-93bb-e7e48983d7d0)|
| latte |
|![image](https://github.com/user-attachments/assets/dba0e01b-d978-4290-887d-9ebedafe614d)|
| mocha |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
