### PR TITLE
fix(chatgpt): login background is white

### DIFF
--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name ChatGPT Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/chatgpt
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/chatgpt
-@version 0.3.6
+@version 0.3.7
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/chatgpt/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Achatgpt
 @description Soothing pastel theme for ChatGPT

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -1024,6 +1024,10 @@
       background-color: fade(@accent-color, 30%);
     }
 
+    body {
+      background-color: @base !important
+    }
+
     input,
     textarea {
       &::placeholder {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The login page has an inline style[^1] that sets the background colour to white (`<body class="_brandingChatGPT_1x8df_1" style="background-color: rgb(255, 255, 255);" >`.

This changes it to use the base theme colour.

| before |
|:-:|
|![Screenshot From 2024-12-13 21-49-05](https://github.com/user-attachments/assets/a0f997a2-87e7-4a0b-bd8e-3e1fec5a18f4)|
| latte |
|![Screenshot From 2024-12-13 21-48-52](https://github.com/user-attachments/assets/1aaee8fd-f6cd-42a8-8b7f-4719d9268a0a)|
| mocha |

| after |
|:-:|
|![Screenshot From 2024-12-13 21-49-20](https://github.com/user-attachments/assets/1fe66bd9-77ae-4cfd-b8f9-a355b97f65cf)|
| latte |
|![Screenshot From 2024-12-13 21-49-35](https://github.com/user-attachments/assets/feb24ce3-d30a-4f07-b11e-20e751c24241)|
| mocha |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.

[^1]: this shows up as inline in my browser console, their actual source is just...i can't even describe it
