### PR TITLE
refactor(treewide): cleanup and use rgbify mixin

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,7 +16,7 @@
 
     - [Images and SVGs](./guide/images-and-svgs.md)
     - [Syntax highlighting](./guide/syntax-highlighting.md)
-    - [Extracting RGB values](./guide/rgb-values.md)
+    - [Obtaining raw color values](./guide/raw-color-values.md)
 
   - [Tutorials](./tutorials/README.md)
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -4,4 +4,4 @@
 
 - [Images and SVGs](./images-and-svgs.md)
 - [Syntax highlighting](./syntax-highlighting.md)
-- [Extracting RGB values](./rgb-values.md)
+- [Obtaining raw color values](./raw-color-values.md)

--- a/docs/guide/raw-color-values.md
+++ b/docs/guide/raw-color-values.md
@@ -1,0 +1,29 @@
+## Obtaining RGB values
+
+You can use the following snippet to get the raw RGB values from a color.
+
+```less
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
+}
+```
+
+```less
+--ctp-base: #rgbify(@base) []; // -> 30, 30, 46
+```
+
+## Obtaining HSL values
+
+You can use the following snippet to get the raw HSL values from a color.
+
+```less
+#hslify(@color) {
+  @raw: e(
+    %("%s, %s%, %s%", hue(@color), saturation(@color), lightness(@color))
+  );
+}
+```
+
+```less
+--ctp-base: #hslify(@base) []; // -> 240, 21.052631578947366%, 14.901960784313726%
+```

--- a/docs/guide/rgb-values.md
+++ b/docs/guide/rgb-values.md
@@ -1,9 +1,0 @@
-You can use the following snippet to get the raw RGB values from a color.
-
-```less
-#rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
-}
-
---ctp-base: #rgbify(@base) []; // -> 30, 30, 46
-```

--- a/styles/amplenote/catppuccin.user.css
+++ b/styles/amplenote/catppuccin.user.css
@@ -235,7 +235,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/anilist/catppuccin.user.css
+++ b/styles/anilist/catppuccin.user.css
@@ -746,7 +746,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/chatgpt/catppuccin.user.css
+++ b/styles/chatgpt/catppuccin.user.css
@@ -1228,7 +1228,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/crates.io/catppuccin.user.css
+++ b/styles/crates.io/catppuccin.user.css
@@ -311,7 +311,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/elk/catppuccin.user.css
+++ b/styles/elk/catppuccin.user.css
@@ -71,7 +71,7 @@
     --c-border: @surface0 !important;
     --c-border-dark: @surface1 !important;
     --c-bg-base: @base !important;
-    --rgb-bg-base: red(@mantle), green(@mantle), blue(@mantle) !important;
+    --rgb-bg-base: #rgbify(@mantle) [] !important;
     --c-bg-active: @surface0 !important;
     --c-bg-code: @surface0 !important;
     --c-bg-selection: @accent-color !important;
@@ -96,61 +96,41 @@
     }
 
     ::-webkit-scrollbar-thumb {
-      background: alpha(@surface1, 0.7);
+      background: fade(@surface1, 70%);
     }
 
     ::-webkit-scrollbar-thumb:hover {
-      background: alpha(@surface1, 0.8);
+      background: fade(@surface1, 80%);
     }
 
     [text-red],
     [text-red-600],
     [hover^="text-red"]:hover {
-      color: rgbA(red(@red), green(@red), blue(@red), var(--un-text-opacity));
+      color: rgba(#rgbify(@red) [], var(--un-text-opacity));
     }
 
     [text-blue],
     [hover^="text-blue"]:hover {
-      color: rgbA(
-        red(@blue),
-        green(@blue),
-        blue(@blue),
-        var(--un-text-opacity)
-      );
+      color: rgba(#rgbify(@blue) [], var(--un-text-opacity));
     }
 
     [text-green],
     [hover^="text-green"]:hover {
-      color: rgbA(
-        red(@green),
-        green(@green),
-        blue(@green),
-        var(--un-text-opacity)
-      );
+      color: rgba(#rgbify(@green) [], var(--un-text-opacity));
     }
 
     [text-yellow],
     [hover^="text-yellow"]:hover {
-      color: rgbA(
-        red(@yellow),
-        green(@yellow),
-        blue(@yellow),
-        var(--un-text-opacity)
-      );
+      color: rgba(#rgbify(@yellow) [], var(--un-text-opacity));
     }
 
     [text-purple],
     [hover^="text-purple"]:hover {
-      color: rgbA(
-        red(@lavender),
-        green(@lavender),
-        blue(@lavender),
-        var(--un-text-opacity)
-      );
+      color: rgba(#rgbify(@lavender) [], var(--un-text-opacity));
     }
 
     [group-hover^="bg-purple/10"]:hover {
-      background-color: alpha(@lavender, 0.1);
+      background-color: fade(@lavender, 10%);
     }
 
     .filter-saturate-0,
@@ -158,6 +138,10 @@
       filter: none;
     }
   }
+}
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/google-drive/catppuccin.user.css
+++ b/styles/google-drive/catppuccin.user.css
@@ -29,10 +29,6 @@
     }
   }
 
-  #rgbify(@color) {
-    @rgb-raw: red(@color), green(@color), blue(@color);
-  }
-
   #catppuccin(@lookup, @accent) {
     @rosewater: @catppuccin[@@lookup][@rosewater];
     @flamingo: @catppuccin[@@lookup][@flamingo];
@@ -676,6 +672,10 @@
       fill: @green;
     }
   }
+}
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/google-gemini/catppuccin.user.css
+++ b/styles/google-gemini/catppuccin.user.css
@@ -413,7 +413,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/google/catppuccin.user.css
+++ b/styles/google/catppuccin.user.css
@@ -956,11 +956,7 @@
       background-color: @surface0;
     }
     .language_list_languages.tw-ll-top::after {
-      background: linear-gradient(
-        to bottom,
-        rgba(red(@base), green(@base), blue(@base), 0),
-        rgba(red(@base), green(@base), blue(@base), 1)
-      );
+      background: linear-gradient(to bottom, transparent, @base);
     }
     .HsZQAe {
       border-bottom-color: @surface2;
@@ -2421,6 +2417,10 @@
       }
     }
   }
+}
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/instagram/catppuccin.user.css
+++ b/styles/instagram/catppuccin.user.css
@@ -852,7 +852,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/lastfm/catppuccin.user.css
+++ b/styles/lastfm/catppuccin.user.css
@@ -1730,7 +1730,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color) green(@color) blue(@color);
+  @rgb: red(@color) green(@color) blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/lemmy/catppuccin.user.css
+++ b/styles/lemmy/catppuccin.user.css
@@ -249,7 +249,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/mdbook/catppuccin.user.css
+++ b/styles/mdbook/catppuccin.user.css
@@ -155,7 +155,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/namemc/catppuccin.user.css
+++ b/styles/namemc/catppuccin.user.css
@@ -95,10 +95,6 @@
       --bs-btn-active-color: @hover;
     }
 
-    #rgbify(@color) {
-      @rgb-raw: red(@color), green(@color), blue(@color);
-    }
-
     --bs-body-color: @text;
     --bs-body-color-rgb: #rgbify(@text) [];
     --bs-body-bg: @base;
@@ -565,6 +561,10 @@
       }
     }
   }
+}
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/nitter/catppuccin.user.css
+++ b/styles/nitter/catppuccin.user.css
@@ -150,7 +150,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color) green(@color) blue(@color);
+  @rgb: red(@color) green(@color) blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/ollama/catppuccin.user.css
+++ b/styles/ollama/catppuccin.user.css
@@ -277,7 +277,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/perplexity/catppuccin.user.css
+++ b/styles/perplexity/catppuccin.user.css
@@ -435,7 +435,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color) green(@color) blue(@color);
+  @rgb: red(@color) green(@color) blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/pronouns.cc/catppuccin.user.css
+++ b/styles/pronouns.cc/catppuccin.user.css
@@ -248,7 +248,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/pronouns.page/catppuccin.user.css
+++ b/styles/pronouns.page/catppuccin.user.css
@@ -470,7 +470,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -221,7 +221,8 @@
       --interaction-default: transparent;
       --interaction-default-hover: fadeout(@overlay1, 80%);
       --interaction-default-active: fadeout(@overlay1, 60%);
-      --shadow-primary-color: #rgbify(@accent-color) [];
+      --shadow-primary-color: red(@accent-color) green(@accent-color)
+        blue(@accent-color);
       --shadow-norm-opacity: 0.5;
       --shadow-raised-opacity: 1;
       --shadow-lifted-opacity: 0.75;
@@ -274,10 +275,6 @@
       }
     }
   }
-}
-
-#rgbify(@color) {
-  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/proton/catppuccin.user.css
+++ b/styles/proton/catppuccin.user.css
@@ -221,8 +221,7 @@
       --interaction-default: transparent;
       --interaction-default-hover: fadeout(@overlay1, 80%);
       --interaction-default-active: fadeout(@overlay1, 60%);
-      --shadow-primary-color: red(@accent-color) green(@accent-color)
-        blue(@accent-color);
+      --shadow-primary-color: #rgbify(@accent-color) [];
       --shadow-norm-opacity: 0.5;
       --shadow-raised-opacity: 1;
       --shadow-lifted-opacity: 0.75;
@@ -275,6 +274,10 @@
       }
     }
   }
+}
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -70,7 +70,7 @@
     body > main#root * {
       --sigMain: @base;
       --sigSurface: @mantle;
-      --sigSurfaceRGB: red(@mantle) green(@mantle) blue(@mantle);
+      --sigSurfaceRGB: #rgbify(@mantle) [];
       --sigAboveSurface: @crust;
       --sigSurfaceDown: @base;
       --sigSubscreen: @crust;
@@ -160,6 +160,10 @@
       --sigColorAlwaysWhite: @surface0;
     }
   }
+}
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/snapchat-web/catppuccin.user.css
+++ b/styles/snapchat-web/catppuccin.user.css
@@ -70,7 +70,7 @@
     body > main#root * {
       --sigMain: @base;
       --sigSurface: @mantle;
-      --sigSurfaceRGB: #rgbify(@mantle) [];
+      --sigSurfaceRGB: red(@mantle) green(@mantle) blue(@mantle);
       --sigAboveSurface: @crust;
       --sigSurfaceDown: @base;
       --sigSubscreen: @crust;
@@ -160,10 +160,6 @@
       --sigColorAlwaysWhite: @surface0;
     }
   }
-}
-
-#rgbify(@color) {
-  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/stack-overflow/catppuccin.user.css
+++ b/styles/stack-overflow/catppuccin.user.css
@@ -485,7 +485,7 @@ domain('superuser.com'), domain('mathoverflow.net'), domain('askubuntu.com'), do
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/substack/catppuccin.user.css
+++ b/styles/substack/catppuccin.user.css
@@ -295,7 +295,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/trinket/catppuccin.user.css
+++ b/styles/trinket/catppuccin.user.css
@@ -1321,7 +1321,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/vercel/catppuccin.user.css
+++ b/styles/vercel/catppuccin.user.css
@@ -319,7 +319,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color), green(@color), blue(@color);
+  @rgb: red(@color), green(@color), blue(@color);
 }
 
 /* prettier-ignore */

--- a/styles/whatsapp-web/catppuccin.user.css
+++ b/styles/whatsapp-web/catppuccin.user.css
@@ -673,7 +673,7 @@
 }
 
 #rgbify(@color) {
-  @rgb-raw: red(@color) green(@color) blue(@color);
+  @rgb: red(@color) green(@color) blue(@color);
 }
 
 /* prettier-ignore */


### PR DESCRIPTION
Adds a new `hslify` mixin to match the functionality of the `rgbify` mixin (extract color values) - not used yet but I did needeto use it for https://github.com/catppuccin/userstyles/pull/1510. Also simplifies the existing `rgbify` mixin and inserts it in places where we should be using it (_technically_ might not be the exact same since the comma vs space separated rgb syntax is weird, will have to check).