### PR TITLE
fix(youtube): shorts titles and views

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.16
+@version 4.2.17
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -1072,11 +1072,13 @@
     }
 
     /* Shorts titles and views on homepage */
-    .ShortsLockupViewModelHostOutsideMetadataEndpoint {
-      color: @text;
+    .shortsLockupViewModelHostOutsideMetadataTitle {
+      .yt-core-attributed-string {
+        color: @text;
+      }
     }
-    .ShortsLockupViewModelHostOutsideMetadataSubhead {
-      color: @subtext1;
+    .shortsLockupViewModelHostOutsideMetadataSubhead {
+      color: @subtext0;
     }
 
     /* Buy super thanks bar */

--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -1072,10 +1072,8 @@
     }
 
     /* Shorts titles and views on homepage */
-    .shortsLockupViewModelHostOutsideMetadataTitle {
-      .yt-core-attributed-string {
-        color: @text;
-      }
+    .shortsLockupViewModelHostOutsideMetadataEndpoint {
+      color: @text;
     }
     .shortsLockupViewModelHostOutsideMetadataSubhead {
       color: @subtext0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Fixes shorts titles and views on the home page.
|Before|After|Normal Videos|
|-|-|-|
|![image](https://github.com/user-attachments/assets/c05bc3ae-00c0-48f0-af92-a02c8838415f)|![image](https://github.com/user-attachments/assets/958da0af-6362-492d-a01c-5101f6f05b10)|![image](https://github.com/user-attachments/assets/e70c2eb7-95af-4a7f-a0c4-d7cf08234b46)|
<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
