### PR TITLE
fix(youtube): description how this was made section

### DIFF
--- a/styles/youtube/catppuccin.user.css
+++ b/styles/youtube/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 4.2.17
+@version 4.2.18
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -789,6 +789,15 @@
       .YtwCourseProgressViewModelHostProgressBarFill {
         background-color: @text;
       }
+    }
+
+    .ytwHowThisWasMadeSectionViewModelSectionTitle,
+    .ytwHowThisWasMadeSectionViewModelBodyHeader {
+      color: @text;
+    }
+      
+    .ytwHowThisWasMadeSectionViewModelBodyText {
+      color: @subtext0;
     }
 
     /* Thumbnails */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the unstyled 'How this was made' section in the description box.

| **Before**                    | **After**                 |
| ----------------------------- | ------------------------- |
| ![image](https://github.com/user-attachments/assets/a3fb26b0-843e-4d60-961c-51bfaa154b74) | ![image](https://github.com/user-attachments/assets/9d0d4919-c21b-475d-84d3-8abe54248507) |

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
