### PR TITLE
docs(README.md): remove mention of adding yourself as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ To get started contributing to catppuccin/userstyles, see [Contributing](docs/CO
 ## 🖌 Userstyles
 
 > [!IMPORTANT]
-> Userstyles labeled with the "🚧" emoji are looking for maintainers, and may
-> not work as intended. Contributions are still welcome and encouraged. If you
-> would like to become a maintainer, follow the instructions outlined in
-> "[Adding yourself as a maintainer](docs/userstylesyml.md#adding-yourself-as-a-maintainer)."
+> Userstyles labeled with the "🚧" emoji are looking for maintainers, and may not work as intended. Contributions are still welcome and encouraged.
 
 <!-- AUTOGEN:USERSTYLES START -->
 <!-- the following section is auto-generated, do not edit -->


### PR DESCRIPTION
We don't want to encourage new contributors to immediately become maintainers. We can suggest the idea of becoming a maintainer to active contributors when the time is right imo.