### PR TITLE
fix(hacker-news): header, logo, and story ranking color

### DIFF
--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -151,6 +151,11 @@
       color: @lavender;
     }
 
+    font[color="#005a00"],
+    font[color="#be2828"] {
+      color: @lavender;
+    }
+
     /* Comment text */
     .commtext {
       color: @text;

--- a/styles/hacker-news/catppuccin.user.css
+++ b/styles/hacker-news/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name Hacker News Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/hacker-news
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news
-@version 1.0.3
+@version 1.0.4
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hacker-news/catppuccin.user.css
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahacker-news
 @description Soothing pastel theme for Hacker News
@@ -91,25 +91,29 @@
         color: @crust !important;
       }
 
-      img[src="y18.svg"] {
-        @svg: escape(
-          '<svg height="18" viewBox="4 4 188 188" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M4 4h188v188H4z" fill="@{accent-color}"/><path d="M73.252 45.01 96 92.401l22.748-47.391h19.566l-34.324 64.487v41.493H88.01v-41.493L53.686 45.01z" fill="@{crust}"/></svg>'
-        );
-        content: url("data:image/svg+xml,@{svg}");
-        border-color: @crust !important;
-      }
-
       [color="#ffffff"] {
         color: @crust;
       }
     }
 
-    td[bgcolor="#ffffaa"] {
-      background-color: @yellow;
+    td[bgcolor="#cc1010"] {
+      background-color: @accent-color;
 
-      td {
-        color: @crust;
+      a {
+      color: @crust;
+        &:hover {
+          color: @surface2;
+        }
       }
+    }
+
+    /* Header logo */ 
+    img[src="y18t.svg"] {
+        @svg: escape(
+          '<svg height="18" viewBox="4 4 188 188" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M4 4h188v188H4z" fill="@{accent-color}"/><path d="M73.252 45.01 96 92.401l22.748-47.391h19.566l-34.324 64.487v41.493H88.01v-41.493L53.686 45.01z" fill="@{crust}"/></svg>'
+        );
+      content: url("data:image/svg+xml,@{svg}");
+      border-color: @crust !important;
     }
 
     .subtext,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixed the header and logo to use the accent color and corrected the story ranking number color. 
It appeared as expected before, but I believe recent changes to the site caused it to break.

| **Before**                    | **After**                 |
| ----------------------------- | ------------------------- |
| ![image](https://github.com/user-attachments/assets/f6039f6e-cc0e-4e06-b9d8-551b4d66225b) | ![image](https://github.com/user-attachments/assets/3e405236-c4c0-42da-93c4-ecf0200084cb) |

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [X] I have updated the version appropriately in the `==UserStyle==` header of the `catppuccin.user.css` file.
