### PR TITLE
chore(.vscode/settings.json): set deno as default formatter project-wide

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
   "deno.enable": true,
-
-  "[typescript][javascript][less][markdown][json]": {
-    "editor.defaultFormatter": "denoland.vscode-deno"
-  },
-
+  "editor.defaultFormatter": "denoland.vscode-deno",
   "markdown.extension.toc.updateOnSave": false
 }


### PR DESCRIPTION
Not sure why I didn't do this before lol. I forgot to add Yaml to the list of languages and thought we might as well just do everything in case I missed another and for the future.