### PR TITLE
fix(hackage): make headings text

### DIFF
--- a/styles/hackage/catppuccin.user.less
+++ b/styles/hackage/catppuccin.user.less
@@ -110,6 +110,7 @@
     .section5,
     .section6 {
       color: @text;
+      filter: none;
     }
 
     .collapser::before,

--- a/styles/hackage/catppuccin.user.less
+++ b/styles/hackage/catppuccin.user.less
@@ -109,8 +109,7 @@
     .section4,
     .section5,
     .section6 {
-      color: overlay(@accent, @surface0);
-      filter: none;
+      color: @text;
     }
 
     .collapser::before,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-31 at 20 38 08](https://github.com/user-attachments/assets/2176cc57-34b7-45d2-8a22-c6d2e9958ddf) | ![CleanShot 2024-12-31 at 20 37 26](https://github.com/user-attachments/assets/334b7285-e6fd-4ea4-9f1b-d8bb012d2edc) |
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
