### PR TITLE
fix(github): github actions check running indicator

### DIFF
--- a/styles/github/catppuccin.user.less
+++ b/styles/github/catppuccin.user.less
@@ -617,10 +617,10 @@
     }
 
     /* Pull request check in progress indicator */
-    [stroke="#DBAB0A"] {
+    [stroke="#DBAB0A" i] {
       stroke: fade(@yellow, 70%) !important;
     }
-    [fill="#DBAB0A"] {
+    [fill="#DBAB0A" i] {
       fill: @yellow !important;
     }
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

They changed the inline hex values from uppercase to lowercase after #1396 lol. This just makes it case insensitive, just checked on the last merged PR + commit.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
