### PR TITLE
fix(scripts/lint): userstyle names can include dashes

### DIFF
--- a/scripts/lint/main.ts
+++ b/scripts/lint/main.ts
@@ -14,7 +14,7 @@ import stylelintConfig from "../../.stylelintrc.js";
 
 const args = parseArgs(Deno.args, { boolean: ["fix"] });
 const userstyle = args._[0]?.toString().match(
-  /(?<base>styles\/)?(?<userstyle>[a-z0-9_\.]+)(?<trailing>\/)?(?<file>catppuccin\.user\.less)?/,
+  /(?<base>styles\/)?(?<userstyle>[a-z0-9_\-.]+)(?<trailing>\/)?(?<file>catppuccin\.user\.less)?/,
 )?.groups?.userstyle;
 const stylesheets = userstyle
   ? [path.join(REPO_ROOT, "styles", userstyle, "catppuccin.user.less")]


### PR DESCRIPTION
This regex is kinda stupid lol.