### PR TITLE
fix(github): view image file background

### DIFF
--- a/styles/github/catppuccin.user.less
+++ b/styles/github/catppuccin.user.less
@@ -18,7 +18,7 @@
 @-moz-document regexp(
     "https:\/\/(gist\.)*github\.com(?!((\/.+?\/.+?\/commit\/[A-Fa-f0-9]+\.(patch|diff)$)|\/home$|\/features($|\/.*)|\/marketplace($|\?.*|\/.*)|\/organizations\/plan)).*$"
   ),
-  url-prefix("https://viewscreen.githubusercontent.com/diff/img") {
+  regexp("https:\/\/viewscreen\.githubusercontent\.com(\/diff\/img|\/view).*") {
   [data-color-mode="auto"] {
     @media (prefers-color-scheme: light) {
       &[data-light-theme="light"] {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

See https://github.com/uncenter/flake/blob/main/.github/assets/nix.svg, the background around the image was previously unthemed.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
