### PR TITLE
fix(twitch): automod message alert

### DIFF
--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -995,12 +995,12 @@
     }
 
     .chat-line__message--alert {
-      border-color: @peach !important;
+      border-color: @red !important;
       background-color: @base !important;
 
       .text-fragment--moderated-highlight {
         color: @text !important;
-        background-color: fade(@peach, 30%) !important;
+        background-color: fade(@red, 30%) !important;
       }
     }
   }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -993,6 +993,16 @@
         color: @text !important;
       }
     }
+
+    .chat-line__message--alert {
+      border-color: @peach !important;
+      background-color: @base !important;
+
+      .text-fragment--moderated-highlight {
+        color: @text !important;
+        background-color: fade(@peach, 30%) !important;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed AutoMod alerts in chat.
Before | After
---------- | ----------
![2025-01-05-223501_hyprshot](https://github.com/user-attachments/assets/c5cd1b90-f04b-4fd1-b49a-7195e571a5f7) |![2025-01-05-224925_hyprshot](https://github.com/user-attachments/assets/3ddb9d01-d930-43b7-b21e-bb999850c869)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
