### PR TITLE
fix(google): unthemed info cards

### DIFF
--- a/styles/google/catppuccin.user.less
+++ b/styles/google/catppuccin.user.less
@@ -2258,6 +2258,11 @@
     .SU02Qd g-inner-card {
       background-color: @surface0 !important;
     }
+    // small info cards list
+    .gEYEQc.x5W9xd.qYvl9c.klitem {
+      background-color: @base !important;
+      border-color: @surface1 !important; 
+    }
     color: @subtext0;
   }
   @media (prefers-color-scheme: light) {

--- a/styles/google/catppuccin.user.less
+++ b/styles/google/catppuccin.user.less
@@ -2246,6 +2246,18 @@
     .jfk-radiobutton-label {
       color: @subtext1;
     }
+    // large info cards
+    .Qc895c, 
+    .Utq4Cb.PZPZlf {
+      background-color: @surface0 !important;
+    }
+    .Qc895c div, 
+    .Utq4Cb.PZPZlf div {
+      color: @text !important;
+    }
+    .SU02Qd g-inner-card {
+      background-color: @surface0 !important;
+    }
     color: @subtext0;
   }
   @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes some unthemed cards, including release info and genre info cards, which mainly consist of two types:

- [fix: large info cards](https://github.com/catppuccin/userstyles/commit/858d3fba5ba3d71ea4fed949a1b0c2c2f352cc5e)
- [fix: small info cards](https://github.com/catppuccin/userstyles/commit/cfa944734be17df56dbcceaf58c6461be0992a40)

## Screenshots

|**Before|**After|
|--------|-------|
|![image](https://github.com/user-attachments/assets/c7fe5271-555f-47e4-a920-c6694df5472c)|![image](https://github.com/user-attachments/assets/95248eb0-db5f-4bf6-8455-51688f36be66)|
|![image](https://github.com/user-attachments/assets/711d0d13-f092-4d22-b43d-3648f98a9e3a)|![image](https://github.com/user-attachments/assets/b61dad77-0e11-4e5a-ac5a-665cf5c7e0e3)|
|![image](https://github.com/user-attachments/assets/599f958c-61d6-407a-8e39-9a67b84bf374)|![image](https://github.com/user-attachments/assets/7802a90d-deb6-4590-a3a6-73269ab8ce2f)|
|![image](https://github.com/user-attachments/assets/9a4ec7b3-992d-43e3-bf10-e180407c5b4d)|![image](https://github.com/user-attachments/assets/602ae4cb-31fe-4e09-9d7e-c67f37159cd5)|
|![image](https://github.com/user-attachments/assets/909e1d2a-f146-4765-8d3f-9326e2c5de1f)|![image](https://github.com/user-attachments/assets/5cf23118-ea19-410f-bb3b-d9925e892729)|

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
