### PR TITLE
fix(chatgpt): limit alert bg and middle pricing panel

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -386,7 +386,7 @@
     }
 
     .border-green-600 {
-      border-color: @green;
+      border-color: @accent;
     }
 
     .border-orange-400 {
@@ -613,10 +613,6 @@
       background-color: fade(lighten(@green, 10%), 10%);
     }
 
-    .bg-green-600 {
-      background-color: @green;
-    }
-
     .bg-orange-500 {
       background-color: mix(@yellow, @red);
     }
@@ -790,7 +786,7 @@
     }
 
     .text-green-600 {
-      color: @green;
+      color: @accent;
     }
 
     .text-green-700 {

--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -609,6 +609,10 @@
       background-color: fade(lighten(@green, 10%), 10%);
     }
 
+    .bg-green-600 {
+      background-color: fade(@accent, 10%);
+    }
+
     .bg-orange-500 {
       background-color: mix(@yellow, @red);
     }

--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -414,10 +414,6 @@
     }
 
     /* Backgrounds */
-    .bg-token-main-surface-primary {
-      background-color: var(--main-surface-primary);
-    }
-
     .\!bg-brand-purple {
       background-color: @accent !important;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the backgrounds of limit alert and middle pricing panel (which is on the upgrade plan page)

|**Before**|**After**|
|----------|---------|
|![image](https://github.com/user-attachments/assets/fc4ba007-5ba0-47a5-ad62-fe409cccb6aa)|![image](https://github.com/user-attachments/assets/a26ca0eb-2d03-430a-9e64-531b4f5bf16f)|
|![image](https://github.com/user-attachments/assets/4e96b1e0-07b4-4887-a028-de33adc2280a)|![image](https://github.com/user-attachments/assets/876ace73-9515-435b-a777-75bf0f39f468)|

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
