### PR TITLE
fix(github): adjust matcher from `regexp` to generic `domain`

### DIFF
--- a/styles/github/catppuccin.user.less
+++ b/styles/github/catppuccin.user.less
@@ -18,7 +18,7 @@
 @-moz-document regexp(
     "https:\/\/(gist\.)*github\.com(?!((\/.+?\/.+?\/commit\/[A-Fa-f0-9]+\.(patch|diff)$)|\/home$|\/features($|\/.*)|\/marketplace($|\?.*|\/.*)|\/organizations\/plan)).*$"
   ),
-  regexp("https:\/\/viewscreen\.githubusercontent\.com(\/diff\/img|\/view).*") {
+  domain("viewscreen.githubusercontent.com") {
   [data-color-mode="auto"] {
     @media (prefers-color-scheme: light) {
       &[data-light-theme="light"] {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Just themes the whole domain, I don't think this will cause any issues.
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
