### PR TITLE
docs: improve unmaintained notes & emojis in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To get started contributing to catppuccin/userstyles, see [Contributing](docs/CO
 ## 🖌 Userstyles
 
 > [!IMPORTANT]
-> Userstyles labeled with the "🚧" emoji are looking for maintainers, and may not work as intended. Contributions are still welcome and encouraged.
+> Userstyles labeled with the "❤️‍🩹" emoji lack maintainers, and may not work as intended. Contributions are still welcome and encouraged!
 
 <!-- AUTOGEN:USERSTYLES START -->
 <!-- The following section is auto-generated, do not edit. -->

--- a/scripts/generate/readme-repo.ts
+++ b/scripts/generate/readme-repo.ts
@@ -48,7 +48,7 @@ export async function generateMainReadme(
 <summary>{{emoji}} {{name}}</summary>
 
 {{#each ports}}
-- {{#unless maintained}}🚧 {{/unless}}[{{#each name}}{{ this }}{{#unless @last}}, {{/unless}}{{/each}}]({{ path }})
+- {{#unless maintained}}❤️‍🩹 {{/unless}}[{{#each name}}{{ this }}{{#unless @last}}, {{/unless}}{{/each}}]({{ path }})
 {{/each}}
 
 </details>

--- a/scripts/generate/templates/userstyle.md
+++ b/scripts/generate/templates/userstyle.md
@@ -36,8 +36,8 @@
 - [{{name}}]({{url}})
 {{/each}}
 {{else}}
-## 🚧 Looking for Maintainers 🚧
-- If you are interested in maintaining this userstyle, please raise a **Pull Request** and add yourself into the `current-maintainers` array in the `userstyles.yml` file.
+## ❤️‍🩹 Unmaintained
+This userstyle currently lacks maintainers, and may not work correctly. Please feel free to contribute for any issues you find!
 {{/if}}
 
 {{#if collaborators.pastMaintainers}}


### PR DESCRIPTION
Importantly this removes the note about adding yourself as a maintainer - I don't think we want to encourage this. I also decided to change the emoji from the foreboding caution gate emoji to this more fitting broken(?) heart emoji, in line with the current/past maintainers emojis, because userstyles that don't have maintainers can still very well be perfectly fine/working correctly despite that.