### PR TITLE
feat(cobalt): accent-colored active sidebar tab

### DIFF
--- a/styles/cobalt/catppuccin.user.less
+++ b/styles/cobalt/catppuccin.user.less
@@ -132,6 +132,10 @@
     #cobalt-logo path {
       fill: @text;
     }
+
+    .sidebar-tab.active {
+      background-color: @accent !important;
+    }
   }
 }
 


### PR DESCRIPTION
Adds some more variety to the mostly monochrome site with this. Fixes #1573?