### PR TITLE
fix(gmail): search bar and header icons

### DIFF
--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -172,6 +172,10 @@
         color: @text;
       }
     }
+    /* Search mail input on focus */
+    .gb_hd.gb_id {
+      background-color: @base;
+    }
     /* Active search / filter modal */
     .gssb_c {
       /* Icons */

--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -162,7 +162,7 @@
     }
     /* Search mail input */
     .gb_Kc .gb_hd {
-      background-color: @base;
+      background-color: @surface1;
 
       .gb_je,
       .gb_qe,

--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -152,7 +152,7 @@
       background-color: @mantle;
     }
     /* Header icons */
-    .gb_Lc svg,
+    .gb_Kc svg,
     .gb_Pc.gb_Uc svg,
     .gb_Lc .gb_rd .gb_sd,
     .gb_Lc .gb_rd .gb_Kc,
@@ -161,10 +161,13 @@
       color: @text;
     }
     /* Search mail input */
-    .gb_Lc .gb_hd {
-      background-color: @crust;
+    .gb_Kc .gb_hd {
+      background-color: @surface1;
 
       .gb_je,
+      .gb_qe,
+      .gsan_a,
+      .gsas_a,
       svg {
         color: @text;
       }

--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -162,7 +162,7 @@
     }
     /* Search mail input */
     .gb_Kc .gb_hd {
-      background-color: @surface1;
+      background-color: @base;
 
       .gb_je,
       .gb_qe,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Updates the class for header which fixes the search bar input background and header icons (top-right).

|**Before**|**After**|
|----------|---------|
|![image](https://github.com/user-attachments/assets/eb28fe58-1a46-49e1-ba77-bb4fa7686979)|![image](https://github.com/user-attachments/assets/0b232f39-8893-4085-942a-cbd527db5ae1)|
|![Screenshot 2025-01-15 195207](https://github.com/user-attachments/assets/5a0f4c5d-0dc2-4f4a-bc7b-ea1a95302810)|![Screenshot 2025-01-15 204040](https://github.com/user-attachments/assets/d674ed79-90a5-4f27-9300-876ddf8e9a28)|
|![image](https://github.com/user-attachments/assets/517d2b70-de85-45aa-a16b-c9dbf9884966)|![image](https://github.com/user-attachments/assets/f8cf8aaf-936d-4c6a-bf0f-ed04c1251734)|

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
