### PR TITLE
feat(github): docs.github.com

### DIFF
--- a/styles/github/catppuccin.user.less
+++ b/styles/github/catppuccin.user.less
@@ -20,6 +20,7 @@ regexp(
     "https:\/\/github\.com(?!(\/home$|\/features($|\/.*)|\/organizations\/plan)).*$"
   ),
   domain("gist.github.com"),
+  domain("docs.github.com"),
   domain("viewscreen.githubusercontent.com") {
   [data-color-mode="auto"] {
     @media (prefers-color-scheme: light) {
@@ -519,6 +520,9 @@ regexp(
         color: @text;
       }
     }
+      
+    /* docs.github.com */
+    --color-fg-default: @text;
 
     --tooltip-fgColor: @base;
     --tooltip-bgColor: @overlay2;


### PR DESCRIPTION
Looks like it was recently updated to use the new CSS variable naming scheme adopted on the main site last year, so it works like a charm and only needs this one old CSS variable name to be set (for code blocks and presumably other things).