### PR TITLE
fix(stack-overflow): follow style guide for links

### DIFF
--- a/styles/stack-overflow/catppuccin.user.less
+++ b/styles/stack-overflow/catppuccin.user.less
@@ -148,8 +148,6 @@
       --theme-tag-hover-background-color: darken(@accent, 5%);
       --theme-tag-hover-border-color: darken(@accent, 5%);
       --theme-tag-hover-color: @mantle;
-      --theme-post-title-color: @accent;
-      --theme-post-title-color-hover: darken(@accent, 5%);
 
       --highlight-bg: @mantle;
 

--- a/styles/stack-overflow/catppuccin.user.less
+++ b/styles/stack-overflow/catppuccin.user.less
@@ -133,9 +133,9 @@
       --theme-button-primary-background-color: @accent;
       --theme-button-primary-hover-background-color: darken(@accent, 5%);
       --theme-button-primary-active-background-color: @text;
-      --theme-link-color: @accent;
-      --theme-link-color-hover: darken(@accent, 5%);
-      --theme-link-color-visited: @accent;
+      --theme-link-color: @blue;
+      --theme-link-color-hover: @sky;
+      --theme-link-color-visited: @lavender;
       --theme-footer-title-color: @text;
       --theme-footer-text-color: @subtext0;
       --theme-footer-link-color: @subtext0;

--- a/styles/stack-overflow/catppuccin.user.less
+++ b/styles/stack-overflow/catppuccin.user.less
@@ -135,6 +135,7 @@
       --theme-button-primary-active-background-color: @text;
       --theme-link-color: @accent;
       --theme-link-color-hover: darken(@accent, 5%);
+      --theme-link-color-visited: @accent;
       --theme-footer-title-color: @text;
       --theme-footer-text-color: @subtext0;
       --theme-footer-link-color: @subtext0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Makes visited links use accent color. 
| Before  | After |
| ------------- | ------------- |
| ![2025-01-25-221026_hyprshot](https://github.com/user-attachments/assets/7f8bca4b-361b-4f58-97b6-f7b1db05f116) | ![2025-01-25-220729_hyprshot](https://github.com/user-attachments/assets/5d126851-60ea-4651-875a-ba3de441d7f9) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
