### PR TITLE
fix(ghostty.org): adwaita terminal title bar

### DIFF
--- a/styles/ghostty.org/catppuccin.user.less
+++ b/styles/ghostty.org/catppuccin.user.less
@@ -117,6 +117,21 @@
     --callout-warning: @yellow;
     --callout-caution: @red;
 
+    div[class*="Terminal_adwaita"] {
+      --adw-headerbar-color: @mantle !important;
+
+      svg[class*="Terminal_icon"], p[class*="Terminal_title"] {
+        color: @text !important;
+      }
+
+      li[class*="Terminal_circularButton"] {
+        > svg {
+          color: @base !important;
+        }
+        background-color: @accent !important;
+      }
+    }
+
     [class*="Link_buttonLink"]:hover,
     ul [class*="NavTree_active"] {
       color: @crust !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes the terminal title bar on the [home page](https://ghostty.org). (Visible only on Linux user-agent)
| Before | After |
| ------- | ------ |
| ![2025-01-28-010932_hyprshot](https://github.com/user-attachments/assets/e79e0f52-8554-4c60-8832-729c0735db29) | ![2025-01-28-010916_hyprshot](https://github.com/user-attachments/assets/4e6e57ae-4394-48b3-bae9-850f647b30ad) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
