### PR TITLE
fix(twitch): misc

### DIFF
--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -87,6 +87,7 @@
       --color-border-tab: @surface0;
       --color-text-button-primary: @crust;
       --color-text-overlay: @text;
+      --color-text-overlay-alt: @subtext0;
       --color-text-overlay-link-hover: @subtext0;
       --color-text-base: @subtext1;
       --color-text-alt: @text;
@@ -485,8 +486,7 @@
     /* Usercard mod log tabs */
 
     .viewer-card-mod-drawer-tab--active {
-      box-shadow: 0 calc(var(--border-width-default) * -3) 0 @accent inset
-        !important;
+      box-shadow: 0 calc(var(--border-width-default) * -3) 0 @accent inset !important;
     }
 
     /* Usercard header */
@@ -562,7 +562,8 @@
     .chat-scrollable-area__message-container {
       background-color: @mantle;
     }
-    .side-nav-card__link:hover, .side-nav-card__link:focus {
+    .side-nav-card__link:hover,
+    .side-nav-card__link:focus {
       background: @surface0 !important;
     }
     .footer {
@@ -824,8 +825,7 @@
     /* Directory banner */
 
     .directory-header-new__banner-cover {
-      background:
-        linear-gradient(0deg, @base, fade(@mantle, 25%)),
+      background: linear-gradient(0deg, @base, fade(@mantle, 25%)),
         linear-gradient(90deg, @base, fade(@mantle, 25%));
     }
 
@@ -1173,13 +1173,13 @@
     /* Guest Star circle buttons */
 
     .guest-star-circle-button:not(
-      .guest-star-circle-button--inverted,
-      .guest-star-circle-button--alert
-    ),
+        .guest-star-circle-button--inverted,
+        .guest-star-circle-button--alert
+      ),
     .guest-star-circle-button__dropdown:not(
-      .guest-star-circle-button__dropdown--inverted,
-      .guest-star-circle-button__dropdown--alert
-    ) {
+        .guest-star-circle-button__dropdown--inverted,
+        .guest-star-circle-button__dropdown--alert
+      ) {
       background-color: @mantle;
       &:hover {
         background-color: var(--color-hinted-grey-5);
@@ -1264,7 +1264,8 @@
     }
 
     /* Number badges */
-    .tw-number-badge__badge, .tw-channel-status-text-indicator {
+    .tw-number-badge__badge,
+    .tw-channel-status-text-indicator {
       color: @base;
     }
 
@@ -1379,7 +1380,9 @@
     }
 
     .top-stats-tab:hover {
-      box-shadow: inset 0 -2px 0 @accent, 0 4px 6px -4px @accent;
+      box-shadow:
+        inset 0 -2px 0 @accent,
+        0 4px 6px -4px @accent;
       background: @base !important;
     }
 
@@ -1475,7 +1478,8 @@
       }
 
       [data-test-selector="is-affiliate-banner"] {
-        span, a {
+        span,
+        a {
           color: @base !important;
         }
       }
@@ -1534,7 +1538,8 @@
 }
 
 @-moz-document domain("dev.twitch.tv"),
-  url-prefix("https://discuss.dev.twitch.com/embed/topics") {
+  url-prefix("https://discuss.dev.twitch.com/embed/topics")
+{
   :root {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);
@@ -1909,8 +1914,116 @@
 
 /* deno-fmt-ignore */
 @catppuccin: {
-  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
-  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
-  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
-  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+  @latte: {
+    @rosewater: #dc8a78;
+    @flamingo: #dd7878;
+    @pink: #ea76cb;
+    @mauve: #8839ef;
+    @red: #d20f39;
+    @maroon: #e64553;
+    @peach: #fe640b;
+    @yellow: #df8e1d;
+    @green: #40a02b;
+    @teal: #179299;
+    @sky: #04a5e5;
+    @sapphire: #209fb5;
+    @blue: #1e66f5;
+    @lavender: #7287fd;
+    @text: #4c4f69;
+    @subtext1: #5c5f77;
+    @subtext0: #6c6f85;
+    @overlay2: #7c7f93;
+    @overlay1: #8c8fa1;
+    @overlay0: #9ca0b0;
+    @surface2: #acb0be;
+    @surface1: #bcc0cc;
+    @surface0: #ccd0da;
+    @base: #eff1f5;
+    @mantle: #e6e9ef;
+    @crust: #dce0e8;
+  };
+  @frappe: {
+    @rosewater: #f2d5cf;
+    @flamingo: #eebebe;
+    @pink: #f4b8e4;
+    @mauve: #ca9ee6;
+    @red: #e78284;
+    @maroon: #ea999c;
+    @peach: #ef9f76;
+    @yellow: #e5c890;
+    @green: #a6d189;
+    @teal: #81c8be;
+    @sky: #99d1db;
+    @sapphire: #85c1dc;
+    @blue: #8caaee;
+    @lavender: #babbf1;
+    @text: #c6d0f5;
+    @subtext1: #b5bfe2;
+    @subtext0: #a5adce;
+    @overlay2: #949cbb;
+    @overlay1: #838ba7;
+    @overlay0: #737994;
+    @surface2: #626880;
+    @surface1: #51576d;
+    @surface0: #414559;
+    @base: #303446;
+    @mantle: #292c3c;
+    @crust: #232634;
+  };
+  @macchiato: {
+    @rosewater: #f4dbd6;
+    @flamingo: #f0c6c6;
+    @pink: #f5bde6;
+    @mauve: #c6a0f6;
+    @red: #ed8796;
+    @maroon: #ee99a0;
+    @peach: #f5a97f;
+    @yellow: #eed49f;
+    @green: #a6da95;
+    @teal: #8bd5ca;
+    @sky: #91d7e3;
+    @sapphire: #7dc4e4;
+    @blue: #8aadf4;
+    @lavender: #b7bdf8;
+    @text: #cad3f5;
+    @subtext1: #b8c0e0;
+    @subtext0: #a5adcb;
+    @overlay2: #939ab7;
+    @overlay1: #8087a2;
+    @overlay0: #6e738d;
+    @surface2: #5b6078;
+    @surface1: #494d64;
+    @surface0: #363a4f;
+    @base: #24273a;
+    @mantle: #1e2030;
+    @crust: #181926;
+  };
+  @mocha: {
+    @rosewater: #f5e0dc;
+    @flamingo: #f2cdcd;
+    @pink: #f5c2e7;
+    @mauve: #cba6f7;
+    @red: #f38ba8;
+    @maroon: #eba0ac;
+    @peach: #fab387;
+    @yellow: #f9e2af;
+    @green: #a6e3a1;
+    @teal: #94e2d5;
+    @sky: #89dceb;
+    @sapphire: #74c7ec;
+    @blue: #89b4fa;
+    @lavender: #b4befe;
+    @text: #cdd6f4;
+    @subtext1: #bac2de;
+    @subtext0: #a6adc8;
+    @overlay2: #9399b2;
+    @overlay1: #7f849c;
+    @overlay0: #6c7086;
+    @surface2: #585b70;
+    @surface1: #45475a;
+    @surface0: #313244;
+    @base: #1e1e2e;
+    @mantle: #181825;
+    @crust: #11111b;
+  };
 };

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -74,7 +74,7 @@
     &,
     .tw-dialog-layer {
       --color-background-input-focus: @crust;
-      --color-background-interactable-hover: @surface0;
+      --color-background-interactable-hover: fade(@surface0, 48%);
       --color-background-interactable-alpha-hover: @surface0;
       --color-background-interactable-active: @surface1;
       --color-background-button-secondary-active: @surface1;

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -219,7 +219,7 @@
       --color-red-7: @accent;
       --color-red-8: @accent;
       --color-red-9: @accent;
-      --color-red-10: @accent;
+      --color-red-10: @red;
       --color-red-11: @peach;
       --color-red-12: @peach;
       --color-red-14: @peach;
@@ -249,7 +249,9 @@
       --color-text-tooltip: @base !important;
       --color-background-tooltip: @text !important;
       --color-hinted-grey-2: @surface0;
+      --color-hinted-grey-5: @surface0;
       --color-hinted-grey-8: @subtext0;
+      --color-hinted-grey-12: @subtext0;
       --color-hinted-grey-15: @text;
       --color-background-overlay-alt: fade(@mantle, 60%);
       --color-background-button-overlay-primary-hover: @subtext1;
@@ -264,6 +266,12 @@
       --color-background-toggle-checked: @mantle;
       --color-background-input-checkbox-checked-background: @crust;
       --color-border-balloon-overlay: @surface0;
+    
+      & when (@flavor = latte) {
+        --color-white: @base;
+        --color-black: @text;
+        --color-hinted-grey-12: @mantle;
+      }
     }
 
     --color-text-link: @accent;
@@ -1174,6 +1182,48 @@
     /* Guest star thumbnail border */
     .guest-star-live-card-border {
       background-image: linear-gradient(180deg, @mauve 0, @teal 61.98%, @blue);
+    }
+
+    /* Guest Star circle buttons */
+
+    .guest-star-circle-button:not(.guest-star-circle-button--inverted):not(
+      .guest-star-circle-button--alert
+    ),
+    .guest-star-circle-button__dropdown:not(
+      .guest-star-circle-button__dropdown--inverted
+    ):not(.guest-star-circle-button__dropdown--alert) {
+      background-color: @mantle;
+      &:hover {
+        background-color: var(--color-hinted-grey-5);
+      }
+
+      & when (@flavor = latte) {
+        --color-hinted-grey-5: @subtext0;
+        color: @base;
+        background-color: @text;
+        &:hover {
+          background-color: var(--color-hinted-grey-5);
+        }
+      }
+    }
+
+    .guest-star-circle-button--inverted, .guest-star-circle-button__dropdown--inverted { 
+      color: @base;
+      border-color: @base;
+      & when (@flavor = latte) {
+        color: @text;
+        border-color: @text;
+      }
+    }
+
+    /* End Stream Together button */
+    .guest-star-circle-button--alert {
+      color: @base;
+    }
+
+    /* Guest Star What's new icon */
+    .notification-icon--green svg {
+      fill: @green;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -92,12 +92,12 @@
       --color-text-alt-2: @text;
       --color-text-interactable-selected: @crust;
       --color-background-alt-2: @crust;
-      --color-text-tag: @text;
+      --color-text-tag: @subtext0;
       --color-background-button-secondary-default: @crust;
       --color-background-button-secondary-hover: @surface0;
       --color-background-button-overlay-secondary-default: fade(@text, 13%);
-      --color-background-tag-default: @mantle;
-      --color-background-tag-hover: @crust;
+      --color-background-tag-default: @surface0;
+      --color-background-tag-hover: @surface1;
       --color-background-float: @mantle;
       --color-background-body: @base;
       --color-background-base: @mantle;

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -405,8 +405,8 @@
 
     /* VOD metadata */
 
-    div.tw-media-card-stat {
-      color: @text;
+    div.tw-media-card-stat when not(@flavor = latte) {
+      --color-text-overlay: @text;
     }
 
     /* DMCA warning */
@@ -493,6 +493,9 @@
 
     div[data-a-target="user-card-modal"] p {
       color: @text !important;
+      & when (@flavor = latte) {
+        color: @base !important;
+      }
     }
 
     /* Usercard mod log tabs */
@@ -943,6 +946,9 @@
     .clips-player-seekbar-container {
       .tw-balloon p {
         color: @text !important;
+        & when (@flavor = latte) {
+          color: @base !important;
+        }
       }
     }
 
@@ -1299,6 +1305,10 @@
 
     .edit-video-properties-modal__content {
       --color-background-float: @base;
+    }
+
+    & when (@flavor = latte) {
+      --color-text-pill: @base;
     }
 
     article button {

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1268,7 +1268,8 @@
 
     /* Number badges */
     .tw-number-badge__badge,
-    .tw-channel-status-text-indicator {
+    .tw-channel-status-text-indicator,
+    .channel-status-info--live {
       color: @base;
     }
 

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -956,6 +956,7 @@
     /* Chat popouts */
 
     div[data-test-selector="chat-private-callout-queue__callout-container"] {
+      --color-text-overlay: @base;
       .tw-callout__close > button {
         color: @base !important;
       }
@@ -965,7 +966,7 @@
       div.tw-progress-bar {
         background: fade(@base, 10%);
       }
-      button .tw-svg {
+      button .tw-svg, svg {
         fill: @base;
       }
     }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -564,7 +564,7 @@
     .chat-scrollable-area__message-container {
       background-color: @mantle;
     }
-    .side-nav-card__link:hover {
+    .side-nav-card__link:hover, .side-nav-card__link:focus {
       background: @surface0 !important;
     }
     .footer {
@@ -1160,10 +1160,6 @@
     /* Pinned message shadow */
     .pinned-chat__scrollable-area__gradient {
       background-image: linear-gradient(180deg, transparent 60%, @mantle);
-    }
-
-    .side-nav-card__link:focus {
-      background-color: @surface0;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1754,6 +1754,7 @@
       p {
         color: @subtext0;
       }
+      background-color: @base !important;
     }
 
     blockquote {

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -486,7 +486,8 @@
     /* Usercard mod log tabs */
 
     .viewer-card-mod-drawer-tab--active {
-      box-shadow: 0 calc(var(--border-width-default) * -3) 0 @accent inset !important;
+      box-shadow: 0 calc(var(--border-width-default) * -3) 0 @accent inset
+        !important;
     }
 
     /* Usercard header */
@@ -825,7 +826,8 @@
     /* Directory banner */
 
     .directory-header-new__banner-cover {
-      background: linear-gradient(0deg, @base, fade(@mantle, 25%)),
+      background:
+        linear-gradient(0deg, @base, fade(@mantle, 25%)),
         linear-gradient(90deg, @base, fade(@mantle, 25%));
     }
 
@@ -1173,13 +1175,13 @@
     /* Guest Star circle buttons */
 
     .guest-star-circle-button:not(
-        .guest-star-circle-button--inverted,
-        .guest-star-circle-button--alert
-      ),
+      .guest-star-circle-button--inverted,
+      .guest-star-circle-button--alert
+    ),
     .guest-star-circle-button__dropdown:not(
-        .guest-star-circle-button__dropdown--inverted,
-        .guest-star-circle-button__dropdown--alert
-      ) {
+      .guest-star-circle-button__dropdown--inverted,
+      .guest-star-circle-button__dropdown--alert
+    ) {
       background-color: @mantle;
       &:hover {
         background-color: var(--color-hinted-grey-5);
@@ -1380,9 +1382,7 @@
     }
 
     .top-stats-tab:hover {
-      box-shadow:
-        inset 0 -2px 0 @accent,
-        0 4px 6px -4px @accent;
+      box-shadow: inset 0 -2px 0 @accent, 0 4px 6px -4px @accent;
       background: @base !important;
     }
 
@@ -1538,8 +1538,7 @@
 }
 
 @-moz-document domain("dev.twitch.tv"),
-  url-prefix("https://discuss.dev.twitch.com/embed/topics")
-{
+  url-prefix("https://discuss.dev.twitch.com/embed/topics") {
   :root {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);
@@ -1914,116 +1913,8 @@
 
 /* deno-fmt-ignore */
 @catppuccin: {
-  @latte: {
-    @rosewater: #dc8a78;
-    @flamingo: #dd7878;
-    @pink: #ea76cb;
-    @mauve: #8839ef;
-    @red: #d20f39;
-    @maroon: #e64553;
-    @peach: #fe640b;
-    @yellow: #df8e1d;
-    @green: #40a02b;
-    @teal: #179299;
-    @sky: #04a5e5;
-    @sapphire: #209fb5;
-    @blue: #1e66f5;
-    @lavender: #7287fd;
-    @text: #4c4f69;
-    @subtext1: #5c5f77;
-    @subtext0: #6c6f85;
-    @overlay2: #7c7f93;
-    @overlay1: #8c8fa1;
-    @overlay0: #9ca0b0;
-    @surface2: #acb0be;
-    @surface1: #bcc0cc;
-    @surface0: #ccd0da;
-    @base: #eff1f5;
-    @mantle: #e6e9ef;
-    @crust: #dce0e8;
-  };
-  @frappe: {
-    @rosewater: #f2d5cf;
-    @flamingo: #eebebe;
-    @pink: #f4b8e4;
-    @mauve: #ca9ee6;
-    @red: #e78284;
-    @maroon: #ea999c;
-    @peach: #ef9f76;
-    @yellow: #e5c890;
-    @green: #a6d189;
-    @teal: #81c8be;
-    @sky: #99d1db;
-    @sapphire: #85c1dc;
-    @blue: #8caaee;
-    @lavender: #babbf1;
-    @text: #c6d0f5;
-    @subtext1: #b5bfe2;
-    @subtext0: #a5adce;
-    @overlay2: #949cbb;
-    @overlay1: #838ba7;
-    @overlay0: #737994;
-    @surface2: #626880;
-    @surface1: #51576d;
-    @surface0: #414559;
-    @base: #303446;
-    @mantle: #292c3c;
-    @crust: #232634;
-  };
-  @macchiato: {
-    @rosewater: #f4dbd6;
-    @flamingo: #f0c6c6;
-    @pink: #f5bde6;
-    @mauve: #c6a0f6;
-    @red: #ed8796;
-    @maroon: #ee99a0;
-    @peach: #f5a97f;
-    @yellow: #eed49f;
-    @green: #a6da95;
-    @teal: #8bd5ca;
-    @sky: #91d7e3;
-    @sapphire: #7dc4e4;
-    @blue: #8aadf4;
-    @lavender: #b7bdf8;
-    @text: #cad3f5;
-    @subtext1: #b8c0e0;
-    @subtext0: #a5adcb;
-    @overlay2: #939ab7;
-    @overlay1: #8087a2;
-    @overlay0: #6e738d;
-    @surface2: #5b6078;
-    @surface1: #494d64;
-    @surface0: #363a4f;
-    @base: #24273a;
-    @mantle: #1e2030;
-    @crust: #181926;
-  };
-  @mocha: {
-    @rosewater: #f5e0dc;
-    @flamingo: #f2cdcd;
-    @pink: #f5c2e7;
-    @mauve: #cba6f7;
-    @red: #f38ba8;
-    @maroon: #eba0ac;
-    @peach: #fab387;
-    @yellow: #f9e2af;
-    @green: #a6e3a1;
-    @teal: #94e2d5;
-    @sky: #89dceb;
-    @sapphire: #74c7ec;
-    @blue: #89b4fa;
-    @lavender: #b4befe;
-    @text: #cdd6f4;
-    @subtext1: #bac2de;
-    @subtext0: #a6adc8;
-    @overlay2: #9399b2;
-    @overlay1: #7f849c;
-    @overlay0: #6c7086;
-    @surface2: #585b70;
-    @surface1: #45475a;
-    @surface0: #313244;
-    @base: #1e1e2e;
-    @mantle: #181825;
-    @crust: #11111b;
-  };
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
 };

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -271,6 +271,7 @@
         --color-white: @base;
         --color-black: @text;
         --color-hinted-grey-12: @mantle;
+        --color-background-overlay-alt: fade(@text, 60%);
       }
     }
 
@@ -831,6 +832,11 @@
     .reward-icon__cost {
       color: @text !important;
       background: fade(@mantle, 60%) !important;
+
+      & when (@flavor = latte) {
+        color: @base !important;
+        background: fade(@text, 60%) !important;
+      }
     }
 
     /* Directory banner */
@@ -841,8 +847,8 @@
         linear-gradient(90deg, @base, fade(@mantle, 25%));
     }
 
-    .home-video * {
-      color: @text !important;
+    .home-video when not(@flavor = latte) {
+      --color-text-overlay: @text;
     }
 
     /* Cookies and Advertising Choices */
@@ -1227,6 +1233,29 @@
     /* Guest Star What's new icon */
     .notification-icon--green svg {
       fill: @green;
+    }
+
+    .video-player__overlay when (@flavor = latte) {
+      --color-text-pill: @base;
+    }
+
+    /* Polls */
+    .community-highlight-stack__card {
+      .container--default {
+        background-color: @base;
+      }
+
+      .container--winner p {
+        color: @base !important;
+      }
+
+      .choice-progress__fill--default {
+        background-color: @surface0;
+      }
+
+      .top-poll-community-points-contributor {
+        color: @green;
+      }
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1140,15 +1140,12 @@
 
     .draggable-slider__overlay--purple {
       border-color: @accent;
+      background-color: fade(@accent, 30%);
     }
 
     .draggable-slider-handle--purple {
       background-color: @accent;
       --color-white: @base;
-    }
-
-    .draggable-slider__overlay--purple {
-      background-color: fade(@accent, 30%);
     }
 
     .clip-editor-timeline-background {

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -86,13 +86,14 @@
       --color-border-input: @base;
       --color-border-tab: @surface0;
       --color-text-button-primary: @crust;
-      --color-text-overlay: @text;
+      --color-text-overlay: @base;
       --color-text-overlay-alt: @subtext0;
       --color-text-overlay-link-hover: @subtext0;
       --color-text-base: @subtext1;
       --color-text-alt: @text;
       --color-text-alt-2: @subtext0;
       --color-text-interactable-selected: @crust;
+      --color-text-interactable-inverted: @base;
       --color-background-alt-2: @crust;
       --color-text-tag: @subtext0;
       --color-background-button-secondary-default: @crust;
@@ -205,6 +206,7 @@
       --color-blue-9: @blue;
       --color-blue-10: @sky;
       --color-blue-11: @sky;
+      --color-blue-12: @sky;
       --color-blue-14: @sky;
       --color-magenta-5: @flamingo;
       --color-magenta-6: @flamingo;
@@ -275,10 +277,10 @@
         --color-black: @text;
         --color-hinted-grey-12: @mantle;
         --color-text-pill: @base;
-        --color-text-overlay: @base;
         --color-text-overlay-link-hover: @surface0;
         --color-background-overlay-alt: fade(@text, 60%);
         --color-text-button-destructive: @base;
+        --color-text-button-overlay: @base !important;
       }
     }
 
@@ -409,12 +411,6 @@
       --color-text-overlay: @text;
     }
 
-    /* DMCA warning */
-
-    div.muted-segments-alert__content p {
-      color: @text;
-    }
-
     /* Seekbar segment */
 
     div[data-test-selector="seekbar-interaction-area__interactionArea"]
@@ -477,10 +473,10 @@
       color: @text;
     }
 
-    /* Following usercard */
+    /* Followers list usercard */
 
-    div[data-a-target="user-card-modal"] p when (@flavor = latte) {
-      --color-text-overlay: @base;
+    div[data-a-target="user-card-modal"] p when not(@flavor = latte) {
+      --color-text-overlay: @text;
     }
 
     /* Usercard mod log tabs */
@@ -922,15 +918,6 @@
       color: @subtext0 !important;
     }
 
-    /* Clips timestamp */
-
-    .player-controls,
-    .clips-player-seekbar-container {
-      .tw-balloon p when (@flavor = latte) {
-        color: @base !important;
-      }
-    }
-
     .sunlight-modal__content {
       color: @text !important;
     }
@@ -939,14 +926,9 @@
       color: @text;
     }
 
-    .video-player__container when (@flavor = latte) {
-      --color-text-overlay: @base;
-    }
-
-    .player-overlay-background when (@flavor = latte) {
-      div,
-      div p {
-        color: @base !important;
+    .video-player__container, .clips-root__main {
+      & when not(@flavor = latte) {
+        --color-text-overlay: @text;
       }
     }
 
@@ -957,7 +939,6 @@
     /* Chat popouts */
 
     div[data-test-selector="chat-private-callout-queue__callout-container"] {
-      --color-text-overlay: @base;
       .tw-callout__close > button {
         color: @base !important;
       }
@@ -1001,6 +982,8 @@
         color: @text !important;
       }
     }
+
+    /* AutoMod caught message */
 
     .chat-line__message--alert {
       border-color: @red !important;
@@ -1098,6 +1081,8 @@
       }
     }
 
+    /* Clips sharing buttons */
+
     .converter(@bg, @fg: @base) {
       color: @fg !important;
       background-color: @bg;
@@ -1128,14 +1113,8 @@
       }
     }
 
-    .clips-root__main {
-      .tw-balloon {
-        --color-text-overlay: @text;
-      }
-
-      .seekbar-bar {
-        background-color: @surface0 !important;
-      }
+    .clips-root__main .seekbar-bar {
+      background-color: @surface0 !important;
     }
 
     /* Clips editor timeline */
@@ -1248,12 +1227,8 @@
       background-color: @base;
     }
 
-    .footer__link {
+    .footer__link, .footer__link:hover {
       color: @text;
-
-      &:hover {
-        color: @text;
-      }
     }
 
     .footer__glitch
@@ -1267,16 +1242,14 @@
       }
     }
 
-    /* Number badges */
-    .tw-number-badge__badge,
-    .tw-channel-status-text-indicator,
-    .vertical-selector__internal,
-    .channel-status-info--live {
+    .tw-channel-status-text-indicator {
       color: @base;
     }
 
-    article {
-      --color-text-overlay: @base;
+    .player-captions-container {
+      .player-captions-container__caption-line[style*="; color: rgb(255, 255, 255)"] {
+        color: if(@flavor = latte, @base, @text) !important;
+      }
     }
   }
 }
@@ -1428,6 +1401,7 @@
     /* Collection thumbnails */
 
     .collection-preview-image__wrapper {
+      color: @text !important;
       background: linear-gradient(
         90deg,
         fade(@mantle, 0%),
@@ -1537,6 +1511,10 @@
     /* Stream Manager statistics */
     .sunlight-tile {
       background-color: @crust;
+    }
+
+    .creator-home-card__icon-background--yellow {
+      background-color: @yellow;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -840,7 +840,8 @@
     .top-bar--pointer-enabled .consent-banner__content--gdpr-v2,
     .consent-banner {
       a,
-      button {
+      button,
+      p {
         color: @base !important;
       }
 
@@ -1269,6 +1270,7 @@
     /* Number badges */
     .tw-number-badge__badge,
     .tw-channel-status-text-indicator,
+    .vertical-selector__internal,
     .channel-status-info--live {
       color: @base;
     }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -261,6 +261,7 @@
       --color-border-toggle-hover: @text;
       --color-background-toggle-checked: @mantle;
       --color-background-input-checkbox-checked-background: @crust;
+      --color-border-balloon-overlay: @surface0;
     }
 
     --color-text-link: @accent;
@@ -1004,11 +1005,11 @@
     .chat-line__message--alert {
       border-color: @red !important;
       background-color: @base !important;
+    }
 
-      .text-fragment--moderated-highlight {
-        color: @text !important;
-        background-color: fade(@red, 30%) !important;
-      }
+    .text-fragment--moderated-highlight {
+      color: @text !important;
+      background-color: fade(@red, 30%) !important;
     }
 
     /* Activity feed icons */
@@ -1095,6 +1096,68 @@
         color: @base;
         background-color: @text;
       }
+    }
+
+    .converter(@bg, @fg: @base) {
+      color: @fg !important;
+      background-color: @bg;
+
+      &:not([disabled]):hover {
+        background-color: darken(@bg, 5%);
+      }
+    }
+
+    .converter-youtube-button button {
+      .converter(@red);
+    }
+
+    .converter-instagram-button button {
+      .converter(@mauve);
+    }
+
+    .share-tiktok-button {
+      background-image: linear-gradient(135deg, @sky, @red);
+
+      button {
+        color: @text !important;
+        background-color: @mantle;
+
+        &:not([disabled]):hover {
+          background-color: @surface0;
+        }
+      }
+    }
+
+    .clips-root__main {
+      .tw-balloon {
+        --color-text-overlay: @text;
+      }
+
+      .seekbar-bar {
+        background-color: @surface0 !important;
+      }
+    }
+
+    .draggable-slider__overlay--purple {
+      border-color: @accent;
+    }
+
+    .draggable-slider-handle--purple {
+      background-color: @accent;
+      --color-white: @base;
+    }
+
+    .draggable-slider__overlay--purple {
+      background-color: fade(@accent, 30%);
+    }
+
+    .clip-editor-timeline-background {
+      background-color: @base;
+    }
+
+    .clip-editor-slider-popover {
+      color: @base;
+      background-color: @text;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1161,6 +1161,11 @@
     .pinned-chat__scrollable-area__gradient {
       background-image: linear-gradient(180deg, transparent 60%, @mantle);
     }
+
+    /* What's new mod view icon */
+    .whats-new-button--has-new-posts {
+      color: @green;
+    }
   }
 }
 

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1282,6 +1282,12 @@
     .footer__glitch path[d="m18 17 4-4V2H6v15h4v4l4-4h4zM12 6h2v6h-2V6zm7 0h-2v6h2V6z"] {
       fill: @text;
     }
+
+    .bits-leaderboard-expanded__collapse {
+      svg {
+        fill: @surface0;
+      }
+    }
   }
 }
 

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1138,6 +1138,8 @@
       }
     }
 
+    /* Clips editor timeline */
+
     .draggable-slider__overlay--purple {
       border-color: @accent;
       background-color: fade(@accent, 30%);
@@ -1165,6 +1167,11 @@
     /* What's new mod view icon */
     .whats-new-button--has-new-posts {
       color: @green;
+    }
+
+    /* Guest star thumbnail border */
+    .guest-star-live-card-border {
+      background-image: linear-gradient(180deg, @mauve 0, @teal 61.98%, @blue);
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -94,6 +94,7 @@
       --color-background-alt-2: @crust;
       --color-text-tag: @subtext0;
       --color-background-button-secondary-default: @crust;
+      --color-background-button-primary-hover: darken(@accent, 5%);
       --color-background-button-secondary-hover: @surface0;
       --color-background-button-overlay-secondary-default: fade(@text, 13%);
       --color-background-tag-default: @surface0;

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -266,7 +266,7 @@
       --color-background-toggle-checked: @mantle;
       --color-background-input-checkbox-checked-background: @crust;
       --color-border-balloon-overlay: @surface0;
-    
+
       & when (@flavor = latte) {
         --color-white: @base;
         --color-black: @text;
@@ -1186,12 +1186,14 @@
 
     /* Guest Star circle buttons */
 
-    .guest-star-circle-button:not(.guest-star-circle-button--inverted):not(
+    .guest-star-circle-button:not(
+      .guest-star-circle-button--inverted,
       .guest-star-circle-button--alert
     ),
     .guest-star-circle-button__dropdown:not(
-      .guest-star-circle-button__dropdown--inverted
-    ):not(.guest-star-circle-button__dropdown--alert) {
+      .guest-star-circle-button__dropdown--inverted,
+      .guest-star-circle-button__dropdown--alert
+    ) {
       background-color: @mantle;
       &:hover {
         background-color: var(--color-hinted-grey-5);
@@ -1207,7 +1209,8 @@
       }
     }
 
-    .guest-star-circle-button--inverted, .guest-star-circle-button__dropdown--inverted { 
+    .guest-star-circle-button--inverted,
+    .guest-star-circle-button__dropdown--inverted {
       color: @base;
       border-color: @base;
       & when (@flavor = latte) {

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -86,7 +86,8 @@
       --color-border-input: @base;
       --color-border-tab: @surface0;
       --color-text-button-primary: @crust;
-      --color-text-overlay: @base;
+      --color-text-overlay: @text;
+      --color-text-overlay-link-hover: @subtext0;
       --color-text-base: @subtext1;
       --color-text-alt: @text;
       --color-text-alt-2: @subtext0;
@@ -272,7 +273,11 @@
         --color-white: @base;
         --color-black: @text;
         --color-hinted-grey-12: @mantle;
+        --color-text-pill: @base;
+        --color-text-overlay: @base;
+        --color-text-overlay-link-hover: @surface0;
         --color-background-overlay-alt: fade(@text, 60%);
+        --color-text-button-destructive: @base;
       }
     }
 
@@ -289,13 +294,6 @@
     /* Hardcoded accent color */
     [style="color: rgb(160, 84, 255);"] {
       color: @accent !important;
-    }
-
-    /* Full screened video player title & description */
-
-    p[data-test-selector="stream-info-card-component__subtitle"],
-    p[data-test-selector="stream-info-card-component__description"] {
-      color: @text !important;
     }
 
     /* `Pinned message` popup */
@@ -416,18 +414,6 @@
       color: @text;
     }
 
-    /* VOD time labels */
-
-    div.vod-seekbar-time-labels p {
-      color: @text !important;
-    }
-
-    /* VOD timestamp */
-
-    div.vod-seekbar-preview-overlay__wrapper p {
-      color: @text !important;
-    }
-
     /* Seekbar segment */
 
     div[data-test-selector="seekbar-interaction-area__interactionArea"]
@@ -492,11 +478,8 @@
 
     /* Following usercard */
 
-    div[data-a-target="user-card-modal"] p {
-      color: @text !important;
-      & when (@flavor = latte) {
-        color: @base !important;
-      }
+    div[data-a-target="user-card-modal"] p when (@flavor = latte) {
+      --color-text-overlay: @base;
     }
 
     /* Usercard mod log tabs */
@@ -666,10 +649,6 @@
 
     /* FrankerFaceZ uptime timer */
     .ffz-il-tooltip__container {
-      .tw-c-text-overlay {
-        background-color: var(--color-background-overlay-alt) !important;
-      }
-
       p,
       figure.ffz-i-flag {
         color: @text;
@@ -677,7 +656,6 @@
     }
 
     [data-a-target="preview-card-image-link"] when (@flavor = latte) {
-      --color-background-overlay-alt: fade(@text, 80%);
       .tw-media-card-stat,
       p,
       figure.ffz-i-flag {
@@ -945,11 +923,8 @@
 
     .player-controls,
     .clips-player-seekbar-container {
-      .tw-balloon p {
-        color: @text !important;
-        & when (@flavor = latte) {
-          color: @base !important;
-        }
+      .tw-balloon p when (@flavor = latte) {
+        color: @base !important;
       }
     }
 
@@ -961,16 +936,14 @@
       color: @text;
     }
 
-    .player-overlay-background {
+    .video-player__container when (@flavor = latte) {
+      --color-text-overlay: @base;
+    }
+
+    .player-overlay-background when (@flavor = latte) {
       div,
       div p {
-        color: @text !important;
-      }
-      & when (@flavor = latte) {
-        div,
-        div p {
-          color: @base !important;
-        }
+        color: @base !important;
       }
     }
 
@@ -1279,7 +1252,8 @@
       }
     }
 
-    .footer__glitch path[d="m18 17 4-4V2H6v15h4v4l4-4h4zM12 6h2v6h-2V6zm7 0h-2v6h2V6z"] {
+    .footer__glitch
+      path[d="m18 17 4-4V2H6v15h4v4l4-4h4zM12 6h2v6h-2V6zm7 0h-2v6h2V6z"] {
       fill: @text;
     }
 
@@ -1287,6 +1261,15 @@
       svg {
         fill: @surface0;
       }
+    }
+
+    /* Number badges */
+    .tw-number-badge__badge, .tw-channel-status-text-indicator {
+      color: @base;
+    }
+
+    article {
+      --color-text-overlay: @base;
     }
   }
 }
@@ -1330,10 +1313,6 @@
 
     .edit-video-properties-modal__content {
       --color-background-float: @base;
-    }
-
-    & when (@flavor = latte) {
-      --color-text-pill: @base;
     }
 
     article button {
@@ -1442,7 +1421,6 @@
     /* Collection thumbnails */
 
     .collection-preview-image__wrapper {
-      color: @text !important;
       background: linear-gradient(
         90deg,
         fade(@mantle, 0%),
@@ -1478,7 +1456,6 @@
     }
 
     .clmgr-table__row {
-      --color-text-overlay: @text !important;
       &:hover {
         background: @surface0 !important;
       }
@@ -1498,7 +1475,7 @@
       }
 
       [data-test-selector="is-affiliate-banner"] {
-        a {
+        span, a {
           color: @base !important;
         }
       }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1156,6 +1156,12 @@
       color: @base;
       background-color: @text;
     }
+
+    /* Pinned message shadow */
+
+    .pinned-chat__scrollable-area__gradient {
+      background-image: linear-gradient(180deg, transparent 60%, @mantle);
+    }
   }
 }
 

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -89,7 +89,7 @@
       --color-text-overlay: @base;
       --color-text-base: @subtext1;
       --color-text-alt: @text;
-      --color-text-alt-2: @text;
+      --color-text-alt-2: @subtext0;
       --color-text-interactable-selected: @crust;
       --color-background-alt-2: @crust;
       --color-text-tag: @subtext0;
@@ -249,6 +249,7 @@
       --color-text-tooltip: @base !important;
       --color-background-tooltip: @text !important;
       --color-hinted-grey-2: @surface0;
+      --color-hinted-grey-8: @subtext0;
       --color-hinted-grey-15: @text;
       --color-background-overlay-alt: fade(@mantle, 60%);
       --color-background-button-overlay-primary-hover: @subtext1;
@@ -1214,6 +1215,10 @@
     @crust: @catppuccin[@@flavor][@crust];
     @accent: @catppuccin[@@flavor][@@accentColor];
 
+    .edit-video-properties-modal__content {
+      --color-background-float: @base;
+    }
+
     article button {
       --color-fill-current: @base !important;
       --color-background-button-overlay: @base !important;
@@ -1295,6 +1300,7 @@
     /* Autohost / managed channels list */
 
     .dashboard-centered-page {
+      --color-background-alt: @base;
       .simplebar-scroll-content,
       .simplebar-content {
         background: transparent !important;
@@ -1424,6 +1430,11 @@
         color: @subtext0;
         background-color: @surface0;
       }
+    }
+
+    /* Stream Manager statistics */
+    .sunlight-tile {
+      background-color: @crust;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1158,9 +1158,12 @@
     }
 
     /* Pinned message shadow */
-
     .pinned-chat__scrollable-area__gradient {
       background-image: linear-gradient(180deg, transparent 60%, @mantle);
+    }
+
+    .side-nav-card__link:focus {
+      background-color: @surface0;
     }
   }
 }

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -1270,6 +1270,18 @@
     [class*="rewardsLearnMoreExpandedView"] {
       background-color: @base;
     }
+
+    .footer__link {
+      color: @text;
+
+      &:hover {
+        color: @text;
+      }
+    }
+
+    .footer__glitch path[d="m18 17 4-4V2H6v15h4v4l4-4h4zM12 6h2v6h-2V6zm7 0h-2v6h2V6z"] {
+      fill: @text;
+    }
   }
 }
 

--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -266,6 +266,7 @@
       --color-background-toggle-checked: @mantle;
       --color-background-input-checkbox-checked-background: @crust;
       --color-border-balloon-overlay: @surface0;
+      --color-opac-gd-1: fade(@surface0, 35%);
 
       & when (@flavor = latte) {
         --color-white: @base;
@@ -1262,6 +1263,12 @@
       .top-poll-community-points-contributor {
         color: @green;
       }
+    }
+
+    /* Channel points rewards - Learn more */
+    [class*="rewardsLearnMoreHeadersDark"],
+    [class*="rewardsLearnMoreExpandedView"] {
+      background-color: @base;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Themes share buttons in clip editor
- Themes timeline in clip editor
- Themes stream thumbnail border (when streaming with Guest Star)
- Fixes timestamp balloon text color
- Fixes highlight in automod queue
- Fixes pinned message shadow
- Fixes followed channels background color on focus
- Fixes stream manager stats background color
- Fixes Guest Star circle buttons
- Fixes poll winner text color
- Fixes footer link text color
- Fixes button background color in channel rewards *Learn more* section
- Makes primary button a little darker on hover
- Changes alt text color to match Twitch

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
