### PR TITLE
feat(deepseek): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -313,6 +313,13 @@ userstyles:
     readme:
       app-link: https://deepl.com
     current-maintainers: [*watatomo]
+  deepseek:
+    name: DeepSeek
+    categories: [artificial_intelligence]
+    color: blue
+    readme:
+      app-link: https://chat.deepseek.com
+    current-maintainers: [*uncenter]
   docs.rs:
     name: docs.rs
     categories: [development]

--- a/styles/deepseek/catppuccin.user.less
+++ b/styles/deepseek/catppuccin.user.less
@@ -1,0 +1,222 @@
+/* ==UserStyle==
+@name DeepSeek Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/deepseek
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/deepseek
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/deepseek/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Adeepseek
+@description Soothing pastel theme for DeepSeek
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain("chat.deepseek.com") {
+  @import url("https://prismjs.catppuccin.com/variables.css");
+
+  body {
+    #catppuccin(@lightFlavor);
+  }
+  body[data-ds-dark-theme] {
+    #catppuccin(@darkFlavor);
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    --ctp-rosewater: @rosewater;
+    --ctp-flamingo: @flamingo;
+    --ctp-pink: @pink;
+    --ctp-mauve: @mauve;
+    --ctp-red: @red;
+    --ctp-maroon: @maroon;
+    --ctp-peach: @peach;
+    --ctp-yellow: @yellow;
+    --ctp-green: @green;
+    --ctp-teal: @teal;
+    --ctp-sky: @sky;
+    --ctp-sapphire: @sapphire;
+    --ctp-blue: @blue;
+    --ctp-lavender: @lavender;
+    --ctp-text: @text;
+    --ctp-subtext1: @subtext1;
+    --ctp-subtext0: @subtext0;
+    --ctp-overlay2: @overlay2;
+    --ctp-overlay1: @overlay1;
+    --ctp-overlay0: @overlay0;
+    --ctp-surface2: @surface2;
+    --ctp-surface1: @surface1;
+    --ctp-surface0: @surface0;
+    --ctp-base: @base;
+    --ctp-mantle: @mantle;
+    --ctp-crust: @crust;
+
+    color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    --dsr-bg: @base;
+    --dsr-text-1: @text;
+    --dsr-input-bg: @surface0;
+    --dsr-tooltip-fg: @text;
+    --dsr-tooltip-bg: @crust;
+    --dsr-side-bg: @mantle;
+    --dsr-side-hover-bg: @surface0;
+
+    --ds-rgb-label-1: #rgbify(@text)[];
+    --ds-rgb-zinc-500: #rgbify(@overlay0)[];
+    --ds-rgb-neutral-100: #rgbify(@text)[];
+    --ds-rgb-neutral-600: #rgbify(@surface1)[];
+    --ds-rgb-neutral-650: #rgbify(@surface0)[];
+    --ds-rgb-red-500: #rgbify(@red)[];
+
+    --ds-rgb-primary: #rgbify(@accent)[];
+    path[fill="#4D6BFE"] {
+      fill: @accent !important;
+    }
+
+    /* Hi, I'm DeepSeek. */
+    div:has(> div > div.ds-icon path[fill="#4D6BFE"]) {
+      color: @text;
+
+      /* How can I help you today? */
+      > div:last-child {
+        color: @subtext1;
+      }
+    }
+
+    /* User messages */
+    div:has(+ div > .ds-markdown) > div {
+      background-color: @surface0;
+      color: @text;
+    }
+
+    .ds-markdown {
+      color: @text !important;
+
+      .md-code-block {
+        background-color: @mantle;
+        color: @text;
+
+        .md-code-block-banner {
+          background-color: @surface0;
+        }
+      }
+
+      code {
+        background-color: @mantle;
+      }
+    }
+
+    .ds-button {
+      color: @text;
+      border-color: @surface1;
+
+      &.ds-button--filled {
+        &:hover {
+          background-color: @surface1;
+        }
+        &.ds-button--primary {
+          .ds-icon {
+            color: @text !important;
+          }
+        }
+        &.ds-button--error {
+          background-color: @red;
+          color: @crust;
+        }
+      }
+    }
+
+    .ds-icon-button {
+      &:hover::before {
+        background-color: @surface0;
+      }
+    }
+
+    .ds-dropdown-menu {
+      background-color: @base;
+
+      .ds-dropdown-menu-option {
+        color: @text;
+
+        &.ds-dropdown-menu-option--pending {
+          background-color: @surface0;
+        }
+      }
+    }
+
+    .ds-tooltip {
+      background-color: @crust;
+      color: @text;
+    }
+
+    .ds-modal-content {
+      background-color: @surface0;
+    }
+    .ds-segmented {
+      background-color: @surface1;
+
+      .ds-segmented-button {
+        &.ds-segmented-button--selected {
+          background-color: @surface2;
+        }
+      }
+    }
+
+    .ds-native-select .ds-native-select__select {
+      background-color: @surface1;
+    }
+  }
+}
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
+}
+
+/* deno-fmt-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+};

--- a/styles/deepseek/catppuccin.user.less
+++ b/styles/deepseek/catppuccin.user.less
@@ -96,7 +96,9 @@
 
     --dsr-bg: @base;
     --dsr-text-1: @text;
+    --dsr-main: @accent;
     --dsr-input-bg: @surface0;
+    --ds-input-focus-border-color: @accent;
     --dsr-tooltip-fg: @text;
     --dsr-tooltip-bg: @crust;
     --dsr-side-bg: @mantle;
@@ -108,9 +110,11 @@
     --ds-rgb-neutral-600: #rgbify(@surface1)[];
     --ds-rgb-neutral-650: #rgbify(@surface0)[];
     --ds-rgb-red-500: #rgbify(@red)[];
+    --ds-rgb-amber-500: #rgbify(@peach)[];
+    --ds-rgb-slate-50: #rgbify(@crust)[];
 
     --ds-rgb-primary: #rgbify(@accent)[];
-    path[fill="#4D6BFE"] {
+    svg [fill="#4D6BFE"] {
       fill: @accent !important;
     }
 
@@ -156,6 +160,11 @@
           background-color: @surface1;
         }
         &.ds-button--primary {
+            &:not(.ds-button--m) {
+          background-color: @accent;
+          color: @crust;
+            }
+
           .ds-icon {
             color: @text !important;
           }
@@ -165,6 +174,12 @@
           color: @crust;
         }
       }
+      
+        &.ds-button--bordered {
+            &:hover {
+                background-color: @surface1;
+            }
+        }
     }
 
     .ds-icon-button {
@@ -206,6 +221,17 @@
     .ds-native-select .ds-native-select__select {
       background-color: @surface1;
     }
+      .ds-checkbox.ds-checkbox--active {
+          background-color: @accent;
+          
+          svg {
+              color: @crust;
+          }
+      }
+      
+      .ds-a.ds-a--link {
+          color: @accent;
+      }
   }
 }
 


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [DeepSeek](https://chat.deepseek.com) 🎉

WIP, site uses a lot of autogenerated classes which makes things like primary buttons and the shadow at the top of the chat window hard to theme, but I'll try!

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [ ] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
  - [ ] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
