### PR TITLE
fix(wikipedia): remove default anchor element color

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -232,8 +232,6 @@
     }
 
     a {
-      color: @accent;
-
       &:focus {
         outline-color: @accent;
       }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #1613. Leaving as a draft for now since I'm pretty sure I had this set for a reason when I rewrote it (but I can't find what the issue was now).

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
