### PR TITLE
fix(instagram): prev/next button svgs

### DIFF
--- a/styles/instagram/catppuccin.user.less
+++ b/styles/instagram/catppuccin.user.less
@@ -199,17 +199,13 @@
     }
 
     /* Icons */
-    svg[aria-label="Unlike"] {
-      fill: @accent;
-    }
-    svg[aria-label="Close"] {
-      color: @text;
-    }
+    svg[aria-label="Unlike"],
     svg[aria-label="Verified"] {
-      fill: @accent;
+      fill: @accent !important;
     }
     svg[aria-label="Next"],
-    svg[aria-label="Go back"] {
+    svg[aria-label="Go back"],
+    svg[aria-label="Close"] {
       fill: @text !important;
     }
 

--- a/styles/instagram/catppuccin.user.less
+++ b/styles/instagram/catppuccin.user.less
@@ -208,6 +208,10 @@
     svg[aria-label="Verified"] {
       fill: @accent;
     }
+    svg[aria-label="Next"],
+    svg[aria-label="Go back"] {
+      fill: @text !important;
+    }
 
     /* new post thingy */
     ._aa1q._aa1q {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixing the `Next` and `Go back` svg buttons fill color for reels post 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] `Next` svg fill color
- [x] `Go back` svg fill color
