### PR TITLE
feat(gleam.run): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -375,6 +375,13 @@ userstyles:
       app-link: https://github.com
     current-maintainers: [*uncenter]
     past-maintainers: [*unseen-ninja, *pocco81, *glowingumbreon]
+  gleam.run:
+    name: gleam.run
+    categories: [development]
+    color: pink
+    readme:
+      app-link: https://gleam.run
+    current-maintainers: [*uncenter]
   gmail:
     name: Gmail
     categories: [email_client, productivity]

--- a/styles/gleam.run/catppuccin.user.less
+++ b/styles/gleam.run/catppuccin.user.less
@@ -30,9 +30,7 @@
     @media (prefers-color-scheme: dark) {
       #catppuccin(@darkFlavor);
     }
-  }
 
-  :root {
     &.theme-light {
       #catppuccin(@lightFlavor);
     }

--- a/styles/gleam.run/catppuccin.user.less
+++ b/styles/gleam.run/catppuccin.user.less
@@ -1,0 +1,222 @@
+/* ==UserStyle==
+@name gleam.run Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/gleam.run
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/gleam.run
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/gleam.run/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agleam.run
+@description Soothing pastel theme for gleam.run
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain("gleam.run") {
+  @import url("https://prismjs.catppuccin.com/variables.important.css");
+  @import url("https://unpkg.com/@catppuccin/highlightjs@1.0.0/css/catppuccin-variables.important.css");
+
+  code.hljs {
+    background: none !important;
+  }
+
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  :root {
+    &.theme-light {
+      #catppuccin(@lightFlavor);
+    }
+    &.theme-dark {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    --ctp-rosewater: @rosewater;
+    --ctp-flamingo: @flamingo;
+    --ctp-pink: @pink;
+    --ctp-mauve: @mauve;
+    --ctp-red: @red;
+    --ctp-maroon: @maroon;
+    --ctp-peach: @peach;
+    --ctp-yellow: @yellow;
+    --ctp-green: @green;
+    --ctp-teal: @teal;
+    --ctp-sky: @sky;
+    --ctp-sapphire: @sapphire;
+    --ctp-blue: @blue;
+    --ctp-lavender: @lavender;
+    --ctp-text: @text;
+    --ctp-subtext1: @subtext1;
+    --ctp-subtext0: @subtext0;
+    --ctp-overlay2: @overlay2;
+    --ctp-overlay1: @overlay1;
+    --ctp-overlay0: @overlay0;
+    --ctp-surface2: @surface2;
+    --ctp-surface1: @surface1;
+    --ctp-surface0: @surface0;
+    --ctp-base: @base;
+    --ctp-mantle: @mantle;
+    --ctp-crust: @crust;
+
+    color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    --color-charcoal: #2f2f2f;
+    --color-underwater-blue: @base;
+    --color-black: @mantle;
+    --color-blacker: @crust;
+    --color-white: @text;
+    --color-faff-pink: @accent;
+    --color-aged-plastic-yellow: @text;
+    --color-unnamed-blue: #a6f0fc;
+    --color-code-grey: @subtext1;
+    --color-code-blue: @sky;
+    --color-code-green: @green;
+    --color-code-dark-grey: @overlay2;
+    --color-code-yellow: @yellow;
+    --color-code-red: @red;
+    --color-code-orange: @peach;
+    --color-code-light-pink: @pink;
+
+    --charcoal: var(--color-charcoal);
+    --underwater-blue: var(--color-underwater-blue);
+    --black: var(--color-black);
+    --blacker: var(--color-blacker);
+    --white: var(--color-white);
+    --faff-pink: var(--color-faff-pink);
+    --aged-plastic-yellow: var(--color-aged-plastic-yellow);
+    --unnamed-blue: var(--color-unnamed-blue);
+    --code-grey: var(--color-code-grey);
+    --code-blue: var(--color-code-blue);
+    --code-green: var(--color-code-green);
+    --code-dark-grey: var(--color-code-dark-grey);
+    --code-yellow: var(--color-code-yellow);
+    --code-red: var(--color-code-red);
+    --code-orange: var(--color-code-orange);
+    --code-light-pink: var(--color-code-light-pink);
+
+    img[src="https://gleam.run/images/lucy/lucy.svg"],
+    img[src="/images/lucy/lucy.svg"] {
+      @svg: escape(
+        '<svg width="2105" height="2016" viewBox="0 0 2105 2016" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M842.026 129.177c28.088-79.594 132.505-98.005 186.124-32.82l281.02 341.663c34.77 42.276 86.23 67.327 140.97 68.66l442.64 10.77c84.51 2.055 134.14 95.497 88.67 166.533l-238.58 372.667a188.1 188.1 0 0 0-27.87 75.23 188 188 0 0 0 6 79.99l126.34 423.83c24.08 80.75-49.46 157.01-131.31 135.74l-428.48-111.33c-26.19-6.81-53.54-7.9-80.19-3.2a188.4 188.4 0 0 0-74.25 30.43l-364.553 251.17c-69.644 47.97-164.828 1.47-169.831-82.65l-26.224-441.48c-3.245-54.64-30.129-105.14-73.636-138.37l-351.663-268.6c-67.026-51.194-52.344-155.98 26.363-186.816L585.833 659.08c50.98-19.973 90.766-61.113 108.98-112.732z" fill="@{accent}"/><path d="M918.91 20.388c-49.941 8.807-95.59 41.965-114.49 95.516L657.186 533.07c-14.355 40.671-45.666 73.053-85.859 88.801L159.044 783.395C53.25 824.843 32.792 970.356 122.981 1039.24l351.663 268.57a148 148 0 0 1 40.884 48.15 148 148 0 0 1 17.097 60.8l26.21 441.47c6.724 113.26 138.833 177.69 232.452 113.21l.002-.01 364.581-251.17v-.01a148.5 148.5 0 0 1 121.68-21.45l428.49 111.31c110.02 28.59 212.13-77.15 179.71-185.89v.01l-126.33-423.82c-6.09-20.41-7.7-41.89-4.73-62.99a147.9 147.9 0 0 1 21.96-59.22v-.01l238.6-372.677-.01-.002c61.2-95.578-7.78-225.314-121.37-228.077l-442.66-10.753c-43.15-1.048-83.65-20.767-111.04-54.073L1059.15 70.955c-36.07-43.854-90.309-59.396-140.254-50.588m13.444 76.246c22.695-4.002 47.479 3.838 65.025 25.166l281.015 341.643c42.14 51.241 104.57 81.62 170.88 83.233l442.66 10.753c55.43 1.346 85.71 58.488 55.94 104.974l-238.59 372.678c-35.79 55.87-45.47 124.63-26.53 188.2l126.34 423.81c15.73 52.78-29.25 99.55-82.93 85.61l-428.49-111.32c-64.21-16.69-132.57-4.63-187.2 33.02l-364.576 251.17c-45.679 31.47-103.939 2.9-107.208-52.07l-26.207-441.47c-3.932-66.23-36.555-127.51-89.283-167.79L171.524 975.65c-43.862-33.499-34.944-97.55 16.679-117.783l412.282-161.526c61.771-24.202 110.04-74.101 132.123-136.67v-.002l147.234-417.165c9.192-26.041 29.798-41.886 52.493-45.889" fill="@{crust}"/><path d="M790.631 1144.08c42.736-7.54 71.273-48.29 63.739-91.02-7.534-42.74-48.285-71.267-91.021-63.731-42.736 7.537-71.273 48.291-63.739 91.021s48.286 71.27 91.021 63.73m633.069-111.63c42.73-7.53 71.27-48.286 63.73-91.018-7.53-42.733-48.28-71.266-91.02-63.729-42.73 7.536-71.27 48.288-63.74 91.021 7.54 42.736 48.29 71.266 91.03 63.726m-381.61 94.12c-4.9 1.89-9.38 4.73-13.19 8.35a40.04 40.04 0 0 0-12.4 27.99c-.13 5.25.78 10.48 2.67 15.38a104.5 104.5 0 0 0 21.79 34.37 104.1 104.1 0 0 0 33.29 23.41l.01.01c12.51 5.54 25.99 8.56 39.68 8.89h.03c13.68.32 27.29-2.05 40.06-6.98h.01a104.1 104.1 0 0 0 34.36-21.78h.01v-.01c9.91-9.44 17.86-20.75 23.4-33.26 5.56-12.53 8.58-26.04 8.9-39.74.25-10.6-3.72-20.87-11.04-28.55a40.04 40.04 0 0 0-43.38-9.69 40 40 0 0 0-13.18 8.37c-3.8 3.62-6.85 7.96-8.97 12.77a40 40 0 0 0-3.4 15.23c-.08 3.17-.78 6.3-2.07 9.2v.01l-.01.02a24.4 24.4 0 0 1-5.44 7.74c-2.31 2.2-5.02 3.92-7.99 5.06l-.02.01c-2.98 1.15-6.15 1.7-9.34 1.63-3.18-.08-6.32-.79-9.23-2.08h-.02l-.01-.01a24.3 24.3 0 0 1-7.73-5.43v-.01a24.2 24.2 0 0 1-5.07-8 39.96 39.96 0 0 0-21.12-22.16c-4.8-2.13-9.98-3.29-15.23-3.42s-10.47.78-15.37 2.68" fill="@{crust}"/></svg>'
+      );
+      content: url("data:image/svg+xml,@{svg}");
+    }
+    .hero-lucy-container:hover .hero-lucy, .logo:hover .footer-lucy {
+      @svg: escape(
+        '<svg width="2105" height="2016" viewBox="0 0 2105 2016" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M842.17 129.185c28.088-79.594 132.5-98.004 186.12-32.819l281.02 341.662c34.77 42.277 86.23 67.327 140.97 68.66l442.64 10.77c84.51 2.056 134.14 95.502 88.67 166.533l-238.58 372.679a188.05 188.05 0 0 0-27.87 75.22 188 188 0 0 0 6 79.99l126.34 423.83c24.08 80.76-49.46 157.02-131.31 135.75l-428.48-111.34c-26.19-6.81-53.54-7.9-80.19-3.2a188.6 188.6 0 0 0-74.25 30.43l-364.56 251.17c-69.641 47.98-164.831 1.48-169.829-82.64l-26.224-441.49c-3.245-54.63-30.129-105.14-73.635-138.37l-351.664-268.6c-67.025-51.194-52.343-155.981 26.364-186.816L585.971 659.09c50.98-19.973 90.766-61.113 108.981-112.732z" fill="@{accent}"/><path d="M918.858 20.365c-49.94 8.806-95.585 41.963-114.483 95.515L657.157 533.053c-14.352 40.672-45.661 73.054-85.851 88.8L159.037 783.367C53.245 824.813 32.795 970.329 122.985 1039.21l351.662 268.6a148.2 148.2 0 0 1 40.886 48.15 148.1 148.1 0 0 1 17.099 60.81l26.225 441.49c6.729 113.26 138.844 177.7 232.453 113.21l364.56-251.17v-.01a148.5 148.5 0 0 1 121.68-21.45l428.49 111.34c110.01 28.59 212.12-77.15 179.7-185.89l-126.34-423.83a147.9 147.9 0 0 1-4.73-62.99 148 148 0 0 1 21.95-59.22v-.01l238.58-372.675v-.002c61.19-95.577-7.79-225.324-121.38-228.087l-442.64-10.77c-43.15-1.05-83.65-20.771-111.05-54.079L1059.11 70.96c-36.08-43.856-90.312-59.4-140.252-50.595m13.447 76.249c22.694-4.002 47.478 3.84 65.024 25.169l281.011 341.658c42.15 51.245 104.57 81.627 170.89 83.241l442.64 10.769c55.44 1.349 85.72 58.493 55.96 104.977l-238.59 372.682c-35.78 55.87-45.46 124.62-26.51 188.2l126.35 423.84c15.73 52.77-29.25 99.55-82.92 85.6l-428.49-111.34c-64.21-16.69-132.57-4.64-187.2 33.01l-364.548 251.17h-.002c-45.673 31.47-103.939 2.9-107.204-52.08l-26.224-441.48c-3.934-66.23-36.558-127.52-89.286-167.79L171.544 975.638c-43.862-33.502-34.948-97.559 16.675-117.782L600.49 696.339c61.767-24.199 110.032-74.098 132.11-136.663l-.001-.002 147.218-417.172c9.19-26.041 29.795-41.886 52.489-45.887" fill="@{crust}"/><path d="M1035.64 1124.95a40 40 0 0 0-22.16 21.12c-4.3 9.7-4.57 20.71-.75 30.6a104.4 104.4 0 0 0 21.79 34.38 104.1 104.1 0 0 0 33.29 23.41l.01.01c12.51 5.54 26 8.56 39.68 8.89l.01.01h.02c13.68.32 27.28-2.05 40.05-6.98h.01a104.3 104.3 0 0 0 34.37-21.78l.01-.01c9.91-9.45 17.86-20.75 23.4-33.27 5.55-12.53 8.58-26.03 8.9-39.73a40.03 40.03 0 0 0-11.05-28.56 40.02 40.02 0 0 0-28-12.37c-5.25-.12-10.48.79-15.38 2.68-4.9 1.9-9.37 4.74-13.17 8.37-3.8 3.62-6.85 7.96-8.98 12.77a40 40 0 0 0-3.4 15.23c-.07 3.17-.77 6.3-2.06 9.2l-.01.01-.01.02a24.3 24.3 0 0 1-5.44 7.74v.01a24.3 24.3 0 0 1-7.99 5.05l-.01.01c-2.98 1.15-6.15 1.7-9.34 1.63-3.18-.08-6.32-.79-9.23-2.08h-.02l-.01-.01a24.1 24.1 0 0 1-7.73-5.43v-.01a24.4 24.4 0 0 1-5.08-8 40 40 0 0 0-21.11-22.17 40.04 40.04 0 0 0-30.61-.74M687.713 969.904a40 40 0 0 0-34.761 56.716 39.9 39.9 0 0 0 9.172 12.62 40 40 0 0 0 13.307 8.16l28.763 10.61-23.396 19.81a40.02 40.02 0 0 0-14.016 27.22 40.02 40.02 0 0 0 9.335 29.16 40.03 40.03 0 0 0 27.218 14.01 40 40 0 0 0 29.156-9.33l75.731-64.12a40.03 40.03 0 0 0 11.768-16.93 40.03 40.03 0 0 0 1.774-20.55 40 40 0 0 0-8.692-18.69 40 40 0 0 0-16.849-11.89l-93.096-34.353a40 40 0 0 0-15.414-2.443m756.117-133.323a40 40 0 0 0-13.66 7.57l-75.72 64.123a40 40 0 0 0-11.77 16.931 40 40 0 0 0-1.77 20.541 39.99 39.99 0 0 0 25.54 30.581l93.09 34.353a40 40 0 0 0 51.37-23.678 40.1 40.1 0 0 0 2.45-15.416 40.1 40.1 0 0 0-3.65-15.176 39.8 39.8 0 0 0-9.17-12.628 40 40 0 0 0-13.3-8.156l-28.76-10.613 23.39-19.81a40.1 40.1 0 0 0 9.72-12.216c2.4-4.67 3.86-9.768 4.3-15.003a40.1 40.1 0 0 0-1.77-15.507 40 40 0 0 0-7.57-13.65 40 40 0 0 0-19.51-12.603 40 40 0 0 0-23.22.357" fill="@{crust}"/></svg>'
+      );
+      content: url("data:image/svg+xml,@{svg}");
+    }
+
+    .pride .page-header {
+      @svg: escape(
+        '<svg width="1920" height="780" viewBox="0 0 1920 780" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#a)"><path fill="@{red}" d="m-315.199 100.192 2016.665-734.006 88.169 242.242L-227.03 342.434z"/><path fill="@{peach}" d="M-227.03 342.435 1789.635-391.57l72.613 199.502-2016.665 734.006z"/><path fill="@{yellow}" d="M-154.417 541.937 1862.248-192.07 1934.86 7.432-81.805 741.438z"/><path fill="@{green}" d="M-81.805 741.44 1934.86 7.432l72.613 199.502L-9.192 940.94z"/><path fill="@{blue}" d="m-9.192 940.94 2016.665-734.006 72.613 199.501L63.42 1140.441z"/><path fill="@{mauve}" d="m63.42 1140.44 2016.666-734.006 103.734 285.008-2016.665 734.006z"/><path fill="#fff" fill-opacity=".56" d="m-315.199 100.192 2016.665-734.006 482.58 1325.878L167.381 1426.07z"/></g><defs><clipPath id="a"><path fill="#fff" d="M0 0h1920v780H0z"/></clipPath></defs></svg>'
+      );
+      background-image: url("data:image/svg+xml,@{svg}");
+    }
+
+    .home-waves {
+      @svg: escape(
+        '<svg preserveAspectRatio="none" width="1920" height="122" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M463.5 21.13C180-26.413 0 21.13 0 21.13v100h1920V71.087c-190-49.957-273.5-71-498-49.957-224.5 21.044-281.21 44.66-540 49.957-172.829 3.537-307.645-31.366-418.5-49.957" fill="@{base}"/><path d="M1458 33.087c283.5-47.543 462 0 462 0v88.044H0V71.087C190 21.13 310 53.674 498 21.13s342-12.543 540 49.957c172.37 3.528 308.43-19.289 419.12-37.853z" fill="@{base}" fill-opacity=".28"/></svg>'
+      );
+      content: url("data:image/svg+xml,@{svg}");
+    }
+
+    p > code, li > code {
+      background-color: @surface0;
+      opacity: 1;
+    }
+
+    /* gleam.run home */
+    .button {
+      color: @crust !important;
+      background-color: @accent;
+    }
+    .home-still-here {
+      .button {
+        background-color: @text;
+        color: @crust;
+      }
+
+      /* Wanna keep in touch? */
+      input[type="submit"] {
+        background-color: @text !important;
+        color: @crust;
+      }
+      input[type="email"] {
+        background-color: @mantle;
+        color: @text;
+      }
+    }
+
+    /* tour.gleam.run */
+    --color-text: @text;
+    --color-link: @text;
+    --color-background: @base;
+    --color-background-dim: @crust;
+    --color-text-accent: @accent;
+    --color-accent-muted: fade(@accent, 50%);
+
+    --code-background: @base;
+    --code-token-base: @text;
+    --color-code: @accent;
+  }
+}
+
+/* deno-fmt-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+};

--- a/styles/gleam.run/preview.webp
+++ b/styles/gleam.run/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:256e3f0ec85abee013ae2ab0f7e3c11a52777f85d17f25081e690f61ad855dc2
+size 95444


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [Gleam](https://gleam.run) 🎉

![](https://media.githubusercontent.com/media/catppuccin/userstyles/feat/gleam/styles/gleam.run/preview.webp)

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

## 💬 Additional Comments 💬

I don't think we can call this just `gleam` since there is already a `catppuccin/gleam` and I don't want to intentionally create more port "duplicates".

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [ ] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
  - [ ] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
