### PR TITLE
fix(chatgpt): message input box background

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -433,7 +433,7 @@
 
     /* Main message input box */
     .dark\:bg-\[\#303030\] {
-      background-color: @mantle;
+      background-color: @surface0;
     }
 
     .bg-[\#0077FF],


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The message input box background color should be `@surface0`. As far as I know, it was previously set correctly to `@surface0`.

## Screenshots

|**Before**|**After**|
|---|---|
|![image](https://github.com/user-attachments/assets/40176148-65b2-4967-b3c8-ee90366290c1)|![image](https://github.com/user-attachments/assets/edfc06b6-26a3-424a-9e10-c905db6bcf74)|

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
