### PR TITLE
fix(chatgpt): chat input box background

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -432,12 +432,9 @@
     }
 
     /* Main message input box */
+    .bg-\[\#303030\],
     .dark\:bg-\[\#303030\] {
       background-color: @surface0;
-    }
-
-    .bg-\[\#303030\] {
-      background-color: @crust;
     }
 
     .bg-[\#0077FF],

--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -436,6 +436,10 @@
       background-color: @surface0;
     }
 
+    .bg-\[\#303030\] {
+      background-color: @crust;
+    }
+
     .bg-[\#0077FF],
     .bg-\[\#3C46FF\],
     .bg-[\#3C46FF],


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the message input box in temporary chat option

## Screenshot

|**Before**|**After**|
|---|---|
|![image](https://github.com/user-attachments/assets/30f747ba-9f71-4dd8-a43e-9d862fabe1e3)|![image](https://github.com/user-attachments/assets/3f1c83e4-f4b7-49a4-8b10-70921af993ed)|

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
