### PR TITLE
fix(brave-search): theme ask a follow-up question field 

### DIFF
--- a/styles/brave-search/catppuccin.user.less
+++ b/styles/brave-search/catppuccin.user.less
@@ -65,7 +65,11 @@
     ::selection {
       background-color: fade(@accent, 30%);
     }
-
+    .conversation-input-field.svelte-1cceli6.type--default {
+    background: @crust;
+    border: none;
+    color: @text;
+    }
     input,
     textarea {
       &::placeholder {

--- a/styles/brave-search/catppuccin.user.less
+++ b/styles/brave-search/catppuccin.user.less
@@ -2,7 +2,7 @@
 @name Brave Search Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/brave-search
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/brave-search
-@version 2025.02.28
+@version 2025.02.01
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/brave-search/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Abrave-search
 @description Soothing pastel theme for Brave Search

--- a/styles/brave-search/catppuccin.user.less
+++ b/styles/brave-search/catppuccin.user.less
@@ -65,11 +65,7 @@
     ::selection {
       background-color: fade(@accent, 30%);
     }
-    .conversation-input-field.svelte-1cceli6.type--default {
-    background: @crust;
-    border: none;
-    color: @text;
-    }
+
     input,
     textarea {
       &::placeholder {
@@ -211,6 +207,11 @@
         );
         content: url("data:image/svg+xml,@{svg}");
         height: 48px;
+      }
+      .conversation-input-field.svelte-1cceli6.type--default {
+      background: @crust;
+      border: none;
+      color: @text;
       }
     }
   }

--- a/styles/brave-search/catppuccin.user.less
+++ b/styles/brave-search/catppuccin.user.less
@@ -141,11 +141,6 @@
     #searchbox::placeholder {
       color: @subtext0;
     }
-    .conversation-input-field.type--default {
-      background: @crust;
-      border: none;
-      color: @text;
-    }
     .button.type--filled.theme--default {
       color: @base;
 
@@ -163,6 +158,11 @@
     }
     .tab-item.active ::after {
       background: @accent !important;
+    }
+    .conversation-input-field.type--default {
+      background: @crust;
+      border-color: @crust;
+      color: @text;
     }
 
     .logo-img {

--- a/styles/brave-search/catppuccin.user.less
+++ b/styles/brave-search/catppuccin.user.less
@@ -2,7 +2,7 @@
 @name Brave Search Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/brave-search
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/brave-search
-@version 2025.02.01
+@version 2025.02.28
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/brave-search/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Abrave-search
 @description Soothing pastel theme for Brave Search
@@ -141,7 +141,7 @@
     #searchbox::placeholder {
       color: @subtext0;
     }
-    .conversation-input-field.svelte-1cceli6.type--default {
+    .conversation-input-field.type--default {
     background: @crust;
     border: none;
     color: @text;

--- a/styles/brave-search/catppuccin.user.less
+++ b/styles/brave-search/catppuccin.user.less
@@ -142,9 +142,9 @@
       color: @subtext0;
     }
     .conversation-input-field.type--default {
-    background: @crust;
-    border: none;
-    color: @text;
+      background: @crust;
+      border: none;
+      color: @text;
     }
     .button.type--filled.theme--default {
       color: @base;

--- a/styles/brave-search/catppuccin.user.less
+++ b/styles/brave-search/catppuccin.user.less
@@ -141,7 +141,11 @@
     #searchbox::placeholder {
       color: @subtext0;
     }
-
+    .conversation-input-field.svelte-1cceli6.type--default {
+    background: @crust;
+    border: none;
+    color: @text;
+    }
     .button.type--filled.theme--default {
       color: @base;
 
@@ -207,11 +211,6 @@
         );
         content: url("data:image/svg+xml,@{svg}");
         height: 48px;
-      }
-      .conversation-input-field.svelte-1cceli6.type--default {
-      background: @crust;
-      border: none;
-      color: @text;
       }
     }
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes the "Ask a follow-up question" text field.

## 🗒 Checklist 🗒

- [v] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
