### PR TITLE
fix(seventv): chat mod button color

### DIFF
--- a/styles/seventv/catppuccin.user.less
+++ b/styles/seventv/catppuccin.user.less
@@ -510,7 +510,7 @@
       background-color: @surface0;
     }
 
-    .seventv-sub-message-container {
+    .seventv-sub-message-container, .seventv-reward-message-container {
       background-color: @base;
     }
 
@@ -563,6 +563,14 @@
 
     [style*="rgb(255, 255, 255)"] .seventv-chat-user-username span {
       color: @text !important;
+    }
+
+    .seventv-chat-mod-buttons {
+      color: @subtext0;
+
+      svg:hover {
+        color: @text;
+      }
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Themes chat mod buttons in the extension.
| Before | After |
| ------- | ------ |
| ![2025-03-02-163651_hyprshot](https://github.com/user-attachments/assets/92b42b6c-2a33-4133-87e0-a8fd9d7541b7) | ![2025-03-02-163744_hyprshot](https://github.com/user-attachments/assets/0f1b612f-f48c-4fce-af8d-ff4412e6a89a) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
