### PR TITLE
fix(chess.com): arrow and square highlights

### DIFF
--- a/styles/chess.com/catppuccin.user.less
+++ b/styles/chess.com/catppuccin.user.less
@@ -447,16 +447,16 @@
 
     .highlight {
       &[style*="rgb(235, 97, 80)"] {
-        background: @highlight1 !important;
+        background: fade(@highlight1, 80%) !important;
       }
       &[style*="rgb(172, 206, 89)"] {
-        background: @highlight2 !important;
+        background: fade(@highlight2, 80%) !important;
       }
       &[style*="rgb(255, 170, 0)"] {
-        background: @highlight3 !important;
+        background: fade(@highlight3, 80%) !important;
       }
       &[style*="rgb(82, 176, 220)"] {
-        background: @highlight4 !important;
+        background: fade(@highlight4, 80%) !important;
       }
       opacity: 1 !important;
     }

--- a/styles/chess.com/catppuccin.user.less
+++ b/styles/chess.com/catppuccin.user.less
@@ -481,7 +481,18 @@
     }
 
     .arrow {
-      fill: @overlay0 !important;
+      &[style*="rgba(248, 85, 63, 0.8)"] {
+        fill: @red !important;
+      }
+      &[style*="rgba(255, 170, 0, 0.8)"] {
+        fill: @peach !important;
+      }
+      &[style*="rgba(72, 193, 249, 0.8)"] {
+        fill: @blue !important;
+      }
+      &[style*="rgba(159, 207, 63, 0.8)"] {
+        fill: @green !important;
+      }
     }
 
     g#winner [fill="#dbac16"] {

--- a/styles/chess.com/catppuccin.user.less
+++ b/styles/chess.com/catppuccin.user.less
@@ -438,7 +438,18 @@
     }
 
     .highlight {
-      background: @highlight !important;
+      &[style*="rgb(235, 97, 80)"] {
+        background: @red !important;
+      }
+      &[style*="rgb(255, 170, 0)"] {
+        background: @peach !important;
+      }
+      &[style*="rgb(82, 176, 220)"] {
+        background: @blue !important;
+      }
+      &[style*="rgb(172, 206, 89)"] {
+        background: @green !important;
+      }
       opacity: 1 !important;
     }
     .hover-square rect {

--- a/styles/chess.com/catppuccin.user.less
+++ b/styles/chess.com/catppuccin.user.less
@@ -15,6 +15,10 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 
 @var select highlightColor "Highlight" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon*", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+@var select highlightColor1 "Highlight 1" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red*", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+@var select highlightColor2 "Highlight 2" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green*", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+@var select highlightColor3 "Highlight 3" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach*", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+@var select highlightColor4 "Highlight 4" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue*", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
 @-moz-document domain("chess.com") {
@@ -56,6 +60,10 @@
     @accent: @catppuccin[@@flavor][@@accentColor];
 
     @highlight: @catppuccin[@@flavor][@@highlightColor];
+    @highlight1: @catppuccin[@@flavor][@@highlightColor1];
+    @highlight2: @catppuccin[@@flavor][@@highlightColor2];
+    @highlight3: @catppuccin[@@flavor][@@highlightColor3];
+    @highlight4: @catppuccin[@@flavor][@@highlightColor4];
 
     color-scheme: if(@flavor = latte, light, dark);
 
@@ -439,16 +447,16 @@
 
     .highlight {
       &[style*="rgb(235, 97, 80)"] {
-        background: @red !important;
-      }
-      &[style*="rgb(255, 170, 0)"] {
-        background: @peach !important;
-      }
-      &[style*="rgb(82, 176, 220)"] {
-        background: @blue !important;
+        background: @highlight1 !important;
       }
       &[style*="rgb(172, 206, 89)"] {
-        background: @green !important;
+        background: @highlight2 !important;
+      }
+      &[style*="rgb(255, 170, 0)"] {
+        background: @highlight3 !important;
+      }
+      &[style*="rgb(82, 176, 220)"] {
+        background: @highlight4 !important;
       }
       opacity: 1 !important;
     }
@@ -493,16 +501,16 @@
 
     .arrow {
       &[style*="rgba(248, 85, 63, 0.8)"] {
-        fill: @red !important;
-      }
-      &[style*="rgba(255, 170, 0, 0.8)"] {
-        fill: @peach !important;
-      }
-      &[style*="rgba(72, 193, 249, 0.8)"] {
-        fill: @blue !important;
+        fill: @highlight1 !important;
       }
       &[style*="rgba(159, 207, 63, 0.8)"] {
-        fill: @green !important;
+        fill: @highlight2 !important;
+      }
+      &[style*="rgba(255, 170, 0, 0.8)"] {
+        fill: @highlight3 !important;
+      }
+      &[style*="rgba(72, 193, 249, 0.8)"] {
+        fill: @highlight4 !important;
       }
     }
 

--- a/styles/chess.com/catppuccin.user.less
+++ b/styles/chess.com/catppuccin.user.less
@@ -14,7 +14,6 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 
-@var select highlightColor "Highlight" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon*", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 @var select highlightColor1 "Highlight 1" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red*", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 @var select highlightColor2 "Highlight 2" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green*", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 @var select highlightColor3 "Highlight 3" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red", "maroon:Maroon", "peach:Peach*", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
@@ -59,7 +58,6 @@
     @crust: @catppuccin[@@flavor][@crust];
     @accent: @catppuccin[@@flavor][@@accentColor];
 
-    @highlight: @catppuccin[@@flavor][@@highlightColor];
     @highlight1: @catppuccin[@@flavor][@@highlightColor1];
     @highlight2: @catppuccin[@@flavor][@@highlightColor2];
     @highlight3: @catppuccin[@@flavor][@@highlightColor3];
@@ -710,7 +708,7 @@
     }
 
     --theme-board-style-image: url("data:image/svg+xml,@{board}");
-    --theme-board-style-highlight-color: @highlight;
+    --theme-board-style-highlight-color: @highlight1;
 
     --theme-piece-set-wp: #piece(@pawn, "white")[];
     --theme-piece-set-wn: #piece(@knight, "white")[];


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes #1606.

![image](https://github.com/user-attachments/assets/98112951-dc29-41c2-a19b-e594c2dba7b9)

- [x] arrow 4 variant color fix
- [x] highlight 4 variant color fix

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
