### PR TITLE
fix(youtube): live chat card

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -935,6 +935,9 @@
         color: @text;
       }
     }
+    .ytVideoMetadataCarouselViewModelHost {
+	    background-color: @surface0
+    }
 
     .html5-video-player {
       color: @white;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The Live chat card not being styled on YouTube
Before:
![image](https://github.com/user-attachments/assets/8800c9ba-a692-4a65-a9e4-ae9444805334)

After: 
![image](https://github.com/user-attachments/assets/cfb5aa66-058a-4383-8778-fb01cad95017)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
