### PR TITLE
feat(google-calendar): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -123,6 +123,8 @@ collaborators:
     url: https://github.com/pynappo
   - &nuexq
     url: https://github.com/nuexq
+  - &WalkQuackBack
+    url: https://github.com/WalkQuackBack
 
 userstyles:
   advent-of-code:
@@ -374,6 +376,14 @@ userstyles:
     readme:
       app-link: https://google.com
     current-maintainers: []
+  google-calendar:
+    name: Google Calendar
+    categories: [productivity]
+    icon: googlecalendar
+    color: blue
+    readme:
+      app-link: https://calendar.google.com
+    current-maintainers: [*WalkQuackBack]
   google-drive:
     name: Google Drive
     categories: [productivity]

--- a/styles/google-calendar/catppuccin.user.less
+++ b/styles/google-calendar/catppuccin.user.less
@@ -1,0 +1,398 @@
+/* ==UserStyle==
+@name Google Calendar Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/google-calendar
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-calendar
+@version 2025.03.20
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-calendar/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-calendar
+@description Soothing pastel theme for Google Calendar
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain("calendar.google.com") {
+    .DO879e:not(.PC2yOb).CcsDpe {
+        #catppuccin(@darkFlavor);
+    }
+
+    .DO879e:not(.PC2yOb):not(.CcsDpe) {
+        #catppuccin(@lightFlavor);
+    }
+
+    #rgbify(@color) {
+        @rgb: red(@color), green(@color), blue(@color);
+    }
+
+    #catppuccin(@flavor) {
+        @rosewater: @catppuccin[@@flavor][@rosewater];
+        @flamingo: @catppuccin[@@flavor][@flamingo];
+        @pink: @catppuccin[@@flavor][@pink];
+        @mauve: @catppuccin[@@flavor][@mauve];
+        @red: @catppuccin[@@flavor][@red];
+        @maroon: @catppuccin[@@flavor][@maroon];
+        @peach: @catppuccin[@@flavor][@peach];
+        @yellow: @catppuccin[@@flavor][@yellow];
+        @green: @catppuccin[@@flavor][@green];
+        @teal: @catppuccin[@@flavor][@teal];
+        @sky: @catppuccin[@@flavor][@sky];
+        @sapphire: @catppuccin[@@flavor][@sapphire];
+        @blue: @catppuccin[@@flavor][@blue];
+        @lavender: @catppuccin[@@flavor][@lavender];
+        @text: @catppuccin[@@flavor][@text];
+        @subtext1: @catppuccin[@@flavor][@subtext1];
+        @subtext0: @catppuccin[@@flavor][@subtext0];
+        @overlay2: @catppuccin[@@flavor][@overlay2];
+        @overlay1: @catppuccin[@@flavor][@overlay1];
+        @overlay0: @catppuccin[@@flavor][@overlay0];
+        @surface2: @catppuccin[@@flavor][@surface2];
+        @surface1: @catppuccin[@@flavor][@surface1];
+        @surface0: @catppuccin[@@flavor][@surface0];
+        @base: @catppuccin[@@flavor][@base];
+        @mantle: @catppuccin[@@flavor][@mantle];
+        @crust: @catppuccin[@@flavor][@crust];
+        @accent: @catppuccin[@@flavor][@@accentColor];
+        
+        @gm3-sys-color-error: @red;
+        @gm3-sys-color-error-rgb: #rgbify(@gm3-sys-color-error) [];
+        @gm3-sys-color-error-container: desaturate(darken(@red, 50%), 50%);
+        @gm3-sys-color-error-container-rgb: #rgbify(@gm3-sys-color-error-container) [];
+
+        @gm3-sys-color-on-error: darken(desaturate(@red, 20%), 50%);
+        @gm3-sys-color-on-error-rgb: #rgbify(@gm3-sys-color-on-error) [];
+        @gm3-sys-color-on-error-container: desaturate(darken(@red, -10%), 50%);
+        @gm3-sys-color-on-error-container-rgb: #rgbify(@gm3-sys-color-on-error-container) [];
+
+        @gm3-sys-color-primary: @accent;
+        @gm3-sys-color-primary-rgb: #rgbify(@gm3-sys-color-primary) [];
+        @gm3-sys-color-primary-fixed: lighten(@accent, 5%);
+        @gm3-sys-color-primary-fixed-rgb: #rgbify(@gm3-sys-color-primary-fixed) [];
+        @gm3-sys-color-primary-fixed-dim: darken(@accent, 5%);
+        @gm3-sys-color-primary-fixed-dim-rgb: #rgbify(@gm3-sys-color-primary-fixed-dim) [];
+
+        @gm3-sys-color-on-primary: saturate(mix(@gm3-sys-color-primary, @base, 20%), 25%);
+        @gm3-sys-color-on-primary-rgb: #rgbify(@gm3-sys-color-on-primary) [];
+        @gm3-sys-color-on-primary-fixed: darken(@gm3-sys-color-on-primary, 5%);
+        @gm3-sys-color-on-primary-fixed-rgb: #rgbify(@gm3-sys-color-on-primary-fixed) [];
+        @gm3-sys-color-on-primary-fixed-variant: lighten(@gm3-sys-color-on-primary, 5%);
+        @gm3-sys-color-on-primary-fixed-variant-rgb: #rgbify(@gm3-sys-color-on-primary-fixed-variant) [];
+
+        @gm3-sys-color-primary-container: saturate(mix(@gm3-sys-color-primary, @mantle, 40%), 20%);
+        @gm3-sys-color-primary-container-rgb: #rgbify(@gm3-sys-color-primary-container) [];
+        @gm3-sys-color-on-primary-container: saturate(mix(@gm3-sys-color-primary, @text, 10%), 25%);
+        @gm3-sys-color-on-primary-container-rgb: #rgbify(@gm3-sys-color-on-primary-container) [];
+
+        @gm3-sys-color-secondary: desaturate(@accent, 40%);
+        @gm3-sys-color-secondary-rgb: #rgbify(@gm3-sys-color-secondary) [];
+        @gm3-sys-color-secondary-fixed: lighten(@gm3-sys-color-secondary, 5%);
+        @gm3-sys-color-secondary-fixed-rgb: #rgbify(@gm3-sys-color-secondary-fixed) [];
+        @gm3-sys-color-secondary-fixed-dim: darken(@gm3-sys-color-secondary, 5%);
+        @gm3-sys-color-secondary-fixed-dim-rgb: #rgbify(@gm3-sys-color-secondary-fixed-dim) [];
+
+        @gm3-sys-color-on-secondary: saturate(mix(@gm3-sys-color-secondary, @base, 20%), 25%);
+        @gm3-sys-color-on-secondary-rgb: #rgbify(@gm3-sys-color-on-secondary) [];
+        @gm3-sys-color-on-secondary-fixed: darken(@gm3-sys-color-on-secondary, 5%);
+        @gm3-sys-color-on-secondary-fixed-rgb: #rgbify(@gm3-sys-color-on-secondary-fixed) [];
+        @gm3-sys-color-on-secondary-fixed-variant: lighten(@gm3-sys-color-on-primary, 5%);
+        @gm3-sys-color-on-secondary-fixed-variant-rgb: #rgbify(@gm3-sys-color-on-secondary-fixed-variant) [];
+
+        @gm3-sys-color-secondary-container: saturate(mix(@gm3-sys-color-secondary, @mantle, 20%), 10%);
+        @gm3-sys-color-secondary-container-rgb: #rgbify(@gm3-sys-color-secondary-container) [];
+        @gm3-sys-color-on-secondary-container: saturate(mix(@gm3-sys-color-secondary, @text, 10%), 25%);
+        @gm3-sys-color-on-secondary-container-rgb: #rgbify(@gm3-sys-color-on-secondary-container) [];
+
+        @gm3-sys-color-tertiary: @accent;
+        @gm3-sys-color-tertiary-rgb: #rgbify(@gm3-sys-color-tertiary) [];
+        @gm3-sys-color-tertiary-fixed: lighten(@gm3-sys-color-tertiary, 5%);
+        @gm3-sys-color-tertiary-fixed-rgb: #rgbify(@gm3-sys-color-tertiary-fixed) [];
+        @gm3-sys-color-tertiary-fixed-dim: darken(@gm3-sys-color-tertiary, 5%);
+        @gm3-sys-color-tertiary-fixed-dim-rgb: #rgbify(@gm3-sys-color-tertiary-fixed-dim) [];
+
+        @gm3-sys-color-on-tertiary: darken(desaturate(@gm3-sys-color-tertiary, 25%), 50%);
+        @gm3-sys-color-on-tertiary-rgb: #rgbify(@gm3-sys-color-on-tertiary) [];
+        @gm3-sys-color-on-tertiary-fixed: darken(@gm3-sys-color-on-tertiary, 5%);
+        @gm3-sys-color-on-tertiary-fixed-rgb: #rgbify(@gm3-sys-color-on-tertiary-fixed) [];
+        @gm3-sys-color-on-tertiary-fixed-variant: lighten(@gm3-sys-color-on-tertiary, 5%);
+        @gm3-sys-color-on-tertiary-fixed-variant-rgb: #rgbify(@gm3-sys-color-on-tertiary-fixed-variant) [];
+
+        @gm3-sys-color-tertiary-container: saturate(mix(@gm3-sys-color-tertiary, @mantle, 20%), 0%);
+        @gm3-sys-color-tertiary-container-rgb: #rgbify(@gm3-sys-color-tertiary-container) [];
+        @gm3-sys-color-on-tertiary-container: lighten(saturate(@gm3-sys-color-tertiary-container, 50%), 65%);
+        @gm3-sys-color-on-tertiary-container-rgb: #rgbify(@gm3-sys-color-on-tertiary-container) [];
+
+        @gm3-sys-color-background: @base;
+        @gm3-sys-color-background-rgb: #rgbify(@gm3-sys-color-background) [];
+        @gm3-sys-color-on-background: @text;
+        @gm3-sys-color-on-background-rgb: #rgbify(@gm3-sys-color-on-background) [];
+
+        @gm3-sys-color-surface: @base;
+        @gm3-sys-color-surface-rgb: #rgbify(@gm3-sys-color-surface) [];
+        @gm3-sys-color-surface-bright: @surface0;
+        @gm3-sys-color-surface-bright-rgb: #rgbify(@gm3-sys-color-surface-bright) [];
+        @gm3-sys-color-surface-dim: @crust;
+        @gm3-sys-color-surface-dim-rgb: #rgbify(@gm3-sys-color-surface-dim) [];
+        @gm3-sys-color-surface-variant: mix(@mantle, @accent, 87.5%);
+        @gm3-sys-color-surface-variant-rgb: #rgbify(@gm3-sys-color-surface-variant) [];
+        @gm3-sys-color-surface-tint: @accent;
+        @gm3-sys-color-surface-tint-rgb: #rgbify(@gm3-sys-color-surface-tint) [];
+
+        @gm3-sys-color-on-surface: @text;
+        @gm3-sys-color-on-surface-rgb: #rgbify(@gm3-sys-color-on-surface) [];
+        @gm3-sys-color-on-surface-variant: @subtext0;
+        @gm3-sys-color-on-surface-variant-rgb: #rgbify(@gm3-sys-color-on-surface-variant) [];
+
+        @gm3-sys-color-inverse-surface: @text;
+        @gm3-sys-color-inverse-surface-rgb: #rgbify(@gm3-sys-color-inverse-surface) [];
+        @gm3-sys-color-inverse-on-surface: @mantle;
+        @gm3-sys-color-inverse-on-surface-rgb: #rgbify(@gm3-sys-color-inverse-on-surface) [];
+        @gm3-sys-color-inverse-primary: if(@flavor = latte, @catppuccin[@mocha][@@accentColor], @catppuccin[@latte][@@accentColor]);; // TODO: Colour role clarification
+        @gm3-sys-color-inverse-primary-rgb: #rgbify(@gm3-sys-color-inverse-primary) [];
+
+        @gm3-sys-color-surface-container-highest: @surface1;
+        @gm3-sys-color-surface-container-highest-rgb: #rgbify(@gm3-sys-color-surface-container-highest) [];
+        @gm3-sys-color-surface-container-high: @surface0;
+        @gm3-sys-color-surface-container-high-rgb: #rgbify(@gm3-sys-color-surface-container-high) [];
+        @gm3-sys-color-surface-container: @surface0;
+        @gm3-sys-color-surface-container-rgb: #rgbify(@gm3-sys-color-surface-container) [];
+        @gm3-sys-color-surface-container-low: @mantle;
+        @gm3-sys-color-surface-container-low-rgb: #rgbify(@gm3-sys-color-surface-container-low) [];
+        @gm3-sys-color-surface-container-lowest: @crust;
+        @gm3-sys-color-surface-container-lowest-rgb: #rgbify(@gm3-sys-color-surface-container-lowest) [];
+
+        @gm3-sys-color-outline: @overlay2;
+        @gm3-sys-color-outline-rgb: #rgbify(@gm3-sys-color-outline) [];
+        @gm3-sys-color-outline-variant: @overlay0;
+        @gm3-sys-color-outline-variant-rgb: #rgbify(@gm3-sys-color-outline-variant) [];
+
+        @gm3-sys-color-scrim: #000;
+        @gm3-sys-color-scrim-rgb: #rgbify(@gm3-sys-color-scrim) [];
+        @gm3-sys-color-shadow: #000;
+        @gm3-sys-color-shadow-rgb: #rgbify(@gm3-sys-color-shadow) [];
+
+        @cal-sys-color-warning: @yellow;
+        @cal-sys-color-warning-container: saturate(mix(@yellow, @mantle, 20%), 0%);
+        @cal-sys-color-on-warning: #4d2600;
+        @cal-sys-color-on-warning-container: #fff2b4;
+
+        @cal-sys-color-conflict: @peach;
+        @cal-sys-color-conflict-container: saturate(mix(@peach, @mantle, 20%), 0%);
+        @cal-sys-color-on-conflict: #522302;
+        @cal-sys-color-on-conflict-container: #ffdcc3;
+
+        @cal-sys-color-success: @green;
+        @cal-sys-color-success-container: saturate(mix(@green, @mantle, 20%), 0%);
+        @cal-sys-color-on-success: #00381f;
+        @cal-sys-color-on-success-container: #beefbb;
+
+        @cal-sys-color-night: @lavender;
+        @cal-sys-color-night-container: saturate(mix(@lavender, @mantle, 20%), 0%);
+        @cal-sys-color-on-night: #400b84;
+        @cal-sys-color-on-night-container: #eedcfe;
+
+        @cal-sys-color-scrollbar: @surface2;
+        @cal-sys-color-scrollbar-hover: lighten(@surface2, 6%);
+        @cal-sys-color-scrollbar-active: lighten(@surface2, 12%);
+
+        @cal-sys-color-now-indicator: @maroon;
+        @cal-sys-color-helper-variant: @subtext0;
+
+        // TODO: Look at how Gemini userstyle handles this for consistency.
+        @ae-genai-generation-gradient: linear-gradient(135deg,#217bfe,#078efb,#ac87eb,#217bfe);
+        @ae-sidekick-container-color: var(--gm3-sys-color-surface-dim,#131314);
+        @ae-sidekick-prompt-input-text-color: @text;
+        @ae-sidekick-prompt-input-text-placeholder-color: @subtext1;
+        @ae-sidekick-user-message-container-color: var(--gm3-sys-color-on-primary,#062e6f);
+
+        --gm3-sys-color-background: @gm3-sys-color-background;
+        --gm3-sys-color-background-rgb: @gm3-sys-color-background-rgb;
+        --gm3-sys-color-error: @gm3-sys-color-error;
+        --gm3-sys-color-error-rgb: @gm3-sys-color-error-rgb;
+        --gm3-sys-color-error-container: @gm3-sys-color-error-container;
+        --gm3-sys-color-error-container-rgb: @gm3-sys-color-error-container-rgb;
+        --gm3-sys-color-inverse-on-surface: @gm3-sys-color-inverse-on-surface;
+        --gm3-sys-color-inverse-on-surface-rgb: @gm3-sys-color-inverse-on-surface-rgb;
+        --gm3-sys-color-inverse-primary: @gm3-sys-color-inverse-primary;
+        --gm3-sys-color-inverse-primary-rgb: @gm3-sys-color-inverse-primary-rgb;
+        --gm3-sys-color-inverse-surface: @gm3-sys-color-inverse-surface;
+        --gm3-sys-color-inverse-surface-rgb: @gm3-sys-color-inverse-surface-rgb;
+        --gm3-sys-color-on-background: @gm3-sys-color-on-background;
+        --gm3-sys-color-on-background-rgb: @gm3-sys-color-on-background-rgb;
+        --gm3-sys-color-on-error: @gm3-sys-color-on-error;
+        --gm3-sys-color-on-error-rgb: @gm3-sys-color-on-error-rgb;
+        --gm3-sys-color-on-error-container: @gm3-sys-color-on-error-container;
+        --gm3-sys-color-on-error-container-rgb: @gm3-sys-color-on-error-container-rgb;
+        --gm3-sys-color-on-primary: @gm3-sys-color-on-primary;
+        --gm3-sys-color-on-primary-rgb: @gm3-sys-color-on-primary-rgb;
+        --gm3-sys-color-on-primary-container: @gm3-sys-color-on-primary-container;
+        --gm3-sys-color-on-primary-container-rgb: @gm3-sys-color-on-primary-container-rgb;
+        --gm3-sys-color-on-primary-fixed: @gm3-sys-color-on-primary-fixed;
+        --gm3-sys-color-on-primary-fixed-rgb: @gm3-sys-color-on-primary-fixed-rgb;
+        --gm3-sys-color-on-primary-fixed-variant: @gm3-sys-color-on-primary-fixed-variant;
+        --gm3-sys-color-on-primary-fixed-variant-rgb: @gm3-sys-color-on-primary-fixed-variant-rgb;
+        --gm3-sys-color-on-secondary: @gm3-sys-color-on-secondary;
+        --gm3-sys-color-on-secondary-rgb: @gm3-sys-color-on-secondary-rgb;
+        --gm3-sys-color-on-secondary-container: @gm3-sys-color-on-secondary-container;
+        --gm3-sys-color-on-secondary-container-rgb: @gm3-sys-color-on-secondary-container-rgb;
+        --gm3-sys-color-on-secondary-fixed: @gm3-sys-color-on-secondary-fixed;
+        --gm3-sys-color-on-secondary-fixed-rgb: @gm3-sys-color-on-secondary-fixed-rgb;
+        --gm3-sys-color-on-secondary-fixed-variant: @gm3-sys-color-on-secondary-fixed-variant;
+        --gm3-sys-color-on-secondary-fixed-variant-rgb: @gm3-sys-color-on-secondary-fixed-variant-rgb;
+        --gm3-sys-color-on-surface: @gm3-sys-color-on-surface;
+        --gm3-sys-color-on-surface-rgb: @gm3-sys-color-on-surface-rgb;
+        --gm3-sys-color-on-surface-variant: @gm3-sys-color-on-surface-variant;
+        --gm3-sys-color-on-surface-variant-rgb: @gm3-sys-color-on-surface-variant-rgb;
+        --gm3-sys-color-on-tertiary: @gm3-sys-color-on-tertiary;
+        --gm3-sys-color-on-tertiary-rgb: @gm3-sys-color-on-tertiary-rgb;
+        --gm3-sys-color-on-tertiary-container: @gm3-sys-color-on-tertiary-container;
+        --gm3-sys-color-on-tertiary-container-rgb: @gm3-sys-color-on-tertiary-container-rgb;
+        --gm3-sys-color-on-tertiary-fixed: @gm3-sys-color-on-tertiary-fixed;
+        --gm3-sys-color-on-tertiary-fixed-rgb: @gm3-sys-color-on-tertiary-fixed-rgb;
+        --gm3-sys-color-on-tertiary-fixed-variant: @gm3-sys-color-on-tertiary-fixed-variant;
+        --gm3-sys-color-on-tertiary-fixed-variant-rgb: @gm3-sys-color-on-tertiary-fixed-variant-rgb;
+        --gm3-sys-color-outline: @gm3-sys-color-outline;
+        --gm3-sys-color-outline-rgb: @gm3-sys-color-outline-rgb;
+        --gm3-sys-color-outline-variant: @gm3-sys-color-outline-variant;
+        --gm3-sys-color-outline-variant-rgb: @gm3-sys-color-outline-variant-rgb;
+        --gm3-sys-color-primary: @gm3-sys-color-primary;
+        --gm3-sys-color-primary-rgb: @gm3-sys-color-primary-rgb;
+        --gm3-sys-color-primary-container: @gm3-sys-color-primary-container;
+        --gm3-sys-color-primary-container-rgb: @gm3-sys-color-primary-container-rgb;
+        --gm3-sys-color-primary-fixed: @gm3-sys-color-primary-fixed;
+        --gm3-sys-color-primary-fixed-rgb: @gm3-sys-color-primary-fixed-rgb;
+        --gm3-sys-color-primary-fixed-dim: @gm3-sys-color-primary-fixed-dim;
+        --gm3-sys-color-primary-fixed-dim-rgb: @gm3-sys-color-primary-fixed-dim-rgb;
+        --gm3-sys-color-scrim: @gm3-sys-color-scrim;
+        --gm3-sys-color-scrim-rgb: @gm3-sys-color-scrim-rgb;
+        --gm3-sys-color-secondary: @gm3-sys-color-secondary;
+        --gm3-sys-color-secondary-rgb: @gm3-sys-color-secondary-rgb;
+        --gm3-sys-color-secondary-container: @gm3-sys-color-secondary-container;
+        --gm3-sys-color-secondary-container-rgb: @gm3-sys-color-secondary-container-rgb;
+        --gm3-sys-color-secondary-fixed: @gm3-sys-color-secondary-fixed;
+        --gm3-sys-color-secondary-fixed-rgb: @gm3-sys-color-secondary-fixed-rgb;
+        --gm3-sys-color-secondary-fixed-dim: @gm3-sys-color-secondary-fixed-dim;
+        --gm3-sys-color-secondary-fixed-dim-rgb: @gm3-sys-color-secondary-fixed-dim-rgb;
+        --gm3-sys-color-shadow: @gm3-sys-color-shadow;
+        --gm3-sys-color-shadow-rgb: @gm3-sys-color-shadow-rgb;
+        --gm3-sys-color-surface: @gm3-sys-color-surface;
+        --gm3-sys-color-surface-rgb: @gm3-sys-color-surface-rgb;
+        --gm3-sys-color-surface-bright: @gm3-sys-color-surface-bright;
+        --gm3-sys-color-surface-bright-rgb: @gm3-sys-color-surface-bright-rgb;
+        --gm3-sys-color-surface-container: @gm3-sys-color-surface-container;
+        --gm3-sys-color-surface-container-rgb: @gm3-sys-color-surface-container-rgb;
+        --gm3-sys-color-surface-container-high: @gm3-sys-color-surface-container-high;
+        --gm3-sys-color-surface-container-high-rgb: @gm3-sys-color-surface-container-high-rgb;
+        --gm3-sys-color-surface-container-highest: @gm3-sys-color-surface-container-highest;
+        --gm3-sys-color-surface-container-highest-rgb: @gm3-sys-color-surface-container-highest-rgb;
+        --gm3-sys-color-surface-container-low: @gm3-sys-color-surface-container-low;
+        --gm3-sys-color-surface-container-low-rgb: @gm3-sys-color-surface-container-low-rgb;
+        --gm3-sys-color-surface-container-lowest: @gm3-sys-color-surface-container-lowest;
+        --gm3-sys-color-surface-container-lowest-rgb: @gm3-sys-color-surface-container-lowest-rgb;
+        --gm3-sys-color-surface-dim: @gm3-sys-color-surface-dim;
+        --gm3-sys-color-surface-dim-rgb: @gm3-sys-color-surface-dim-rgb;
+        --gm3-sys-color-surface-tint: @gm3-sys-color-surface-tint;
+        --gm3-sys-color-surface-tint-rgb: @gm3-sys-color-surface-tint-rgb;
+        --gm3-sys-color-surface-variant: @gm3-sys-color-surface-variant;
+        --gm3-sys-color-surface-variant-rgb: @gm3-sys-color-surface-variant-rgb;
+        --gm3-sys-color-tertiary: @gm3-sys-color-tertiary;
+        --gm3-sys-color-tertiary-rgb: @gm3-sys-color-tertiary-rgb;
+        --gm3-sys-color-tertiary-container: @gm3-sys-color-tertiary-container;
+        --gm3-sys-color-tertiary-container-rgb: @gm3-sys-color-tertiary-container-rgb;
+        --gm3-sys-color-tertiary-fixed: @gm3-sys-color-tertiary-fixed;
+        --gm3-sys-color-tertiary-fixed-rgb: @gm3-sys-color-tertiary-fixed-rgb;
+        --gm3-sys-color-tertiary-fixed-dim: @gm3-sys-color-tertiary-fixed-dim;
+        --gm3-sys-color-tertiary-fixed-dim-rgb: @gm3-sys-color-tertiary-fixed-dim-rgb;
+        --cal-sys-color-warning: @cal-sys-color-warning;
+        --cal-sys-color-warning-container: @cal-sys-color-warning-container;
+        --cal-sys-color-on-warning: @cal-sys-color-on-warning;
+        --cal-sys-color-on-warning-container: @cal-sys-color-on-warning-container;
+        --cal-sys-color-conflict: @cal-sys-color-conflict;
+        --cal-sys-color-conflict-container: @cal-sys-color-conflict-container;
+        --cal-sys-color-on-conflict: @cal-sys-color-on-conflict;
+        --cal-sys-color-on-conflict-container: @cal-sys-color-on-conflict-container;
+        --cal-sys-color-success: @cal-sys-color-success;
+        --cal-sys-color-success-container: @cal-sys-color-success-container;
+        --cal-sys-color-on-success: @cal-sys-color-on-success;
+        --cal-sys-color-on-success-container: @cal-sys-color-on-success-container;
+        --cal-sys-color-night: @cal-sys-color-night;
+        --cal-sys-color-night-container: @cal-sys-color-night-container;
+        --cal-sys-color-on-night: @cal-sys-color-on-night;
+        --cal-sys-color-on-night-container: @cal-sys-color-on-night-container;
+        --cal-sys-color-scrollbar: @cal-sys-color-scrollbar;
+        --cal-sys-color-scrollbar-hover: @cal-sys-color-scrollbar-hover;
+        --cal-sys-color-scrollbar-active: @cal-sys-color-scrollbar-active;
+        --cal-sys-color-now-indicator: @cal-sys-color-now-indicator;
+        --cal-sys-color-helper-variant: @cal-sys-color-helper-variant;
+        --ae-genai-generation-gradient: linear-gradient(135deg,#217bfe,#078efb,#ac87eb,#217bfe);
+        --ae-sidekick-container-color: var(--gm3-sys-color-surface-dim,#131314);
+        --ae-sidekick-prompt-input-text-color: @ae-sidekick-prompt-input-text-color;
+        --ae-sidekick-prompt-input-text-placeholder-color: @ae-sidekick-prompt-input-text-placeholder-color;
+        --ae-sidekick-user-message-container-color: var(--gm3-sys-color-on-primary,#062e6f);
+        --ae-sidekick-shimmer-blend-mode: darken;
+        --ae-sidekick-gem-display-light: none;
+        --ae-sidekick-gem-display-dark: flex;
+        
+        /* Main styles start */
+        color-scheme: if(@flavor = latte, light, dark);
+
+        ::selection {
+            background-color: fade(@accent, 30%);
+        }
+
+        input,
+        textarea {
+            &::placeholder {
+                color: @subtext0 !important;
+            }
+        }
+        
+        .CcsDpe.eh9LUb .TyFLN,
+        .CcsDpe.sphSn .TyFLN {
+            @svg: escape('<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="nonzero"><path fill="@{base}" d="M0 0h12v12H0z"/><path d="M6 0h6L0 12V6l6-6zm6 6v6H6l6-6z" fill="@{surface0}"/></g></svg>');
+            background-image: url("data:image/svg+xml,@{svg}");
+        }
+        
+        .R8qYlc {
+            background-color: var(--gm3-sys-color-inverse-surface);
+        }
+        
+        .RM9ulf {
+            color: var(--gm3-sys-color-inverse-on-surface);
+        }
+        
+        .fy2Kyc.wdLSAe:hover {
+            background-color: var(--gm3-sys-color-primary);
+        }
+        
+        img {
+            &[src="https://ssl.gstatic.com/calendar/images/theme/theme_picker_light.svg"] {
+                @svg: escape('<svg width="140" height="162" viewBox="0 0 140 162" fill="none" var="@{base}" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_5_1739)"><path d="M124 0H16C7.16344 0 0 7.16344 0 16V145.757C0 154.594 7.16344 161.757 16 161.757H124C132.837 161.757 140 154.594 140 145.757V16C140 7.16344 132.837 0 124 0Z" fill="#E6E9EF"/><path d="M33.8961 17.1836L28.9298 16.6318L22.86 17.1836L22.3082 22.7017L22.86 28.2197L28.378 28.9094L33.8961 28.2197L34.4479 22.5637L33.8961 17.1836Z" fill="white"/><path d="M25.1238 25.7451C24.7113 25.4664 24.4258 25.0595 24.2699 24.5215L25.2273 24.1269C25.3142 24.458 25.4659 24.7146 25.6825 24.8967C25.8977 25.0788 26.1598 25.1685 26.4661 25.1685C26.7792 25.1685 27.0482 25.0733 27.2731 24.8829C27.4979 24.6925 27.6111 24.4498 27.6111 24.1559C27.6111 23.8552 27.4924 23.6096 27.2551 23.4193C27.0179 23.2289 26.7199 23.1337 26.364 23.1337H25.8108V22.186H26.3074C26.6137 22.186 26.8716 22.1032 27.0813 21.9377C27.291 21.7721 27.3959 21.5459 27.3959 21.2576C27.3959 21.001 27.302 20.7968 27.1144 20.6437C26.9268 20.4906 26.6895 20.4133 26.4012 20.4133C26.1198 20.4133 25.8963 20.4878 25.7308 20.6382C25.5653 20.7885 25.4452 20.9734 25.3694 21.1914L24.4216 20.7968C24.5472 20.4409 24.7776 20.1264 25.1155 19.8546C25.4535 19.5829 25.8853 19.4463 26.4095 19.4463C26.7972 19.4463 27.1462 19.5208 27.4552 19.6711C27.7642 19.8215 28.007 20.0298 28.1822 20.2947C28.3574 20.5609 28.4443 20.8589 28.4443 21.19C28.4443 21.528 28.3629 21.8135 28.2001 22.048C28.0373 22.2826 27.8373 22.4619 27.6 22.5874V22.644C27.9132 22.775 28.1684 22.9751 28.3698 23.2441C28.5698 23.5131 28.6705 23.8345 28.6705 24.2097C28.6705 24.5849 28.5753 24.9202 28.385 25.214C28.1946 25.5078 27.9311 25.7396 27.5973 25.9079C27.262 26.0762 26.8854 26.1617 26.4674 26.1617C25.9832 26.1631 25.5363 26.0238 25.1238 25.7451Z" fill="#1A73E8"/><path d="M30.9991 20.9941L29.9534 21.7542L29.4279 20.9569L31.3136 19.5967H32.0365V26.0128H30.9991V20.9941Z" fill="#1A73E8"/><path d="M33.8961 33.186L38.8623 28.2198L36.3792 27.1162L33.8961 28.2198L32.7925 30.7029L33.8961 33.186Z" fill="#EA4335"/><path d="M21.7565 30.7028L22.8601 33.1859H33.8961V28.2197H22.8601L21.7565 30.7028Z" fill="#34A853"/><path d="M19.5492 12.2178C18.6346 12.2178 17.8938 12.9586 17.8938 13.8732V28.22L20.3769 29.3236L22.86 28.22V17.184H33.8961L34.9997 14.7009L33.8961 12.2178H19.5492Z" fill="#4285F4"/><path d="M17.8938 28.2197V31.5305C17.8938 32.4451 18.6346 33.1859 19.5492 33.1859H22.86V28.2197H17.8938Z" fill="#188038"/><path d="M33.896 17.1837V28.2197H38.8622V17.1837L36.3791 16.0801L33.896 17.1837Z" fill="#FBBC04"/><path d="M38.8622 17.184V13.8732C38.8622 12.9586 38.1214 12.2178 37.2068 12.2178H33.896V17.184H38.8622Z" fill="#1967D2"/><g filter="url(#filter0_dd_5_1739)"><path d="M112.11 46H28C21.3726 46 16 51.3726 16 58V71.8385C16 78.4659 21.3726 83.8385 28 83.8385H112.11C118.737 83.8385 124.11 78.4659 124.11 71.8385V58C124.11 51.3726 118.737 46 112.11 46Z" fill="#F0F4F9"/></g><path d="M44.3792 65.8662H37.7574V72.4879H35.8655V65.8662H29.2438V63.9743H35.8655V57.3525H37.7574V63.9743H44.3792V65.8662Z" fill="#4C4F69"/><path d="M105.866 63.9727H58.5681C58.0456 63.9727 57.6221 64.3962 57.6221 64.9187C57.6221 65.4411 58.0456 65.8646 58.5681 65.8646H105.866C106.389 65.8646 106.812 65.4411 106.812 64.9187C106.812 64.3962 106.389 63.9727 105.866 63.9727Z" fill="#4C4F69"/><path d="M114.459 98.3779H25.5405C25.0181 98.3779 24.5946 98.8014 24.5946 99.3238C24.5946 99.8463 25.0181 100.27 25.5405 100.27H114.459C114.982 100.27 115.405 99.8463 115.405 99.3238C115.405 98.8014 114.982 98.3779 114.459 98.3779Z" fill="#4C4F69"/><path d="M114.459 115.405H25.5405C25.0181 115.405 24.5946 115.829 24.5946 116.351C24.5946 116.873 25.0181 117.297 25.5405 117.297H114.459C114.982 117.297 115.405 116.873 115.405 116.351C115.405 115.829 114.982 115.405 114.459 115.405Z" fill="#4C4F69"/><path d="M114.459 132.433H25.5405C25.0181 132.433 24.5946 132.857 24.5946 133.379C24.5946 133.901 25.0181 134.325 25.5405 134.325H114.459C114.982 134.325 115.405 133.901 115.405 133.379C115.405 132.857 114.982 132.433 114.459 132.433Z" fill="#4C4F69"/></g><defs><filter id="filter0_dd_5_1739" x="13" y="44" width="114.11" height="43.8385" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1.5"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_5_1739"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/><feBlend mode="normal" in2="effect1_dropShadow_5_1739" result="effect2_dropShadow_5_1739"/><feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_5_1739" result="shape"/></filter><clipPath id="clip0_5_1739"><rect width="140" height="162" fill="white"/></clipPath></defs></svg>');
+                content: url("data:image/svg+xml,@{svg}");
+            }
+            &[src="https://ssl.gstatic.com/calendar/images/theme/theme_picker_dark.svg"] {
+                @svg: escape('<svg width="140" height="162" viewBox="0 0 140 162" fill="none" var="@{base}" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_5_1710)"><path d="M124 0H16C7.16344 0 0 7.16344 0 16V145.757C0 154.594 7.16344 161.757 16 161.757H124C132.837 161.757 140 154.594 140 145.757V16C140 7.16344 132.837 0 124 0Z" fill="#1E2030"/><path d="M124 0H16C7.16344 0 0 7.16344 0 16V145.757C0 154.594 7.16344 161.757 16 161.757H124C132.837 161.757 140 154.594 140 145.757V16C140 7.16344 132.837 0 124 0Z" fill="#D1E1FF" fill-opacity="0.05"/><path d="M33.8961 17.1836L28.9298 16.6318L22.86 17.1836L22.3082 22.7017L22.86 28.2197L28.378 28.9094L33.8961 28.2197L34.4479 22.5637L33.8961 17.1836Z" fill="white"/><path d="M25.1238 25.7451C24.7113 25.4664 24.4258 25.0595 24.2699 24.5215L25.2273 24.1269C25.3142 24.458 25.4659 24.7146 25.6825 24.8967C25.8977 25.0788 26.1598 25.1685 26.4661 25.1685C26.7792 25.1685 27.0482 25.0733 27.2731 24.8829C27.4979 24.6925 27.6111 24.4498 27.6111 24.1559C27.6111 23.8552 27.4924 23.6096 27.2551 23.4193C27.0179 23.2289 26.7199 23.1337 26.364 23.1337H25.8108V22.186H26.3074C26.6137 22.186 26.8716 22.1032 27.0813 21.9377C27.291 21.7721 27.3959 21.5459 27.3959 21.2576C27.3959 21.001 27.302 20.7968 27.1144 20.6437C26.9268 20.4906 26.6895 20.4133 26.4012 20.4133C26.1198 20.4133 25.8963 20.4878 25.7308 20.6382C25.5653 20.7885 25.4452 20.9734 25.3694 21.1914L24.4216 20.7968C24.5472 20.4409 24.7776 20.1264 25.1155 19.8546C25.4535 19.5829 25.8853 19.4463 26.4095 19.4463C26.7972 19.4463 27.1462 19.5208 27.4552 19.6711C27.7642 19.8215 28.007 20.0298 28.1822 20.2947C28.3574 20.5609 28.4443 20.8589 28.4443 21.19C28.4443 21.528 28.3629 21.8135 28.2001 22.048C28.0373 22.2826 27.8373 22.4619 27.6 22.5874V22.644C27.9132 22.775 28.1684 22.9751 28.3698 23.2441C28.5698 23.5131 28.6705 23.8345 28.6705 24.2097C28.6705 24.5849 28.5753 24.9202 28.385 25.214C28.1946 25.5078 27.9311 25.7396 27.5973 25.9079C27.262 26.0762 26.8854 26.1617 26.4674 26.1617C25.9832 26.1631 25.5363 26.0238 25.1238 25.7451Z" fill="#1A73E8"/><path d="M30.9991 20.9941L29.9534 21.7542L29.4279 20.9569L31.3136 19.5967H32.0365V26.0128H30.9991V20.9941Z" fill="#1A73E8"/><path d="M33.8961 33.186L38.8623 28.2198L36.3792 27.1162L33.8961 28.2198L32.7925 30.7029L33.8961 33.186Z" fill="#EA4335"/><path d="M21.7565 30.7028L22.8601 33.1859H33.8961V28.2197H22.8601L21.7565 30.7028Z" fill="#34A853"/><path d="M19.5492 12.2178C18.6346 12.2178 17.8938 12.9586 17.8938 13.8732V28.22L20.3769 29.3236L22.86 28.22V17.184H33.8961L34.9997 14.7009L33.8961 12.2178H19.5492Z" fill="#4285F4"/><path d="M17.8938 28.2197V31.5305C17.8938 32.4451 18.6346 33.1859 19.5492 33.1859H22.86V28.2197H17.8938Z" fill="#188038"/><path d="M33.896 17.1837V28.2197H38.8622V17.1837L36.3791 16.0801L33.896 17.1837Z" fill="#FBBC04"/><path d="M38.8622 17.184V13.8732C38.8622 12.9586 38.1214 12.2178 37.2068 12.2178H33.896V17.184H38.8622Z" fill="#1967D2"/><path d="M114.459 98.3779H25.5406C25.0181 98.3779 24.5946 98.8014 24.5946 99.3238C24.5946 99.8463 25.0181 100.27 25.5406 100.27H114.459C114.982 100.27 115.405 99.8463 115.405 99.3238C115.405 98.8014 114.982 98.3779 114.459 98.3779Z" fill="#CAD3F5"/><path d="M114.459 115.405H25.5406C25.0181 115.405 24.5946 115.829 24.5946 116.351C24.5946 116.873 25.0181 117.297 25.5406 117.297H114.459C114.982 117.297 115.405 116.873 115.405 116.351C115.405 115.829 114.982 115.405 114.459 115.405Z" fill="#CAD3F5"/><path d="M114.459 132.433H25.5406C25.0181 132.433 24.5946 132.857 24.5946 133.379C24.5946 133.901 25.0181 134.325 25.5406 134.325H114.459C114.982 134.325 115.405 133.901 115.405 133.379C115.405 132.857 114.982 132.433 114.459 132.433Z" fill="#CAD3F5"/><g filter="url(#filter0_dd_5_1710)"><path d="M111.243 43.5137H27.1348C20.5074 43.5137 15.1348 48.8863 15.1348 55.5137V69.3515C15.1348 75.9789 20.5074 81.3515 27.1348 81.3515H111.243C117.87 81.3515 123.243 75.9789 123.243 69.3515V55.5137C123.243 48.8863 117.87 43.5137 111.243 43.5137Z" fill="#1E2030"/></g><path d="M43.5127 63.3787H36.8911V70.0004H34.9992V63.3787H28.3776V61.4869H34.9992V54.8652H36.8911V61.4869H43.5127V63.3787Z" fill="#CAD3F5"/><path d="M105 61.4863H57.7028C57.1803 61.4863 56.7568 61.9098 56.7568 62.4322C56.7568 62.9547 57.1803 63.3782 57.7028 63.3782H105C105.522 63.3782 105.946 62.9547 105.946 62.4322C105.946 61.9098 105.522 61.4863 105 61.4863Z" fill="#CAD3F5"/></g><defs><filter id="filter0_dd_5_1710" x="12.1348" y="41.5137" width="114.108" height="43.8378" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1.5"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_5_1710"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/><feBlend mode="normal" in2="effect1_dropShadow_5_1710" result="effect2_dropShadow_5_1710"/><feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_5_1710" result="shape"/></filter><clipPath id="clip0_5_1710"><rect width="140" height="162" fill="white"/></clipPath></defs></svg>');
+                content: url("data:image/svg+xml,@{svg}");
+            }
+            &[src="https://ssl.gstatic.com/calendar/images/theme/theme_picker_device_light.svg"] {
+                @svg: escape('<svg width="70" height="162" viewBox="0 0 70 162" fill="none" var="@{base}" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_5_1688)"><mask id="mask0_5_1688" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="162"><path d="M0 16C0 7.16344 7.16344 0 16 0H70V161.757H16C7.16344 161.757 0 154.593 0 145.757V16Z" fill="white"/></mask><g mask="url(#mask0_5_1688)"><path d="M0 16C0 7.16344 7.16344 0 16 0H70V161.757H16C7.16344 161.757 0 154.593 0 145.757V16Z" fill="#E6E9EF"/><path d="M34.0023 16.9658L29.036 16.414L22.9662 16.9658L22.4144 22.4839L22.9662 28.0019L28.4842 28.6916L34.0023 28.0019L34.5541 22.3459L34.0023 16.9658Z" fill="white"/><path d="M25.23 25.5273C24.8175 25.2486 24.532 24.8417 24.3761 24.3037L25.3335 23.9091C25.4204 24.2402 25.5721 24.4968 25.7887 24.6789C26.0039 24.861 26.266 24.9507 26.5723 24.9507C26.8854 24.9507 27.1544 24.8555 27.3793 24.6651C27.6041 24.4747 27.7173 24.232 27.7173 23.9381C27.7173 23.6374 27.5986 23.3918 27.3613 23.2015C27.1241 23.0111 26.8261 22.9159 26.4702 22.9159H25.917V21.9682H26.4136C26.7199 21.9682 26.9778 21.8854 27.1875 21.7199C27.3972 21.5543 27.5021 21.3281 27.5021 21.0398C27.5021 20.7832 27.4082 20.579 27.2206 20.4259C27.033 20.2728 26.7957 20.1955 26.5074 20.1955C26.226 20.1955 26.0025 20.27 25.837 20.4204C25.6715 20.5707 25.5514 20.7556 25.4756 20.9736L24.5278 20.579C24.6534 20.2231 24.8838 19.9086 25.2217 19.6368C25.5597 19.3651 25.9915 19.2285 26.5157 19.2285C26.9034 19.2285 27.2524 19.303 27.5614 19.4533C27.8704 19.6037 28.1132 19.812 28.2884 20.0769C28.4636 20.3431 28.5505 20.6411 28.5505 20.9722C28.5505 21.3102 28.4691 21.5957 28.3063 21.8302C28.1435 22.0648 27.9435 22.2441 27.7062 22.3696V22.4262C28.0194 22.5572 28.2746 22.7573 28.476 23.0263C28.676 23.2953 28.7767 23.6167 28.7767 23.9919C28.7767 24.3671 28.6815 24.7024 28.4912 24.9962C28.3008 25.29 28.0373 25.5218 27.7035 25.6901C27.3682 25.8584 26.9916 25.9439 26.5736 25.9439C26.0894 25.9453 25.6425 25.806 25.23 25.5273Z" fill="#1A73E8"/><path d="M31.1053 20.7763L30.0596 21.5364L29.5341 20.7391L31.4198 19.3789H32.1427V25.795H31.1053V20.7763Z" fill="#1A73E8"/><path d="M34.0023 32.9682L38.9685 28.002L36.4854 26.8984L34.0023 28.002L32.8987 30.4851L34.0023 32.9682Z" fill="#EA4335"/><path d="M21.8627 30.485L22.9663 32.9681H34.0023V28.0019H22.9663L21.8627 30.485Z" fill="#34A853"/><path d="M19.6554 12C18.7408 12 18 12.7408 18 13.6554V28.0022L20.4831 29.1058L22.9662 28.0022V16.9662H34.0023L35.1059 14.4831L34.0023 12H19.6554Z" fill="#4285F4"/><path d="M18 28.0019V31.3127C18 32.2273 18.7408 32.9681 19.6554 32.9681H22.9662V28.0019H18Z" fill="#188038"/><path d="M34.0022 16.9659V28.0019H38.9684V16.9659L36.4853 15.8623L34.0022 16.9659Z" fill="#FBBC04"/><path d="M38.9684 16.9662V13.6554C38.9684 12.7408 38.2276 12 37.313 12H34.0022V16.9662H38.9684Z" fill="#1967D2"/><g filter="url(#filter0_dd_5_1688)"><path d="M111.243 43.5137H27.1348C20.5074 43.5137 15.1348 48.8863 15.1348 55.5137V69.3515C15.1348 75.9789 20.5074 81.3515 27.1348 81.3515H111.243C117.87 81.3515 123.243 75.9789 123.243 69.3515V55.5137C123.243 48.8863 117.87 43.5137 111.243 43.5137Z" fill="#F0F4F9"/></g><path d="M43.5127 63.3787H36.8911V70.0004H34.9992V63.3787H28.3776V61.4869H34.9992V54.8652H36.8911V61.4869H43.5127V63.3787Z" fill="#4C4F69"/><path d="M105 61.4863H57.7028C57.1803 61.4863 56.7568 61.9098 56.7568 62.4322C56.7568 62.9547 57.1803 63.3782 57.7028 63.3782H105C105.522 63.3782 105.946 62.9547 105.946 62.4322C105.946 61.9098 105.522 61.4863 105 61.4863Z" fill="#4C4F69"/><path d="M114.459 98.3779H25.5406C25.0181 98.3779 24.5946 98.8014 24.5946 99.3238C24.5946 99.8463 25.0181 100.27 25.5406 100.27H114.459C114.982 100.27 115.405 99.8463 115.405 99.3238C115.405 98.8014 114.982 98.3779 114.459 98.3779Z" fill="#4C4F69"/><path d="M114.459 115.405H25.5406C25.0181 115.405 24.5946 115.829 24.5946 116.351C24.5946 116.873 25.0181 117.297 25.5406 117.297H114.459C114.982 117.297 115.405 116.873 115.405 116.351C115.405 115.829 114.982 115.405 114.459 115.405Z" fill="#4C4F69"/><path d="M114.459 132.433H25.5406C25.0181 132.433 24.5946 132.857 24.5946 133.379C24.5946 133.901 25.0181 134.325 25.5406 134.325H114.459C114.982 134.325 115.405 133.901 115.405 133.379C115.405 132.857 114.982 132.433 114.459 132.433Z" fill="#4C4F69"/></g></g><defs><filter id="filter0_dd_5_1688" x="12.1348" y="41.5137" width="114.108" height="43.8378" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1.5"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_5_1688"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/><feBlend mode="normal" in2="effect1_dropShadow_5_1688" result="effect2_dropShadow_5_1688"/><feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_5_1688" result="shape"/></filter><clipPath id="clip0_5_1688"><rect width="70" height="162" fill="white"/></clipPath></defs></svg>');
+                content: url("data:image/svg+xml,@{svg}");
+            }
+            &[src="https://ssl.gstatic.com/calendar/images/theme/theme_picker_device_dark.svg"] {
+                @svg: escape('<svg width="140" height="162" viewBox="0 0 140 162" fill="none" var="@{base}" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_5_1729)"><path d="M124 0H16C7.16344 0 0 7.16344 0 16V145.757C0 154.594 7.16344 161.757 16 161.757H124C132.837 161.757 140 154.594 140 145.757V16C140 7.16344 132.837 0 124 0Z" fill="#1E2030"/><path d="M124 0H16C7.16344 0 0 7.16344 0 16V145.757C0 154.594 7.16344 161.757 16 161.757H124C132.837 161.757 140 154.594 140 145.757V16C140 7.16344 132.837 0 124 0Z" fill="#D1E1FF" fill-opacity="0.05"/><g filter="url(#filter0_dd_5_1729)"><path d="M111.243 43.5137H27.1348C20.5074 43.5137 15.1348 48.8863 15.1348 55.5137V69.3515C15.1348 75.9789 20.5074 81.3515 27.1348 81.3515H111.243C117.87 81.3515 123.243 75.9789 123.243 69.3515V55.5137C123.243 48.8863 117.87 43.5137 111.243 43.5137Z" fill="#1E2030"/></g><path d="M43.5127 63.3787H36.8911V70.0004H34.9992V63.3787H28.3776V61.4869H34.9992V54.8652H36.8911V61.4869H43.5127V63.3787Z" fill="#CAD3F5"/><path d="M105 61.4863H57.7028C57.1803 61.4863 56.7568 61.9098 56.7568 62.4322C56.7568 62.9547 57.1803 63.3782 57.7028 63.3782H105C105.522 63.3782 105.946 62.9547 105.946 62.4322C105.946 61.9098 105.522 61.4863 105 61.4863Z" fill="#CAD3F5"/><path d="M114.459 98.3779H25.5406C25.0181 98.3779 24.5946 98.8014 24.5946 99.3238C24.5946 99.8463 25.0181 100.27 25.5406 100.27H114.459C114.982 100.27 115.405 99.8463 115.405 99.3238C115.405 98.8014 114.982 98.3779 114.459 98.3779Z" fill="#CAD3F5"/><path d="M114.459 115.405H25.5406C25.0181 115.405 24.5946 115.829 24.5946 116.351C24.5946 116.873 25.0181 117.297 25.5406 117.297H114.459C114.982 117.297 115.405 116.873 115.405 116.351C115.405 115.829 114.982 115.405 114.459 115.405Z" fill="#CAD3F5"/><path d="M114.459 132.433H25.5406C25.0181 132.433 24.5946 132.857 24.5946 133.379C24.5946 133.901 25.0181 134.325 25.5406 134.325H114.459C114.982 134.325 115.405 133.901 115.405 133.379C115.405 132.857 114.982 132.433 114.459 132.433Z" fill="#CAD3F5"/></g><defs><filter id="filter0_dd_5_1729" x="12.1348" y="41.5137" width="114.108" height="43.8378" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1.5"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_5_1729"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset dy="1"/><feGaussianBlur stdDeviation="1"/><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/><feBlend mode="normal" in2="effect1_dropShadow_5_1729" result="effect2_dropShadow_5_1729"/><feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_5_1729" result="shape"/></filter><clipPath id="clip0_5_1729"><rect width="140" height="162" fill="white"/></clipPath></defs></svg>');
+                content: url("data:image/svg+xml,@{svg}");
+            }
+        }
+    }
+}
+
+/* deno-fmt-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+};

--- a/styles/google-calendar/preview.webp
+++ b/styles/google-calendar/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8ff331ed044baf64ea58eaffbcb29188bfcbb34cebba498583cd3cb7d06575c
+size 46120


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [Website ](https://calendar.google.com/)🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

Google Calendar is a sharable online calendar which focuses on aiding with time management, and is part of the Google Workspace line of products.

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

## 🗒 Checklist 🗒

- [ ] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [ ] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [ ] I have ensured that the new directory is in **lower-kebab-case**.
  - [ ] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [ ] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [ ] I have included the following files:
  - [ ] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
  - [ ] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
