### PR TITLE
fix(perplexity): various fixes, make colors more consistent with orig…

### DIFF
--- a/styles/perplexity/catppuccin.user.less
+++ b/styles/perplexity/catppuccin.user.less
@@ -2,7 +2,7 @@
 @name Perplexity Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/perplexity
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/perplexity
-@version 2024.12.31
+@version 2025.03.25
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/perplexity/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aperplexity
 @description Soothing pastel theme for Perplexity
@@ -76,6 +76,9 @@
     .bg-alert {
       background-color: @peach !important;
     }
+    .bg-text-100 {
+      background-color: @text !important;
+    }
 
     .bg-backdrop-lightbox\/95 {
       background-color: @crust !important;
@@ -85,12 +88,16 @@
       background-color: @mantle !important;
     }
 
-    .bg-background {
+    .bg-background, .bg-background-50 {
       background-color: @base !important;
     }
 
-    .bg-background-300 {
-      background-color: @crust !important;
+    .bg-background-100 {
+      background-color: @base !important;
+    }
+
+    .bg-background-300, .bg-background-200 {
+      background-color: @mantle !important;
     }
 
     .bg-background-super-alt {
@@ -152,7 +159,7 @@
     }
 
     .bg-textMain {
-      background-color: @overlay0 !important;
+      background-color: @crust !important;
     }
 
     .bg-textMainDark,
@@ -335,7 +342,12 @@
       background-color: @accent !important;
     }
 
-    [class*="hover:bg-offset"]:hover {
+    [class*="data-[focused=self]:bg-background-200"]:focus,
+    [class*="hover:bg-background-200"]:hover {
+      background-color: @crust !important;
+    }
+
+    [class*=":hover:bg-offset"]:hover, [class*="hover:bg-offset"]:hover {
       background-color: @surface0 !important;
     }
 
@@ -364,6 +376,10 @@
       color: @text !important;
     }
 
+    [data-focused="self"] {
+      background-color: @surface1 !important;
+    }
+
     .dark\:divide-borderMainDark\/50:where(
       [data-color-scheme="dark"] .dark\:divide-borderMainDark\/50,
       [data-color-scheme="dark"] .dark\:divide-borderMainDark\/50 *
@@ -386,12 +402,32 @@
       color: @accent !important;
     }
 
+    .focus-visible\:bg-offsetPlus:focus-visible {
+      background-color: @crust !important;
+    }
+
     *[class*="ring"] {
       --tw-ring-color: @surface2 !important;
       --tw-ring-offset-color: @mantle !important;
     }
 
+    .caret-superDuper {
+      caret-color: @accent !important;
+    }
+    .data-\[state\=checked\]\:bg-super[data-state="checked"] {
+      background-color: @accent !important;
+    }
+
     /* Additional fixes: */
+
+    .scrollbar-thumb-idle {
+      --scrollbar-thumb: @surface1 !important;
+    }
+
+    /* gradient on super long prompt */
+    div[style="background: linear-gradient(transparent, currentcolor);"] {
+      background: linear-gradient(transparent, @base) !important;
+    }
 
     /* citations */
     .citation:hover * {
@@ -430,6 +466,10 @@
     }
     .research-goal-timeline {
       background-color: @surface1;
+    }
+
+    .\!bg-transparent {
+      background: transparent !important;
     }
   }
 }

--- a/styles/perplexity/catppuccin.user.less
+++ b/styles/perplexity/catppuccin.user.less
@@ -56,7 +56,8 @@
     color-scheme: if(@flavor = latte, light, dark);
 
     ::selection {
-      background-color: fade(@accent, 30%);
+      background-color: fade(@accent, 30%) !important;
+      color: @text !important;
     }
 
     input,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

![image](https://github.com/user-attachments/assets/e89b147f-0a7d-4380-8dea-90d371f73e96)
<img width="699" alt="image" src="https://github.com/user-attachments/assets/49415c41-801f-4577-a75f-580f5a024604" />
<img width="190" alt="image" src="https://github.com/user-attachments/assets/54f23265-8e98-4abc-8e4f-b35f4b955078" />
<img width="875" alt="image" src="https://github.com/user-attachments/assets/58d34827-5544-42ee-9798-87720f24df65" />

Some focus and tooltip backgrounds, and selection colors.


<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
