### PR TITLE
feat(google-account): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -376,6 +376,14 @@ userstyles:
     readme:
       app-link: https://google.com
     current-maintainers: []
+  google-account:
+    name: Google Account
+    categories: [productivity, analytics]
+    icon: google
+    color: blue
+    readme:
+      app-link: https://myaccount.google.com
+    current-maintainers: [*WalkQuackBack]
   google-drive:
     name: Google Drive
     categories: [productivity]

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -378,7 +378,7 @@ userstyles:
     current-maintainers: []
   google-account:
     name: Google Account
-    categories: [productivity, analytics]
+    categories: [productivity]
     icon: google
     color: blue
     readme:

--- a/styles/google-account/catppuccin.user.less
+++ b/styles/google-account/catppuccin.user.less
@@ -41,22 +41,26 @@
 
   @media (prefers-color-scheme: light) {
     body, html, body:not(.mcwCGe) {
-      #catppuccin(@lightFlavor, false);
+      #catppuccin(@lightFlavor);
     }
   }
 
   @media (prefers-color-scheme: dark) {
+    // body:not(.mcwCGe) {}
+
+    // Review: Codebase supports dark theme however there's no user
+    // exposed way to trigger this without class editing.
     body,
     html,
     body:not(.mcwCGe),
     // PFP picker image editor
     .P9KVBf,
     .wfJxA {
-      #catppuccin(@darkFlavor, false);
+      #catppuccin(@darkFlavor);
     }
   }
 
-  #catppuccin(@flavor, @isModal) {
+  #catppuccin(@flavor) {
     @rosewater: @catppuccin[@@flavor][@rosewater];
     @flamingo: @catppuccin[@@flavor][@flamingo];
     @pink: @catppuccin[@@flavor][@pink];
@@ -90,7 +94,7 @@
       @catppuccin[@latte][@@accentColor]
     );
 
-    color-scheme: @if(@isModal, initial, if(@flavor = latte, light, dark));
+    color-scheme: initial;
 
     ::selection {
       background-color: fade(@accent, 30%);
@@ -585,7 +589,9 @@
       var(--gm3-sys-color-shadow-rgb),
       0.15
     );
-    --identity-common-ui-components-web-color-level-2-background: var(--gm3-sys-color-surface-container);
+    --identity-common-ui-components-web-color-level-2-background: var(
+      --gm3-sys-color-surface-container
+    );
     --identity-common-ui-components-web-color-level-2-background-translucent: rgba(
       var(--gm3-sys-color-surface-container-rgb)
       0.96
@@ -687,7 +693,7 @@
       background-color: var(--gm3-sys-color-inverse-surface);
       color: var(
         --gm3-tooltip-plain-supporting-text-color,
-        var(--gm3-sys-color-inverse-on-surface)
+        var(--gm3-sys-color-inverse-on-surface, #f2f2f2)
       );
     }
 
@@ -742,7 +748,7 @@
         closest-side,
         var(
           --gm3-ripple-pressed-color,
-          rgba(var(--gm3-sys-color-on-surface-rgb, currentColor), 0.24)
+          rgba(var(--gm3-sys-color-on-surface-rgb, currentcolor), 0.24)
         ) max(100% - 70px, 65%),
         transparent 100%
       );
@@ -1159,7 +1165,13 @@
     .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="false"]:hover,
     .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="true"],
     .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="true"]:focus,
-    .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="false"]:focus {
+    .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="false"]:focus,
+    // PFP picker Google AI sheet
+    .zh8gv,
+    .P9KVBf .zh8gv,
+    .wfJxA .zh8gv,
+    // PFP picker Google AI style sheet
+    .GHW {
       background-color: var(--gm3-sys-color-surface-container);
       color: var(--gm3-sys-color-on-surface);
     }
@@ -1168,9 +1180,21 @@
     .ncFHed .MocG8c.KKjvXb,
     // Security Checkup card sticky header
     .g81fxb.bhe1tb .JaX6Fb,
-    .u7Uqwf.OUzXuf .g81fxb.bhe1tb .JaX6Fb {
+    .u7Uqwf.OUzXuf .g81fxb.bhe1tb .JaX6Fb,
+    // PFP picker Google AI sheet card
+    .P9KVBf .qdE64,
+    .wfJxA .qdE64 {
       background-color: var(--gm3-sys-color-surface-container-highest);
       color: var(--gm3-sys-color-on-surface);
+    }
+
+    // PFP picker Google AI sheet card hover
+    .P9KVBf .qdE64:hover {
+      background-color: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-highest),
+        var(--gm3-sys-color-on-surface) 8%
+      );
     }
 
     // My activity info toast
@@ -1545,6 +1569,49 @@
         linear-gradient(90deg, @yellow 10%, @red 0) top/100% 100%;
     }
 
+    // PFP picker Google AI tonal button
+    .Hu1odf {
+      --gm3-button-filled-tonal-focus-label-text-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-hover-label-text-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-pressed-label-text-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-label-text-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-with-icon-icon-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-with-icon-pressed-icon-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-with-icon-hover-icon-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-with-icon-focus-icon-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-hover-state-layer-color: var(
+        --gm3-sys-color-on-primary
+      );
+      --gm3-button-filled-tonal-container-color: var(--gm3-sys-color-primary);
+    }
+
+    // PFP picker Google AI text button
+    .P9KVBf .bAnecf, .wfJxA .bAnecf {
+      --gm3-button-text-hover-label-text-color: var(
+        --gm3-sys-color-inverse-primary
+      );
+      --gm3-button-text-label-text-color: var(--gm3-sys-color-inverse-primary);
+      --gm3-button-text-pressed-label-text-color: var(
+        --gm3-sys-color-inverse-primary
+      );
+    }
+
     // >M1/M2 FULL LEGACY PAGES<
     body,
     // Main page container
@@ -1554,8 +1621,15 @@
     }
 
     // Floating card
-    .RAYh1e {
+    .RAYh1e,
+    // PFP picker Google AI lower banner
+    .P9KVBf .pjGNzb,
+    .wfJxA .pjGNzb {
       background: var(--gm3-sys-color-surface-container-lowest);
+    }
+
+    // Floating card
+    .RAYh1e {
       border-color: transparent;
     }
 
@@ -1615,1432 +1689,6 @@
         rgba(var(--gm3-sys-color-surface-container-low-rgb), 0) 0%,
         rgba(var(--gm3-sys-color-surface-container-low-rgb), 0.9) 100%
       );
-    }
-  }
-}
-
-@-moz-document domain("ogs.google.com") {
-  body {
-    #catppuccin(@darkFlavor, true);
-  }
-
-  #catppuccin(@flavor, @isModal) {
-    @rosewater: @catppuccin[@@flavor][@rosewater];
-    @flamingo: @catppuccin[@@flavor][@flamingo];
-    @pink: @catppuccin[@@flavor][@pink];
-    @mauve: @catppuccin[@@flavor][@mauve];
-    @red: @catppuccin[@@flavor][@red];
-    @maroon: @catppuccin[@@flavor][@maroon];
-    @peach: @catppuccin[@@flavor][@peach];
-    @yellow: @catppuccin[@@flavor][@yellow];
-    @green: @catppuccin[@@flavor][@green];
-    @teal: @catppuccin[@@flavor][@teal];
-    @sky: @catppuccin[@@flavor][@sky];
-    @sapphire: @catppuccin[@@flavor][@sapphire];
-    @blue: @catppuccin[@@flavor][@blue];
-    @lavender: @catppuccin[@@flavor][@lavender];
-    @text: @catppuccin[@@flavor][@text];
-    @subtext1: @catppuccin[@@flavor][@subtext1];
-    @subtext0: @catppuccin[@@flavor][@subtext0];
-    @overlay2: @catppuccin[@@flavor][@overlay2];
-    @overlay1: @catppuccin[@@flavor][@overlay1];
-    @overlay0: @catppuccin[@@flavor][@overlay0];
-    @surface2: @catppuccin[@@flavor][@surface2];
-    @surface1: @catppuccin[@@flavor][@surface1];
-    @surface0: @catppuccin[@@flavor][@surface0];
-    @base: @catppuccin[@@flavor][@base];
-    @mantle: @catppuccin[@@flavor][@mantle];
-    @crust: @catppuccin[@@flavor][@crust];
-    @accent: @catppuccin[@@flavor][@@accentColor];
-    @inverse-accent: if(
-      @flavor = latte,
-      @catppuccin[@mocha][@@accentColor],
-      @catppuccin[@latte][@@accentColor]
-    );
-
-    color-scheme: @if(@isModal, initial, if(@flavor = latte, light, dark));
-
-    ::selection {
-      background-color: fade(@accent, 30%);
-    }
-
-    input,
-    textarea {
-      &::placeholder {
-        color: @subtext0 !important;
-      }
-    }
-
-    // Set body default text colour
-    color: @text;
-
-    @gm3-sys-color-error: @red;
-    @gm3-sys-color-error-rgb: #rgbify(@gm3-sys-color-error)[];
-    @gm3-sys-color-error-container: desaturate(darken(@red, 50%), 50%);
-    @gm3-sys-color-error-container-rgb: #rgbify(
-      @gm3-sys-color-error-container,
-    )[];
-
-    @gm3-sys-color-on-error: darken(desaturate(@red, 20%), 50%);
-    @gm3-sys-color-on-error-rgb: #rgbify(@gm3-sys-color-on-error)[];
-    @gm3-sys-color-on-error-container: desaturate(darken(@red, -10%), 50%);
-    @gm3-sys-color-on-error-container-rgb: #rgbify(
-      @gm3-sys-color-on-error-container,
-    )[];
-
-    @gm3-sys-color-primary: @accent;
-    @gm3-sys-color-primary-rgb: #rgbify(@gm3-sys-color-primary)[];
-    @gm3-sys-color-primary-fixed: lighten(@accent, 5%);
-    @gm3-sys-color-primary-fixed-rgb: #rgbify(@gm3-sys-color-primary-fixed)[];
-    @gm3-sys-color-primary-fixed-dim: darken(@accent, 5%);
-    @gm3-sys-color-primary-fixed-dim-rgb: #rgbify(
-      @gm3-sys-color-primary-fixed-dim,
-    )[];
-
-    @gm3-sys-color-on-primary: saturate(
-      mix(@gm3-sys-color-primary, @base, 20%),
-      25%
-    );
-    @gm3-sys-color-on-primary-rgb: #rgbify(@gm3-sys-color-on-primary)[];
-    @gm3-sys-color-on-primary-fixed: darken(@gm3-sys-color-on-primary, 5%);
-    @gm3-sys-color-on-primary-fixed-rgb: #rgbify(
-      @gm3-sys-color-on-primary-fixed,
-    )[];
-    @gm3-sys-color-on-primary-fixed-variant: lighten(
-      @gm3-sys-color-on-primary,
-      5%
-    );
-    @gm3-sys-color-on-primary-fixed-variant-rgb: #rgbify(
-      @gm3-sys-color-on-primary-fixed-variant,
-    )[];
-
-    @gm3-sys-color-primary-container: saturate(
-      mix(@gm3-sys-color-primary, @mantle, 40%),
-      20%
-    );
-    @gm3-sys-color-primary-container-rgb: #rgbify(
-      @gm3-sys-color-primary-container,
-    )[];
-    @gm3-sys-color-on-primary-container: saturate(
-      mix(@gm3-sys-color-primary, @text, 10%),
-      25%
-    );
-    @gm3-sys-color-on-primary-container-rgb: #rgbify(
-      @gm3-sys-color-on-primary-container,
-    )[];
-
-    @gm3-sys-color-secondary: desaturate(@accent, 40%);
-    @gm3-sys-color-secondary-rgb: #rgbify(@gm3-sys-color-secondary)[];
-    @gm3-sys-color-secondary-fixed: lighten(@gm3-sys-color-secondary, 5%);
-    @gm3-sys-color-secondary-fixed-rgb: #rgbify(
-      @gm3-sys-color-secondary-fixed,
-    )[];
-    @gm3-sys-color-secondary-fixed-dim: darken(@gm3-sys-color-secondary, 5%);
-    @gm3-sys-color-secondary-fixed-dim-rgb: #rgbify(
-      @gm3-sys-color-secondary-fixed-dim,
-    )[];
-
-    @gm3-sys-color-on-secondary: saturate(
-      mix(@gm3-sys-color-secondary, @base, 20%),
-      25%
-    );
-    @gm3-sys-color-on-secondary-rgb: #rgbify(@gm3-sys-color-on-secondary)[];
-    @gm3-sys-color-on-secondary-fixed: darken(@gm3-sys-color-on-secondary, 5%);
-    @gm3-sys-color-on-secondary-fixed-rgb: #rgbify(
-      @gm3-sys-color-on-secondary-fixed,
-    )[];
-    @gm3-sys-color-on-secondary-fixed-variant: lighten(
-      @gm3-sys-color-on-primary,
-      5%
-    );
-    @gm3-sys-color-on-secondary-fixed-variant-rgb: #rgbify(
-      @gm3-sys-color-on-secondary-fixed-variant,
-    )[];
-
-    @gm3-sys-color-secondary-container: saturate(
-      mix(@gm3-sys-color-secondary, @mantle, 20%),
-      10%
-    );
-    @gm3-sys-color-secondary-container-rgb: #rgbify(
-      @gm3-sys-color-secondary-container,
-    )[];
-    @gm3-sys-color-on-secondary-container: saturate(
-      mix(@gm3-sys-color-secondary, @text, 10%),
-      25%
-    );
-    @gm3-sys-color-on-secondary-container-rgb: #rgbify(
-      @gm3-sys-color-on-secondary-container,
-    )[];
-
-    @gm3-sys-color-tertiary: @accent;
-    @gm3-sys-color-tertiary-rgb: #rgbify(@gm3-sys-color-tertiary)[];
-    @gm3-sys-color-tertiary-fixed: lighten(@gm3-sys-color-tertiary, 5%);
-    @gm3-sys-color-tertiary-fixed-rgb: #rgbify(@gm3-sys-color-tertiary-fixed)[];
-    @gm3-sys-color-tertiary-fixed-dim: darken(@gm3-sys-color-tertiary, 5%);
-    @gm3-sys-color-tertiary-fixed-dim-rgb: #rgbify(
-      @gm3-sys-color-tertiary-fixed-dim,
-    )[];
-
-    @gm3-sys-color-on-tertiary: darken(
-      desaturate(@gm3-sys-color-tertiary, 25%),
-      50%
-    );
-    @gm3-sys-color-on-tertiary-rgb: #rgbify(@gm3-sys-color-on-tertiary)[];
-    @gm3-sys-color-on-tertiary-fixed: darken(@gm3-sys-color-on-tertiary, 5%);
-    @gm3-sys-color-on-tertiary-fixed-rgb: #rgbify(
-      @gm3-sys-color-on-tertiary-fixed,
-    )[];
-    @gm3-sys-color-on-tertiary-fixed-variant: lighten(
-      @gm3-sys-color-on-tertiary,
-      5%
-    );
-    @gm3-sys-color-on-tertiary-fixed-variant-rgb: #rgbify(
-      @gm3-sys-color-on-tertiary-fixed-variant,
-    )[];
-
-    @gm3-sys-color-tertiary-container: saturate(
-      mix(@gm3-sys-color-tertiary, @mantle, 20%),
-      0%
-    );
-    @gm3-sys-color-tertiary-container-rgb: #rgbify(
-      @gm3-sys-color-tertiary-container,
-    )[];
-    @gm3-sys-color-on-tertiary-container: lighten(
-      saturate(@gm3-sys-color-tertiary-container, 50%),
-      65%
-    );
-    @gm3-sys-color-on-tertiary-container-rgb: #rgbify(
-      @gm3-sys-color-on-tertiary-container,
-    )[];
-
-    @gm3-sys-color-background: @base;
-    @gm3-sys-color-background-rgb: #rgbify(@gm3-sys-color-background)[];
-    @gm3-sys-color-on-background: @text;
-    @gm3-sys-color-on-background-rgb: #rgbify(@gm3-sys-color-on-background)[];
-
-    @gm3-sys-color-surface: @base;
-    @gm3-sys-color-surface-rgb: #rgbify(@gm3-sys-color-surface)[];
-    @gm3-sys-color-surface-bright: @surface0;
-    @gm3-sys-color-surface-bright-rgb: #rgbify(@gm3-sys-color-surface-bright)[];
-    @gm3-sys-color-surface-dim: @crust;
-    @gm3-sys-color-surface-dim-rgb: #rgbify(@gm3-sys-color-surface-dim)[];
-    @gm3-sys-color-surface-variant: mix(@mantle, @accent, 87.5%);
-    @gm3-sys-color-surface-variant-rgb: #rgbify(
-      @gm3-sys-color-surface-variant,
-    )[];
-    @gm3-sys-color-surface-tint: @accent;
-    @gm3-sys-color-surface-tint-rgb: #rgbify(@gm3-sys-color-surface-tint)[];
-
-    @gm3-sys-color-on-surface: @text;
-    @gm3-sys-color-on-surface-rgb: #rgbify(@gm3-sys-color-on-surface)[];
-    @gm3-sys-color-on-surface-variant: @subtext0;
-    @gm3-sys-color-on-surface-variant-rgb: #rgbify(
-      @gm3-sys-color-on-surface-variant,
-    )[];
-
-    @gm3-sys-color-inverse-surface: @text;
-    @gm3-sys-color-inverse-surface-rgb: #rgbify(
-      @gm3-sys-color-inverse-surface,
-    )[];
-    @gm3-sys-color-inverse-on-surface: @mantle;
-    @gm3-sys-color-inverse-on-surface-rgb: #rgbify(
-      @gm3-sys-color-inverse-on-surface,
-    )[];
-    @gm3-sys-color-inverse-primary: @inverse-accent; // TODO: Colour role clarification
-    @gm3-sys-color-inverse-primary-rgb: #rgbify(
-      @gm3-sys-color-inverse-primary,
-    )[];
-
-    @gm3-sys-color-surface-container-highest: @surface1;
-    @gm3-sys-color-surface-container-highest-rgb: #rgbify(
-      @gm3-sys-color-surface-container-highest,
-    )[];
-    @gm3-sys-color-surface-container-high: @surface0;
-    @gm3-sys-color-surface-container-high-rgb: #rgbify(
-      @gm3-sys-color-surface-container-high,
-    )[];
-    @gm3-sys-color-surface-container: @surface0;
-    @gm3-sys-color-surface-container-rgb: #rgbify(
-      @gm3-sys-color-surface-container,
-    )[];
-    @gm3-sys-color-surface-container-low: @mantle;
-    @gm3-sys-color-surface-container-low-rgb: #rgbify(
-      @gm3-sys-color-surface-container-low,
-    )[];
-    @gm3-sys-color-surface-container-lowest: @crust;
-    @gm3-sys-color-surface-container-lowest-rgb: #rgbify(
-      @gm3-sys-color-surface-container-lowest,
-    )[];
-
-    @gm3-sys-color-outline: @overlay2;
-    @gm3-sys-color-outline-rgb: #rgbify(@gm3-sys-color-outline)[];
-    @gm3-sys-color-outline-variant: @overlay0;
-    @gm3-sys-color-outline-variant-rgb: #rgbify(
-      @gm3-sys-color-outline-variant,
-    )[];
-
-    @gm3-sys-color-scrim: #000;
-    @gm3-sys-color-scrim-rgb: #rgbify(@gm3-sys-color-scrim)[];
-    @gm3-sys-color-shadow: #000;
-    @gm3-sys-color-shadow-rgb: #rgbify(@gm3-sys-color-shadow)[];
-
-    --gm3-sys-color-background: @gm3-sys-color-background;
-    --gm3-sys-color-background-rgb: @gm3-sys-color-background-rgb;
-    --gm3-sys-color-error: @gm3-sys-color-error;
-    --gm3-sys-color-error-rgb: @gm3-sys-color-error-rgb;
-    --gm3-sys-color-error-container: @gm3-sys-color-error-container;
-    --gm3-sys-color-error-container-rgb: @gm3-sys-color-error-container-rgb;
-    --gm3-sys-color-inverse-on-surface: @gm3-sys-color-inverse-on-surface;
-    --gm3-sys-color-inverse-on-surface-rgb: @gm3-sys-color-inverse-on-surface-rgb;
-    --gm3-sys-color-inverse-primary: @gm3-sys-color-inverse-primary;
-    --gm3-sys-color-inverse-primary-rgb: @gm3-sys-color-inverse-primary-rgb;
-    --gm3-sys-color-inverse-surface: @gm3-sys-color-inverse-surface;
-    --gm3-sys-color-inverse-surface-rgb: @gm3-sys-color-inverse-surface-rgb;
-    --gm3-sys-color-on-background: @gm3-sys-color-on-background;
-    --gm3-sys-color-on-background-rgb: @gm3-sys-color-on-background-rgb;
-    --gm3-sys-color-on-error: @gm3-sys-color-on-error;
-    --gm3-sys-color-on-error-rgb: @gm3-sys-color-on-error-rgb;
-    --gm3-sys-color-on-error-container: @gm3-sys-color-on-error-container;
-    --gm3-sys-color-on-error-container-rgb: @gm3-sys-color-on-error-container-rgb;
-    --gm3-sys-color-on-primary: @gm3-sys-color-on-primary;
-    --gm3-sys-color-on-primary-rgb: @gm3-sys-color-on-primary-rgb;
-    --gm3-sys-color-on-primary-container: @gm3-sys-color-on-primary-container;
-    --gm3-sys-color-on-primary-container-rgb: @gm3-sys-color-on-primary-container-rgb;
-    --gm3-sys-color-on-primary-fixed: @gm3-sys-color-on-primary-fixed;
-    --gm3-sys-color-on-primary-fixed-rgb: @gm3-sys-color-on-primary-fixed-rgb;
-    --gm3-sys-color-on-primary-fixed-variant: @gm3-sys-color-on-primary-fixed-variant;
-    --gm3-sys-color-on-primary-fixed-variant-rgb: @gm3-sys-color-on-primary-fixed-variant-rgb;
-    --gm3-sys-color-on-secondary: @gm3-sys-color-on-secondary;
-    --gm3-sys-color-on-secondary-rgb: @gm3-sys-color-on-secondary-rgb;
-    --gm3-sys-color-on-secondary-container: @gm3-sys-color-on-secondary-container;
-    --gm3-sys-color-on-secondary-container-rgb: @gm3-sys-color-on-secondary-container-rgb;
-    --gm3-sys-color-on-secondary-fixed: @gm3-sys-color-on-secondary-fixed;
-    --gm3-sys-color-on-secondary-fixed-rgb: @gm3-sys-color-on-secondary-fixed-rgb;
-    --gm3-sys-color-on-secondary-fixed-variant: @gm3-sys-color-on-secondary-fixed-variant;
-    --gm3-sys-color-on-secondary-fixed-variant-rgb: @gm3-sys-color-on-secondary-fixed-variant-rgb;
-    --gm3-sys-color-on-surface: @gm3-sys-color-on-surface;
-    --gm3-sys-color-on-surface-rgb: @gm3-sys-color-on-surface-rgb;
-    --gm3-sys-color-on-surface-variant: @gm3-sys-color-on-surface-variant;
-    --gm3-sys-color-on-surface-variant-rgb: @gm3-sys-color-on-surface-variant-rgb;
-    --gm3-sys-color-on-tertiary: @gm3-sys-color-on-tertiary;
-    --gm3-sys-color-on-tertiary-rgb: @gm3-sys-color-on-tertiary-rgb;
-    --gm3-sys-color-on-tertiary-container: @gm3-sys-color-on-tertiary-container;
-    --gm3-sys-color-on-tertiary-container-rgb: @gm3-sys-color-on-tertiary-container-rgb;
-    --gm3-sys-color-on-tertiary-fixed: @gm3-sys-color-on-tertiary-fixed;
-    --gm3-sys-color-on-tertiary-fixed-rgb: @gm3-sys-color-on-tertiary-fixed-rgb;
-    --gm3-sys-color-on-tertiary-fixed-variant: @gm3-sys-color-on-tertiary-fixed-variant;
-    --gm3-sys-color-on-tertiary-fixed-variant-rgb: @gm3-sys-color-on-tertiary-fixed-variant-rgb;
-    --gm3-sys-color-outline: @gm3-sys-color-outline;
-    --gm3-sys-color-outline-rgb: @gm3-sys-color-outline-rgb;
-    --gm3-sys-color-outline-variant: @gm3-sys-color-outline-variant;
-    --gm3-sys-color-outline-variant-rgb: @gm3-sys-color-outline-variant-rgb;
-    --gm3-sys-color-primary: @gm3-sys-color-primary;
-    --gm3-sys-color-primary-rgb: @gm3-sys-color-primary-rgb;
-    --gm3-sys-color-primary-container: @gm3-sys-color-primary-container;
-    --gm3-sys-color-primary-container-rgb: @gm3-sys-color-primary-container-rgb;
-    --gm3-sys-color-primary-fixed: @gm3-sys-color-primary-fixed;
-    --gm3-sys-color-primary-fixed-rgb: @gm3-sys-color-primary-fixed-rgb;
-    --gm3-sys-color-primary-fixed-dim: @gm3-sys-color-primary-fixed-dim;
-    --gm3-sys-color-primary-fixed-dim-rgb: @gm3-sys-color-primary-fixed-dim-rgb;
-    --gm3-sys-color-scrim: @gm3-sys-color-scrim;
-    --gm3-sys-color-scrim-rgb: @gm3-sys-color-scrim-rgb;
-    --gm3-sys-color-secondary: @gm3-sys-color-secondary;
-    --gm3-sys-color-secondary-rgb: @gm3-sys-color-secondary-rgb;
-    --gm3-sys-color-secondary-container: @gm3-sys-color-secondary-container;
-    --gm3-sys-color-secondary-container-rgb: @gm3-sys-color-secondary-container-rgb;
-    --gm3-sys-color-secondary-fixed: @gm3-sys-color-secondary-fixed;
-    --gm3-sys-color-secondary-fixed-rgb: @gm3-sys-color-secondary-fixed-rgb;
-    --gm3-sys-color-secondary-fixed-dim: @gm3-sys-color-secondary-fixed-dim;
-    --gm3-sys-color-secondary-fixed-dim-rgb: @gm3-sys-color-secondary-fixed-dim-rgb;
-    --gm3-sys-color-shadow: @gm3-sys-color-shadow;
-    --gm3-sys-color-shadow-rgb: @gm3-sys-color-shadow-rgb;
-    --gm3-sys-color-surface: @gm3-sys-color-surface;
-    --gm3-sys-color-surface-rgb: @gm3-sys-color-surface-rgb;
-    --gm3-sys-color-surface-bright: @gm3-sys-color-surface-bright;
-    --gm3-sys-color-surface-bright-rgb: @gm3-sys-color-surface-bright-rgb;
-    --gm3-sys-color-surface-container: @gm3-sys-color-surface-container;
-    --gm3-sys-color-surface-container-rgb: @gm3-sys-color-surface-container-rgb;
-    --gm3-sys-color-surface-container-high: @gm3-sys-color-surface-container-high;
-    --gm3-sys-color-surface-container-high-rgb: @gm3-sys-color-surface-container-high-rgb;
-    --gm3-sys-color-surface-container-highest: @gm3-sys-color-surface-container-highest;
-    --gm3-sys-color-surface-container-highest-rgb: @gm3-sys-color-surface-container-highest-rgb;
-    --gm3-sys-color-surface-container-low: @gm3-sys-color-surface-container-low;
-    --gm3-sys-color-surface-container-low-rgb: @gm3-sys-color-surface-container-low-rgb;
-    --gm3-sys-color-surface-container-lowest: @gm3-sys-color-surface-container-lowest;
-    --gm3-sys-color-surface-container-lowest-rgb: @gm3-sys-color-surface-container-lowest-rgb;
-    --gm3-sys-color-surface-dim: @gm3-sys-color-surface-dim;
-    --gm3-sys-color-surface-dim-rgb: @gm3-sys-color-surface-dim-rgb;
-    --gm3-sys-color-surface-tint: @gm3-sys-color-surface-tint;
-    --gm3-sys-color-surface-tint-rgb: @gm3-sys-color-surface-tint-rgb;
-    --gm3-sys-color-surface-variant: @gm3-sys-color-surface-variant;
-    --gm3-sys-color-surface-variant-rgb: @gm3-sys-color-surface-variant-rgb;
-    --gm3-sys-color-tertiary: @gm3-sys-color-tertiary;
-    --gm3-sys-color-tertiary-rgb: @gm3-sys-color-tertiary-rgb;
-    --gm3-sys-color-tertiary-container: @gm3-sys-color-tertiary-container;
-    --gm3-sys-color-tertiary-container-rgb: @gm3-sys-color-tertiary-container-rgb;
-    --gm3-sys-color-tertiary-fixed: @gm3-sys-color-tertiary-fixed;
-    --gm3-sys-color-tertiary-fixed-rgb: @gm3-sys-color-tertiary-fixed-rgb;
-    --gm3-sys-color-tertiary-fixed-dim: @gm3-sys-color-tertiary-fixed-dim;
-    --gm3-sys-color-tertiary-fixed-dim-rgb: @gm3-sys-color-tertiary-fixed-dim-rgb;
-    --mdc-ripple-color: var(--gm3-sys-color-primary);
-
-    --boq-chrometransition-background: var(--gm3-sys-color-surface-container);
-
-    --gm-colortextbutton-ink-color: var(--gm3-sys-color-on-surface);
-    --gm-colortextbutton-ink-color--stateful: var(--gm3-sys-color-on-surface);
-    --gm-colortextbutton-state-color: var(--gm3-sys-color-on-surface);
-    --gm-fillbutton-ink-color: var(--gm3-sys-color-on-primary);
-    --gm-fillbutton-ink-color--stateful: var(--gm3-sys-color-primary);
-    --gm-fillbutton-container-color: var(--gm3-sys-color-primary);
-    --gm-hairlinebutton-outline-color: var(--gm3-sys-color-outline);
-    --gm-hairlinebutton-outline-color--stateful: var(--gm3-sys-color-primary);
-    --gm-hairlinebutton-state-color: var(--gm3-sys-color-primary);
-    --gm-hairlinebutton-ink-color: var(--gm3-sys-color-primary);
-    --gm-hairlinebutton-ink-color--stateful: var(--gm3-sys-color-primary);
-    --gm-radio-state-color: var(--gm3-sys-color-primary);
-    --gm-radio-ink-color: var(--gm3-sys-color-primary);
-    --gm-radio-ink-color--stateful: var(--gm3-sys-color-primary);
-    --gm-outlinedtextfield-caret-color: var(--gm3-sys-color-primary);
-    --gm-outlinedtextfield-ink-color: var(--gm3-sys-color-on-surface);
-    --gm-outlinedtextfield-outline-color: var(--gm3-sys-color-outline);
-    --gm-outlinedtextfield-outline-color--stateful: var(
-      --gm3-sys-color-primary
-    );
-    --gm-outlinedtextfield-label-color: var(--gm3-sys-color-on-surface-variant);
-    --gm-outlinedtextfield-label-color--stateful: var(--gm3-sys-color-primary);
-
-    --mdc-theme-surface: var(--gm3-sys-color-surface);
-    --mdc-theme-on-surface: var(--gm3-sys-color-on-surface);
-
-    --mdc-checkbox-unselected-icon-color: var(--gm3-sys-color-on-surface);
-    --mdc-checkbox-unselected-hover-icon-color: var(--gm3-sys-color-on-surface);
-    --mdc-checkbox-unselected-hover-state-layer-color: var(
-      --gm3-sys-color-on-surface
-    );
-    --mdc-checkbox-unselected-pressed-icon-color: var(
-      --gm3-sys-color-on-surface
-    );
-    --mdc-checkbox-unselected-pressed-state-layer-color: var(
-      --gm3-sys-color-on-surface
-    );
-
-    --mdc-checkbox-selected-icon-color: var(--gm3-sys-color-primary);
-    --mdc-checkbox-selected-hover-icon-color: var(--gm3-sys-color-primary);
-    --mdc-checkbox-selected-hover-state-layer-color: var(
-      --gm3-sys-color-primary
-    );
-    --mdc-checkbox-selected-pressed-icon-color: var(--gm3-sys-color-primary);
-    --mdc-checkbox-selected-pressed-state-layer-color: var(
-      --gm3-sys-color-primary
-    );
-    --mdc-checkbox-selected-checkmark-color: var(--gm3-sys-color-on-primary);
-
-    color: @text;
-
-    // Automatically generated code \/\/
-    // -- IMPORT START
-    .Lvwayc {
-      background: var(--gm3-sys-color-surface-container);
-    }
-    .aRDKUe .Lvwayc {
-      background: var(--gm3-sys-color-surface-container-high);
-    }
-    .LzIwWe {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .LzIwWe {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .fVFoBd {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .fVFoBd {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .DgDbFe .vZvJBb:not(:first-child) .BVnP4c::before {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .Z6NXed {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    @media (hover: hover) {
-      .Z6NXed:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb .Z6NXed:focus-visible, .WLjaOb .Z6NXed:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .Z6NXed:active, .Z6NXed:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    @media (hover: hover) {
-      .aRDKUe .Z6NXed:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb.aRDKUe .Z6NXed:focus-visible,
-    .WLjaOb.aRDKUe .Z6NXed:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .Z6NXed:active, .aRDKUe .Z6NXed:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    .aRDKUe .Z6NXed {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .T6SHIc {
-      border-bottom-color: var(--gm3-sys-color-secondary-container);
-    }
-    .aRDKUe .T6SHIc {
-      border-color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .H0GIIb {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .H0GIIb {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .Wdz6e {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .Wdz6e {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .KKMNAc, .Wdz6e {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .KKMNAc, .aRDKUe .Wdz6e {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .scjzPc {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .scjzPc {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .NoNCCf {
-      color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .NoNCCf {
-      color: var(--gm3-sys-color-primary);
-    }
-    .Y2rnLd {
-      background: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .KoNisf {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .Q3ao0c {
-      color: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 8%
-      );
-    }
-    .bMnvr {
-      background: var(--gm3-sys-color-surface-container-highest);
-    }
-    .aRDKUe .bMnvr {
-      background: var(--gm3-sys-color-surface-container-highest);
-    }
-    .WNTTTe {
-      color: var(--gm3-sys-color-primary);
-    }
-    .CkSNRd {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    @media (hover: hover) {
-      .CkSNRd:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb .CkSNRd:focus-visible, .WLjaOb .CkSNRd:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .CkSNRd:active, .CkSNRd:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    @media (hover: hover) {
-      .aRDKUe .CkSNRd:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb.aRDKUe .CkSNRd:focus-visible,
-    .WLjaOb.aRDKUe .CkSNRd:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .CkSNRd:active, .aRDKUe .CkSNRd:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    .aRDKUe .CkSNRd {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .O52YZb {
-      background: var(--gm3-sys-color-secondary-container);
-      color: var(--gm3-sys-color-on-secondary-container);
-    }
-    @media (hover: hover) {
-      .O52YZb:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-secondary-container),
-          var(--gm3-sys-color-on-secondary-container) 8%
-        );
-      }
-    }
-    .WLjaOb .O52YZb:focus-visible, .WLjaOb .O52YZb:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-secondary-container),
-        var(--gm3-sys-color-on-secondary-container) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .O52YZb:active, .O52YZb:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-secondary-container),
-        var(--gm3-sys-color-on-secondary-container) 12%
-      );
-    }
-    .aRDKUe .O52YZb {
-      background: var(--gm3-sys-color-secondary-container);
-      color: var(--gm3-sys-color-on-secondary-container);
-    }
-    @media (hover: hover) {
-      .aRDKUe .O52YZb:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-secondary-container),
-          var(--gm3-sys-color-on-secondary-container) 8%
-        );
-      }
-    }
-    .WLjaOb .aRDKUe .O52YZb:focus-visible,
-    .WLjaOb .aRDKUe .O52YZb:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-secondary-container),
-        var(--gm3-sys-color-on-secondary-container) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .O52YZb:active, .aRDKUe .O52YZb:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-secondary-container),
-        var(--gm3-sys-color-on-secondary-container) 12%
-      );
-    }
-    .gAlnEe, .UojMw {
-      color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .gAlnEe, .aRDKUe .UojMw {
-      color: var(--gm3-sys-color-primary);
-    }
-    @media (hover: hover) {
-      .gAlnEe:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb .gAlnEe:focus-visible, .WLjaOb .gAlnEe:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .gAlnEe:active, .gAlnEe:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    @media (hover: hover) {
-      .aRDKUe .gAlnEe:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb.aRDKUe .gAlnEe:focus-visible,
-    .WLjaOb.aRDKUe .gAlnEe:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .gAlnEe:active, .aRDKUe .gAlnEe:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    .UojMw {
-      border-color: var(--gm3-sys-color-outline);
-    }
-    @media (hover: hover) {
-      .UojMw:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb .UojMw:focus-visible, .WLjaOb .UojMw:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .UojMw:active, .UojMw:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    .aRDKUe .UojMw {
-      border-color: var(--gm3-sys-color-outline);
-    }
-    @media (hover: hover) {
-      .aRDKUe .UojMw:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb.aRDKUe .UojMw:focus-visible,
-    .WLjaOb.aRDKUe .UojMw:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .UojMw:active, .aRDKUe .UojMw:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    .B6iy6c .XdWBVd, .qUNJcb .XdWBVd {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .B6iy6c .XdWBVd, .aRDKUe .qUNJcb .XdWBVd {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .B6iy6c.qLP7kc .jFfZdd,
-    .qUNJcb.qLP7kc .jFfZdd,
-    .aRDKUe .B6iy6c.qLP7kc .jFfZdd,
-    .aRDKUe .qUNJcb.qLP7kc .jFfZdd {
-      background: var(--gm3-sys-color-primary-container);
-    }
-    .WLjaOb .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
-    .WLjaOb .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd {
-      background: var(--gm3-sys-color-primary-container);
-    }
-    .WLjaOb.aRDKUe .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
-    .WLjaOb.aRDKUe .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .B6iy6c .D2509d, .qUNJcb .D2509d {
-      color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .B6iy6c .D2509d, .aRDKUe .qUNJcb .D2509d {
-      color: var(--gm3-sys-color-primary);
-    }
-    .VfPpkd-qNpTzb-P4pF8c-SmKAyb {
-      border-color: var(--mdc-linear-progress-active-indicator-color, #6200ee);
-    }
-    .KKMNAc {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .KKMNAc {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .ut3Ak .KKMNAc.AJilCf {
-      background: var(--gm3-sys-color-secondary-container);
-    }
-    .aRDKUe .ut3Ak .KKMNAc.AJilCf {
-      background: var(--gm3-sys-color-secondary-container);
-    }
-    .aFCkf {
-      color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .aFCkf {
-      background: var(--gm3-sys-color-surface-container-high);
-      color: var(--gm3-sys-color-primary);
-    }
-    .x8mAUc .HyhVZe {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .x8mAUc .HyhVZe {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .cllK4d {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .cllK4d {
-      background: var(--gm3-sys-color-surface-container-high);
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .coHE2 {
-      border-color: var(--gm3-sys-color-outline);
-    }
-    @media (hover: hover) {
-      .coHE2:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb .coHE2:focus-visible, .WLjaOb .coHE2:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .coHE2:active, .coHE2:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    .aRDKUe .coHE2 {
-      border-color: var(--gm3-sys-color-outline);
-    }
-    @media (hover: hover) {
-      .aRDKUe .coHE2:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb.aRDKUe .coHE2:focus-visible,
-    .WLjaOb.aRDKUe .coHE2:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .coHE2:active, .aRDKUe .coHE2:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    .WkuXae {
-      color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .WkuXae {
-      color: var(--gm3-sys-color-primary);
-    }
-    .wk3GB {
-      fill: var(--gm3-sys-color-surface-container-highest);
-    }
-    .eYSAde {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .eYSAde {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .hCDve {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .G5bXNb {
-      background: var(--gm3-sys-color-surface-container-high);
-    }
-    @media (hover: hover) {
-      .Q3BXBb:hover .GXg3Le {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb .Q3BXBb:focus-visible .GXg3Le,
-    .WLjaOb .Q3BXBb:focus-visible:hover .GXg3Le {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .Q3BXBb:active .GXg3Le, .Q3BXBb:active:focus-visible .GXg3Le {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    @media (hover: hover) {
-      .aRDKUe .Q3BXBb:hover .GXg3Le {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb.aRDKUe .Q3BXBb:focus-visible .GXg3Le,
-    .WLjaOb.aRDKUe .Q3BXBb:focus-visible:hover .GXg3Le {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .Q3BXBb:active .GXg3Le,
-    .aRDKUe .Q3BXBb:active:focus-visible .GXg3Le {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    .Q3BXBb:hover .GXg3Le,
-    // .Q3BXBb:focus-visible .GXg3Le,
-    .Q3BXBb:active .GXg3Le,
-    .WLjaOb .Q3BXBb:focus-visible .GXg3Le,
-    .Q3BXBb:focus-visible .GXg3Le,
-    .GXg3Le:hover,
-    // .GXg3Le:focus-visible,
-    .GXg3Le:active,
-    .WLjaOb .GXg3Le:focus-visible,
-    .GXg3Le:focus-visible {
-      color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .Q3BXBb:hover .GXg3Le,
-    // .aRDKUe .Q3BXBb:focus-visible .GXg3Le,
-    .aRDKUe .Q3BXBb:active .GXg3Le,
-    .aRDKUe .WLjaOb .Q3BXBb:focus-visible .GXg3Le,
-    .aRDKUe .Q3BXBb:focus-visible .GXg3Le,
-    .aRDKUe .GXg3Le:hover,
-    // .aRDKUe .GXg3Le:focus-visible,
-    .aRDKUe .GXg3Le:active,
-    .aRDKUe .WLjaOb .GXg3Le:focus-visible,
-    .aRDKUe .GXg3Le:focus-visible {
-      color: var(--gm3-sys-color-primary);
-    }
-    .GXg3Le {
-      background: var(--gm3-sys-color-surface-container-highest);
-    }
-    @media (hover: hover) {
-      .pQpjR:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb .pQpjR:focus-visible, .WLjaOb .pQpjR:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .pQpjR:active, .pQpjR:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    @media (hover: hover) {
-      .aRDKUe .pQpjR:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb.aRDKUe .pQpjR:focus-visible,
-    .WLjaOb.aRDKUe .pQpjR:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .pQpjR:active, .aRDKUe .pQpjR:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    .SDV7ef {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .SDV7ef {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .qLP7kc .jFfZdd {
-      background: var(--gm3-sys-color-surface-container-low);
-    }
-    .aRDKUe .qLP7kc .jFfZdd {
-      background: var(--gm3-sys-color-surface-container-low);
-    }
-    @media (hover: hover) {
-      .qLP7kc .jFfZdd.Dn5Ezd:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb .qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
-    .WLjaOb .qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .qLP7kc .jFfZdd.Dn5Ezd:active, .qLP7kc .jFfZdd.Dn5Ezd:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    @media (hover: hover) {
-      .aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:hover {
-        background: color-mix(
-          in oklab,
-          var(--gm3-sys-color-surface-container-low),
-          var(--gm3-sys-color-on-surface) 8%
-        );
-      }
-    }
-    .WLjaOb.aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
-    .WLjaOb.aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:active,
-    .aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:active:focus-visible {
-      background: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    .pRjiJb {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .aRDKUe .pRjiJb {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .MbHqJ {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .MbHqJ {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .DmSTqc {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .DmSTqc {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .idKC9b {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .aRDKUe .idKC9b {
-      color: var(--gm3-sys-color-on-surface-variant);
-    }
-    .C6Fnkb {
-      color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .C6Fnkb {
-      color: var(--gm3-sys-color-primary);
-    }
-    .N3AcWd {
-      background: var(--gm3-sys-color-primary);
-      color: var(--gm3-sys-color-surface-container-highest);
-    }
-    .aRDKUe .N3AcWd {
-      background: var(--gm3-sys-color-primary);
-    }
-    .GgqZjb .AHFKnd {
-      border-color: var(--gm3-sys-color-on-surface-variant);
-      border-bottom-color: var(--gm3-sys-color-surface-container-low);
-    }
-    .aRDKUe .GgqZjb .AHFKnd {
-      border-color: var(--gm3-sys-color-on-surface-variant);
-      border-bottom-color: var(--gm3-sys-color-surface-container-low);
-    }
-    .IAMa4b {
-      color: var(--gm3-sys-color-primary);
-    }
-    @media (hover: hover) {
-      .IAMa4b:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb .IAMa4b:focus-visible, .WLjaOb .IAMa4b:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .IAMa4b:active, .IAMa4b:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    .aRDKUe .IAMa4b {
-      color: var(--gm3-sys-color-primary);
-    }
-    @media (hover: hover) {
-      .aRDKUe .IAMa4b:hover {
-        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
-      }
-    }
-    .WLjaOb.aRDKUe .IAMa4b:focus-visible,
-    .WLjaOb.aRDKUe .IAMa4b:focus-visible:hover {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-      border-color: var(--gm3-sys-color-primary);
-    }
-    .aRDKUe .IAMa4b:active, .aRDKUe .IAMa4b:active:focus-visible {
-      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
-    }
-    .EHzcec {
-      background: var(--gm3-sys-color-surface-container-high);
-      background: var(
-        --gm3-sys-color-surface-container-high,
-        var(--gm3-sys-color-surface-container-high)
-      );
-    }
-    .nz9sqb.EHzcec {
-      background: var(--gm3-sys-color-surface-container-high);
-      background: var(
-        --gm3-sys-color-surface-container-high,
-        var(--gm3-sys-color-surface-container-high)
-      );
-    }
-    .nz9sqb.EHzcec .LVal7b {
-      background: var(--gm3-sys-color-surface-container-low);
-      background: var(
-        --gm3-sys-color-surface-container-low,
-        var(--gm3-sys-color-surface-container-low)
-      );
-      color: var(--gm3-sys-color-on-surface-variant);
-      color: var(
-        --gm3-sys-color-on-surface-variant,
-        var(--gm3-sys-color-on-surface-variant)
-      );
-    }
-    .LVal7b {
-      background: var(--gm3-sys-color-surface-container-low);
-      background: var(
-        --gm3-sys-color-surface-container-low,
-        var(--gm3-sys-color-surface-container-low)
-      );
-      color: var(--gm3-sys-color-on-surface-variant);
-      color: var(
-        --gm3-sys-color-on-surface-variant,
-        var(--gm3-sys-color-on-surface-variant)
-      );
-    }
-    .o07G5 .tX9u1b:active,
-    .o07G5 .tX9u1b:active:focus,
-    .o07G5 .tX9u1b:active .Rq5Gcb,
-    .o07G5 .tX9u1b:active:hover .Rq5Gcb {
-      background-color: var(--gm3-sys-color-surface-container-highest);
-    }
-    .nz9sqb.o07G5 .tX9u1b:active,
-    .nz9sqb.o07G5 .tX9u1b:active:focus,
-    .nz9sqb.o07G5 .tX9u1b:active .Rq5Gcb,
-    .nz9sqb.o07G5 .tX9u1b:active:hover .Rq5Gcb {
-      background-color: var(--gm3-sys-color-surface-container-highest);
-    }
-    .Rq5Gcb {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .nz9sqb .Rq5Gcb {
-      color: var(--gm3-sys-color-on-surface);
-    }
-    .dGrefb {
-      border-bottom-color: var(--gm3-sys-color-on-surface);
-    }
-    // .NQV3m {
-    //   background-color: var(--gm3-sys-color-surface-container-highest);
-    // }
-    .OunZ9c {
-      background: var(--gm3-sys-color-surface-container-highest);
-    }
-    .NPEKs {
-      background: var(--gm3-sys-color-primary);
-    }
-    .nz9sqb .NPEKs {
-      background: var(--gm3-sys-color-primary);
-    }
-    .tX9u1b:hover {
-      background-color: var(--gm3-sys-color-surface-container-high);
-      background-color: var(
-        --gm3-sys-color-surface-container-high,
-        var(--gm3-sys-color-surface-container-high)
-      );
-    }
-    .tX9u1b:active, .tX9u1b:active:focus {
-      background-color: var(--gm3-sys-color-surface-container-highest);
-      background-color: var(
-        --gm3-sys-color-surface-container-highest,
-        var(--gm3-sys-color-surface-container-highest)
-      );
-    }
-    .QgddUc .tX9u1b:focus, .QgddUc .tX9u1b:hover:focus {
-      border-color: var(--gm3-sys-color-primary);
-      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-      background-color: var(--gm3-sys-color-surface-container-highest);
-      background-color: var(
-        --gm3-sys-color-surface-container-highest,
-        var(--gm3-sys-color-surface-container-highest)
-      );
-    }
-    .NQV3m {
-      border-color: var(--gm3-sys-color-outline);
-      border-color: var(--gm3-sys-color-outline, var(--gm3-sys-color-outline));
-      color: var(--gm3-sys-color-primary);
-      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .NQV3m:focus-visible {
-      outline-color: var(--gm3-sys-color-primary);
-      outline-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    @media (forced-colors: active) {
-      .NQV3m {
-        border-color: var(--gm3-sys-color-outline);
-        border-color: var(
-          --gm3-sys-color-outline,
-          var(--gm3-sys-color-outline)
-        );
-      }
-    }
-    .nz9sqb .NQV3m {
-      border-color: var(--gm3-sys-color-outline);
-      border-color: var(--gm3-sys-color-outline, var(--gm3-sys-color-outline));
-      color: var(--gm3-sys-color-primary);
-      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .nz9sqb .NQV3m:focus-visible {
-      outline-color: var(--gm3-sys-color-primary);
-      outline-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    @media (forced-colors: active) {
-      .nz9sqb .NQV3m {
-        border-color: var(--gm3-sys-color-outline);
-        border-color: var(
-          --gm3-sys-color-outline,
-          var(--gm3-sys-color-outline)
-        );
-      }
-    }
-    .nz9sqb .tX9u1b:hover {
-      background-color: var(--gm3-sys-color-surface-container-high);
-      background-color: var(
-        --gm3-sys-color-surface-container-high,
-        var(--gm3-sys-color-surface-container-high)
-      );
-    }
-    .nz9sqb .tX9u1b:active, .nz9sqb .tX9u1b:active:focus {
-      background-color: var(--gm3-sys-color-surface-container-highest);
-      background-color: var(
-        --gm3-sys-color-surface-container-highest,
-        var(--gm3-sys-color-surface-container-highest)
-      );
-    }
-    .nz9sqb.QgddUc .tX9u1b:focus, .nz9sqb.QgddUc .tX9u1b:hover:focus {
-      border-color: var(--gm3-sys-color-primary);
-      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .kibP6b, .lHtSbd {
-      background: var(--gm3-sys-color-surface-container-low);
-      background: var(
-        --gm3-sys-color-surface-container-low,
-        var(--gm3-sys-color-surface-container-low)
-      );
-      color: var(--gm3-sys-color-primary);
-      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .lHtSbd {
-      color: var(--gm3-sys-color-on-surface-variant);
-      color: var(
-        --gm3-sys-color-on-surface-variant,
-        var(--gm3-sys-color-on-surface-variant)
-      );
-    }
-    .kibP6b:hover {
-      background-color: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 8%
-      );
-    }
-    .kibP6b:focus:active {
-      background-color: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    .EuVUud, .rn8xOd {
-      fill: var(--gm3-sys-color-primary);
-      fill: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .rn8xOd {
-      fill: var(--gm3-sys-color-on-surface-variant);
-      fill: var(
-        --gm3-sys-color-on-surface-variant,
-        var(--gm3-sys-color-on-surface-variant)
-      );
-    }
-    .p37w9e {
-      color: var(--gm3-sys-color-on-surface-variant);
-      color: var(
-        --gm3-sys-color-on-surface-variant,
-        var(--gm3-sys-color-on-surface-variant)
-      );
-    }
-    .bOwcqf {
-      background-color: var(--gm3-sys-color-primary);
-      background-color: var(
-        --gm3-sys-color-primary,
-        var(--gm3-sys-color-primary)
-      );
-      color: var(--gm3-sys-color-surface-container-low);
-      color: var(
-        --gm3-sys-color-surface-container-low,
-        var(--gm3-sys-color-surface-container-low)
-      );
-      border-color: var(--gm3-sys-color-surface-container-low);
-      border-color: var(
-        --gm3-sys-color-surface-container-low,
-        var(--gm3-sys-color-surface-container-low)
-      );
-    }
-    .QgddUc .kibP6b:focus, .QgddUc .lHtSbd:focus {
-      background: var(--gm3-sys-color-surface-container-highest);
-      background: var(
-        --gm3-sys-color-surface-container-highest,
-        var(--gm3-sys-color-surface-container-highest)
-      );
-      border-color: var(--gm3-sys-color-primary);
-      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .nz9sqb .kibP6b, .nz9sqb .lHtSbd {
-      background: var(--gm3-sys-color-surface-container-low);
-      background: var(
-        --gm3-sys-color-surface-container-low,
-        var(--gm3-sys-color-surface-container-low)
-      );
-      color: var(--gm3-sys-color-primary);
-      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .nz9sqb .kibP6b:focus:active, .nz9sqb .lHtSbd:focus:active {
-      background-color: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-    .nz9sqb .EuVUud, .nz9sqb .rn8xOd {
-      fill: var(--gm3-sys-color-primary);
-      fill: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-    }
-    .nz9sqb .p37w9e {
-      color: var(--gm3-sys-color-on-surface);
-      color: var(
-        --gm3-sys-color-on-background,
-        var(--gm3-sys-color-on-surface)
-      );
-    }
-    .nz9sqb .JI4QMc {
-      stroke: var(--gm3-sys-color-on-surface-variant);
-      stroke: var(
-        --gm3-sys-color-surface-variant,
-        var(--gm3-sys-color-on-surface-variant)
-      );
-    }
-    .nz9sqb .bOwcqf {
-      background-color: var(--gm3-sys-color-primary);
-      background-color: var(
-        --gm3-sys-color-primary,
-        var(--gm3-sys-color-primary)
-      );
-      border-color: var(--gm3-sys-color-surface-container, #1e1f20);
-    }
-    .nz9sqb.QgddUc .kibP6b:focus, .nz9sqb.QgddUc .lHtSbd:focus {
-      border-color: var(--gm3-sys-color-primary);
-      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
-      background-color: color-mix(
-        in oklab,
-        var(--gm3-sys-color-surface-container-low),
-        var(--gm3-sys-color-on-surface) 12%
-      );
-    }
-
-    // -- IMPORT END
-
-    // ## Legacy(M2) code \/ \/
-
-    // Password reset started alert dialog
-    .QsXJJ.vQ43Ie {
-      background: var(--gm3-sys-color-error-container);
-      color: var(--gm3-sys-color-on-error-container);
-    }
-    // Password reset started alert dialog main text
-    .hXhhq {
-      color: inherit;
-    }
-    // Password reset started alert dialog secondary text
-    .TnugZc,
-    // Password reset started alert dialog dismiss action
-    .xFITmb {
-      color: inherit;
-    }
-    // Password reset started alert dialog primary action
-    .QsXJJ .yZqNl,
-    .amE0Md .yZqNl,
-    // Password reset started alert dialog primary action states
-    .QsXJJ .yZqNl:hover,
-    .QsXJJ .yZqNl:hover:focus,
-    .QsXJJ .yZqNl:focus,
-    .QsXJJ .yZqNl:active,
-    .amE0Md .yZqNl:hover,
-    .amE0Md .yZqNl:hover:focus,
-    .amE0Md .yZqNl:focus,
-    .amE0Md .yZqNl:active {
-      background-color: var(--gm3-sys-color-error);
-      outline-color: var(--gm3-sys-color-error);
-    }
-    .yZqNl {
-      color: var(--gm3-sys-color-on-error);
     }
   }
 }

--- a/styles/google-account/catppuccin.user.less
+++ b/styles/google-account/catppuccin.user.less
@@ -41,7 +41,7 @@
 
   @media (prefers-color-scheme: light) {
     body, html, body:not(.mcwCGe) {
-      #catppuccin(@lightFlavor);
+      #catppuccin(@lightFlavor, false);
     }
   }
 
@@ -52,11 +52,11 @@
     // PFP picker image editor
     .P9KVBf,
     .wfJxA {
-      #catppuccin(@darkFlavor);
+      #catppuccin(@darkFlavor, false);
     }
   }
 
-  #catppuccin(@flavor) {
+  #catppuccin(@flavor, @isModal) {
     @rosewater: @catppuccin[@@flavor][@rosewater];
     @flamingo: @catppuccin[@@flavor][@flamingo];
     @pink: @catppuccin[@@flavor][@pink];
@@ -90,8 +90,7 @@
       @catppuccin[@latte][@@accentColor]
     );
 
-    color-scheme: if(@flavor = latte, light, dark);
-    color-scheme: initial;
+    color-scheme: @if(@isModal, initial, if(@flavor = latte, light, dark));
 
     ::selection {
       background-color: fade(@accent, 30%);
@@ -576,7 +575,7 @@
     --identity-common-ui-components-web-color-disclaimer-background: var(
       --gm3-sys-color-surface-container-low
     );
-    --identity-common-ui-components-web-color-icon-warning: rgb(242, 153, 0);
+    --identity-common-ui-components-web-color-icon-warning: @yellow;
     --identity-common-ui-components-web-color-icon-green: @green;
     --identity-common-ui-components-web-color-icon-yellow: @yellow;
     --identity-common-ui-components-web-color-icon-info: @blue;
@@ -586,30 +585,37 @@
       var(--gm3-sys-color-shadow-rgb),
       0.15
     );
-    --identity-common-ui-components-web-color-level-2-background: #fff;
+    --identity-common-ui-components-web-color-level-2-background: var(--gm3-sys-color-surface-container);
     --identity-common-ui-components-web-color-level-2-background-translucent: rgba(
-      255,
-      255,
-      255,
+      var(--gm3-sys-color-surface-container-rgb)
       0.96
     );
     --identity-common-ui-components-web-color-level-2-box-shadow:
       0px 1px 2px 0px rgba(var(--gm3-sys-color-shadow-rgb), 0.3),0px 2px 6px 2px
       rgba(
-      60,
-      64,
-      67,
+      var(--gm3-sys-color-shadow-rgb),
       0.15
     );
-    --identity-common-ui-components-web-color-text-on-warning: #1f1f1f;
-    --identity-common-ui-components-web-color-text-warning: #1f1f1f;
-    --identity-common-ui-components-web-color-text-warning-stateful: #1f1f1f;
-    --identity-common-ui-components-web-color-action-primary-warning: #f09d00;
-    --identity-common-ui-components-web-color-banner-background-warning: #fff0d1;
-    --identity-common-ui-components-web-color-action-primary-disabled: rgb(
-      154,
-      160,
-      166
+    --identity-common-ui-components-web-color-text-on-warning: saturate(
+      mix(@yellow, @base, 20%),
+      25%
+    );
+    --identity-common-ui-components-web-color-text-warning: saturate(
+      mix(@yellow, @base, 20%),
+      25%
+    );
+    --identity-common-ui-components-web-color-text-warning-stateful: saturate(
+      mix(@yellow, @base, 20%),
+      25%
+    );
+    --identity-common-ui-components-web-color-action-primary-warning: @yellow;
+    --identity-common-ui-components-web-color-banner-background-warning: saturate(
+      mix(@yellow, @mantle, 40%),
+      20%
+    );
+    --identity-common-ui-components-web-color-action-primary-disabled: rgba(
+      var(--gm3-sys-color-primary-rgb),
+      0.5
     );
 
     --boq-chrometransition-background: var(--gm3-sys-color-surface-container);
@@ -681,7 +687,7 @@
       background-color: var(--gm3-sys-color-inverse-surface);
       color: var(
         --gm3-tooltip-plain-supporting-text-color,
-        var(--gm3-sys-color-inverse-on-surface, #f2f2f2)
+        var(--gm3-sys-color-inverse-on-surface)
       );
     }
 
@@ -1615,10 +1621,10 @@
 
 @-moz-document domain("ogs.google.com") {
   body {
-    #catppuccin(@darkFlavor);
+    #catppuccin(@darkFlavor, true);
   }
 
-  #catppuccin(@flavor) {
+  #catppuccin(@flavor, @isModal) {
     @rosewater: @catppuccin[@@flavor][@rosewater];
     @flamingo: @catppuccin[@@flavor][@flamingo];
     @pink: @catppuccin[@@flavor][@pink];
@@ -1652,7 +1658,7 @@
       @catppuccin[@latte][@@accentColor]
     );
 
-    // color-scheme: if(@flavor = latte, light, dark);
+    color-scheme: @if(@isModal, initial, if(@flavor = latte, light, dark));
 
     ::selection {
       background-color: fade(@accent, 30%);
@@ -1664,6 +1670,9 @@
         color: @subtext0 !important;
       }
     }
+
+    // Set body default text colour
+    color: @text;
 
     @gm3-sys-color-error: @red;
     @gm3-sys-color-error-rgb: #rgbify(@gm3-sys-color-error)[];
@@ -1975,7 +1984,56 @@
     --gm3-sys-color-tertiary-fixed-dim-rgb: @gm3-sys-color-tertiary-fixed-dim-rgb;
     --mdc-ripple-color: var(--gm3-sys-color-primary);
 
-    --boq-chrometransition-background: var(--gm3-sys-color-surface);
+    --boq-chrometransition-background: var(--gm3-sys-color-surface-container);
+
+    --gm-colortextbutton-ink-color: var(--gm3-sys-color-on-surface);
+    --gm-colortextbutton-ink-color--stateful: var(--gm3-sys-color-on-surface);
+    --gm-colortextbutton-state-color: var(--gm3-sys-color-on-surface);
+    --gm-fillbutton-ink-color: var(--gm3-sys-color-on-primary);
+    --gm-fillbutton-ink-color--stateful: var(--gm3-sys-color-primary);
+    --gm-fillbutton-container-color: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-outline-color: var(--gm3-sys-color-outline);
+    --gm-hairlinebutton-outline-color--stateful: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-state-color: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-ink-color: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-ink-color--stateful: var(--gm3-sys-color-primary);
+    --gm-radio-state-color: var(--gm3-sys-color-primary);
+    --gm-radio-ink-color: var(--gm3-sys-color-primary);
+    --gm-radio-ink-color--stateful: var(--gm3-sys-color-primary);
+    --gm-outlinedtextfield-caret-color: var(--gm3-sys-color-primary);
+    --gm-outlinedtextfield-ink-color: var(--gm3-sys-color-on-surface);
+    --gm-outlinedtextfield-outline-color: var(--gm3-sys-color-outline);
+    --gm-outlinedtextfield-outline-color--stateful: var(
+      --gm3-sys-color-primary
+    );
+    --gm-outlinedtextfield-label-color: var(--gm3-sys-color-on-surface-variant);
+    --gm-outlinedtextfield-label-color--stateful: var(--gm3-sys-color-primary);
+
+    --mdc-theme-surface: var(--gm3-sys-color-surface);
+    --mdc-theme-on-surface: var(--gm3-sys-color-on-surface);
+
+    --mdc-checkbox-unselected-icon-color: var(--gm3-sys-color-on-surface);
+    --mdc-checkbox-unselected-hover-icon-color: var(--gm3-sys-color-on-surface);
+    --mdc-checkbox-unselected-hover-state-layer-color: var(
+      --gm3-sys-color-on-surface
+    );
+    --mdc-checkbox-unselected-pressed-icon-color: var(
+      --gm3-sys-color-on-surface
+    );
+    --mdc-checkbox-unselected-pressed-state-layer-color: var(
+      --gm3-sys-color-on-surface
+    );
+
+    --mdc-checkbox-selected-icon-color: var(--gm3-sys-color-primary);
+    --mdc-checkbox-selected-hover-icon-color: var(--gm3-sys-color-primary);
+    --mdc-checkbox-selected-hover-state-layer-color: var(
+      --gm3-sys-color-primary
+    );
+    --mdc-checkbox-selected-pressed-icon-color: var(--gm3-sys-color-primary);
+    --mdc-checkbox-selected-pressed-state-layer-color: var(
+      --gm3-sys-color-primary
+    );
+    --mdc-checkbox-selected-checkmark-color: var(--gm3-sys-color-on-primary);
 
     color: @text;
 

--- a/styles/google-account/catppuccin.user.less
+++ b/styles/google-account/catppuccin.user.less
@@ -1,0 +1,2996 @@
+/* ==UserStyle==
+@name Google Account Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/google-account
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/google-account
+@version 2025.03.10
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/google-account/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Agoogle-account
+@description Soothing pastel theme for Google Account
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
+}
+
+@-moz-document domain("accounts.google.com"),
+  domain("one.google.com"),
+  domain("myaccount.google.com"),
+  domain("myactivity.google.com"),
+  domain("adssettings.google.com"),
+  domain("myadcenter.google.com") {
+  // body:not(.mcwCGe) {
+  //   #catppuccin(@lightFlavor);
+  // }
+
+  // // Review: Codebase supports dark theme however there's no user
+  // // exposed way to trigger this without class editing.
+  // body.mcwCGe,
+  // body:not(.mcwCGe),
+  // // PFP picker image editor
+  // .P9KVBf,
+  // .wfJxA {
+  //   #catppuccin(@darkFlavor);
+  // }
+
+  @media (prefers-color-scheme: light) {
+    body, html, body:not(.mcwCGe) {
+      #catppuccin(@lightFlavor);
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body,
+    html,
+    body:not(.mcwCGe),
+    // PFP picker image editor
+    .P9KVBf,
+    .wfJxA {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+    @inverse-accent: if(
+      @flavor = latte,
+      @catppuccin[@mocha][@@accentColor],
+      @catppuccin[@latte][@@accentColor]
+    );
+
+    color-scheme: if(@flavor = latte, light, dark);
+    color-scheme: initial;
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    // Set body default text colour
+    background-color: @base;
+    color: @text;
+
+    @gm3-sys-color-error: @red;
+    @gm3-sys-color-error-rgb: #rgbify(@gm3-sys-color-error)[];
+    @gm3-sys-color-error-container: desaturate(darken(@red, 50%), 50%);
+    @gm3-sys-color-error-container-rgb: #rgbify(
+      @gm3-sys-color-error-container,
+    )[];
+
+    @gm3-sys-color-on-error: darken(desaturate(@red, 20%), 50%);
+    @gm3-sys-color-on-error-rgb: #rgbify(@gm3-sys-color-on-error)[];
+    @gm3-sys-color-on-error-container: desaturate(darken(@red, -10%), 50%);
+    @gm3-sys-color-on-error-container-rgb: #rgbify(
+      @gm3-sys-color-on-error-container,
+    )[];
+
+    @gm3-sys-color-primary: @accent;
+    @gm3-sys-color-primary-rgb: #rgbify(@gm3-sys-color-primary)[];
+    @gm3-sys-color-primary-fixed: lighten(@accent, 5%);
+    @gm3-sys-color-primary-fixed-rgb: #rgbify(@gm3-sys-color-primary-fixed)[];
+    @gm3-sys-color-primary-fixed-dim: darken(@accent, 5%);
+    @gm3-sys-color-primary-fixed-dim-rgb: #rgbify(
+      @gm3-sys-color-primary-fixed-dim,
+    )[];
+
+    @gm3-sys-color-on-primary: saturate(
+      mix(@gm3-sys-color-primary, @base, 20%),
+      25%
+    );
+    @gm3-sys-color-on-primary-rgb: #rgbify(@gm3-sys-color-on-primary)[];
+    @gm3-sys-color-on-primary-fixed: darken(@gm3-sys-color-on-primary, 5%);
+    @gm3-sys-color-on-primary-fixed-rgb: #rgbify(
+      @gm3-sys-color-on-primary-fixed,
+    )[];
+    @gm3-sys-color-on-primary-fixed-variant: lighten(
+      @gm3-sys-color-on-primary,
+      5%
+    );
+    @gm3-sys-color-on-primary-fixed-variant-rgb: #rgbify(
+      @gm3-sys-color-on-primary-fixed-variant,
+    )[];
+
+    @gm3-sys-color-primary-container: saturate(
+      mix(@gm3-sys-color-primary, @mantle, 40%),
+      20%
+    );
+    @gm3-sys-color-primary-container-rgb: #rgbify(
+      @gm3-sys-color-primary-container,
+    )[];
+    @gm3-sys-color-on-primary-container: saturate(
+      mix(@gm3-sys-color-primary, @text, 10%),
+      25%
+    );
+    @gm3-sys-color-on-primary-container-rgb: #rgbify(
+      @gm3-sys-color-on-primary-container,
+    )[];
+
+    @gm3-sys-color-secondary: desaturate(@accent, 40%);
+    @gm3-sys-color-secondary-rgb: #rgbify(@gm3-sys-color-secondary)[];
+    @gm3-sys-color-secondary-fixed: lighten(@gm3-sys-color-secondary, 5%);
+    @gm3-sys-color-secondary-fixed-rgb: #rgbify(
+      @gm3-sys-color-secondary-fixed,
+    )[];
+    @gm3-sys-color-secondary-fixed-dim: darken(@gm3-sys-color-secondary, 5%);
+    @gm3-sys-color-secondary-fixed-dim-rgb: #rgbify(
+      @gm3-sys-color-secondary-fixed-dim,
+    )[];
+
+    @gm3-sys-color-on-secondary: saturate(
+      mix(@gm3-sys-color-secondary, @base, 20%),
+      25%
+    );
+    @gm3-sys-color-on-secondary-rgb: #rgbify(@gm3-sys-color-on-secondary)[];
+    @gm3-sys-color-on-secondary-fixed: darken(@gm3-sys-color-on-secondary, 5%);
+    @gm3-sys-color-on-secondary-fixed-rgb: #rgbify(
+      @gm3-sys-color-on-secondary-fixed,
+    )[];
+    @gm3-sys-color-on-secondary-fixed-variant: lighten(
+      @gm3-sys-color-on-primary,
+      5%
+    );
+    @gm3-sys-color-on-secondary-fixed-variant-rgb: #rgbify(
+      @gm3-sys-color-on-secondary-fixed-variant,
+    )[];
+
+    @gm3-sys-color-secondary-container: saturate(
+      mix(@gm3-sys-color-secondary, @mantle, 20%),
+      10%
+    );
+    @gm3-sys-color-secondary-container-rgb: #rgbify(
+      @gm3-sys-color-secondary-container,
+    )[];
+    @gm3-sys-color-on-secondary-container: saturate(
+      mix(@gm3-sys-color-secondary, @text, 10%),
+      25%
+    );
+    @gm3-sys-color-on-secondary-container-rgb: #rgbify(
+      @gm3-sys-color-on-secondary-container,
+    )[];
+
+    @gm3-sys-color-tertiary: @accent;
+    @gm3-sys-color-tertiary-rgb: #rgbify(@gm3-sys-color-tertiary)[];
+    @gm3-sys-color-tertiary-fixed: lighten(@gm3-sys-color-tertiary, 5%);
+    @gm3-sys-color-tertiary-fixed-rgb: #rgbify(@gm3-sys-color-tertiary-fixed)[];
+    @gm3-sys-color-tertiary-fixed-dim: darken(@gm3-sys-color-tertiary, 5%);
+    @gm3-sys-color-tertiary-fixed-dim-rgb: #rgbify(
+      @gm3-sys-color-tertiary-fixed-dim,
+    )[];
+
+    @gm3-sys-color-on-tertiary: darken(
+      desaturate(@gm3-sys-color-tertiary, 25%),
+      50%
+    );
+    @gm3-sys-color-on-tertiary-rgb: #rgbify(@gm3-sys-color-on-tertiary)[];
+    @gm3-sys-color-on-tertiary-fixed: darken(@gm3-sys-color-on-tertiary, 5%);
+    @gm3-sys-color-on-tertiary-fixed-rgb: #rgbify(
+      @gm3-sys-color-on-tertiary-fixed,
+    )[];
+    @gm3-sys-color-on-tertiary-fixed-variant: lighten(
+      @gm3-sys-color-on-tertiary,
+      5%
+    );
+    @gm3-sys-color-on-tertiary-fixed-variant-rgb: #rgbify(
+      @gm3-sys-color-on-tertiary-fixed-variant,
+    )[];
+
+    @gm3-sys-color-tertiary-container: saturate(
+      mix(@gm3-sys-color-tertiary, @mantle, 20%),
+      0%
+    );
+    @gm3-sys-color-tertiary-container-rgb: #rgbify(
+      @gm3-sys-color-tertiary-container,
+    )[];
+    @gm3-sys-color-on-tertiary-container: lighten(
+      saturate(@gm3-sys-color-tertiary-container, 50%),
+      65%
+    );
+    @gm3-sys-color-on-tertiary-container-rgb: #rgbify(
+      @gm3-sys-color-on-tertiary-container,
+    )[];
+
+    @gm3-sys-color-background: @base;
+    @gm3-sys-color-background-rgb: #rgbify(@gm3-sys-color-background)[];
+    @gm3-sys-color-on-background: @text;
+    @gm3-sys-color-on-background-rgb: #rgbify(@gm3-sys-color-on-background)[];
+
+    @gm3-sys-color-surface: @base;
+    @gm3-sys-color-surface-rgb: #rgbify(@gm3-sys-color-surface)[];
+    @gm3-sys-color-surface-bright: @surface0;
+    @gm3-sys-color-surface-bright-rgb: #rgbify(@gm3-sys-color-surface-bright)[];
+    @gm3-sys-color-surface-dim: @crust;
+    @gm3-sys-color-surface-dim-rgb: #rgbify(@gm3-sys-color-surface-dim)[];
+    @gm3-sys-color-surface-variant: mix(@mantle, @accent, 87.5%);
+    @gm3-sys-color-surface-variant-rgb: #rgbify(
+      @gm3-sys-color-surface-variant,
+    )[];
+    @gm3-sys-color-surface-tint: @accent;
+    @gm3-sys-color-surface-tint-rgb: #rgbify(@gm3-sys-color-surface-tint)[];
+
+    @gm3-sys-color-on-surface: @text;
+    @gm3-sys-color-on-surface-rgb: #rgbify(@gm3-sys-color-on-surface)[];
+    @gm3-sys-color-on-surface-variant: @subtext0;
+    @gm3-sys-color-on-surface-variant-rgb: #rgbify(
+      @gm3-sys-color-on-surface-variant,
+    )[];
+
+    @gm3-sys-color-inverse-surface: @text;
+    @gm3-sys-color-inverse-surface-rgb: #rgbify(
+      @gm3-sys-color-inverse-surface,
+    )[];
+    @gm3-sys-color-inverse-on-surface: @mantle;
+    @gm3-sys-color-inverse-on-surface-rgb: #rgbify(
+      @gm3-sys-color-inverse-on-surface,
+    )[];
+    @gm3-sys-color-inverse-primary: @inverse-accent; // TODO: Colour role clarification
+    @gm3-sys-color-inverse-primary-rgb: #rgbify(
+      @gm3-sys-color-inverse-primary,
+    )[];
+
+    @gm3-sys-color-surface-container-highest: @surface1;
+    @gm3-sys-color-surface-container-highest-rgb: #rgbify(
+      @gm3-sys-color-surface-container-highest,
+    )[];
+    @gm3-sys-color-surface-container-high: @surface0;
+    @gm3-sys-color-surface-container-high-rgb: #rgbify(
+      @gm3-sys-color-surface-container-high,
+    )[];
+    @gm3-sys-color-surface-container: @surface0;
+    @gm3-sys-color-surface-container-rgb: #rgbify(
+      @gm3-sys-color-surface-container,
+    )[];
+    @gm3-sys-color-surface-container-low: @mantle;
+    @gm3-sys-color-surface-container-low-rgb: #rgbify(
+      @gm3-sys-color-surface-container-low,
+    )[];
+    @gm3-sys-color-surface-container-lowest: @crust;
+    @gm3-sys-color-surface-container-lowest-rgb: #rgbify(
+      @gm3-sys-color-surface-container-lowest,
+    )[];
+
+    @gm3-sys-color-outline: @overlay2;
+    @gm3-sys-color-outline-rgb: #rgbify(@gm3-sys-color-outline)[];
+    @gm3-sys-color-outline-variant: @overlay0;
+    @gm3-sys-color-outline-variant-rgb: #rgbify(
+      @gm3-sys-color-outline-variant,
+    )[];
+
+    @gm3-sys-color-scrim: #000;
+    @gm3-sys-color-scrim-rgb: #rgbify(@gm3-sys-color-scrim)[];
+    @gm3-sys-color-shadow: #000;
+    @gm3-sys-color-shadow-rgb: #rgbify(@gm3-sys-color-shadow)[];
+
+    --gm3-sys-color-background: @gm3-sys-color-background;
+    --gm3-sys-color-background-rgb: @gm3-sys-color-background-rgb;
+    --gm3-sys-color-error: @gm3-sys-color-error;
+    --gm3-sys-color-error-rgb: @gm3-sys-color-error-rgb;
+    --gm3-sys-color-error-container: @gm3-sys-color-error-container;
+    --gm3-sys-color-error-container-rgb: @gm3-sys-color-error-container-rgb;
+    --gm3-sys-color-inverse-on-surface: @gm3-sys-color-inverse-on-surface;
+    --gm3-sys-color-inverse-on-surface-rgb: @gm3-sys-color-inverse-on-surface-rgb;
+    --gm3-sys-color-inverse-primary: @gm3-sys-color-inverse-primary;
+    --gm3-sys-color-inverse-primary-rgb: @gm3-sys-color-inverse-primary-rgb;
+    --gm3-sys-color-inverse-surface: @gm3-sys-color-inverse-surface;
+    --gm3-sys-color-inverse-surface-rgb: @gm3-sys-color-inverse-surface-rgb;
+    --gm3-sys-color-on-background: @gm3-sys-color-on-background;
+    --gm3-sys-color-on-background-rgb: @gm3-sys-color-on-background-rgb;
+    --gm3-sys-color-on-error: @gm3-sys-color-on-error;
+    --gm3-sys-color-on-error-rgb: @gm3-sys-color-on-error-rgb;
+    --gm3-sys-color-on-error-container: @gm3-sys-color-on-error-container;
+    --gm3-sys-color-on-error-container-rgb: @gm3-sys-color-on-error-container-rgb;
+    --gm3-sys-color-on-primary: @gm3-sys-color-on-primary;
+    --gm3-sys-color-on-primary-rgb: @gm3-sys-color-on-primary-rgb;
+    --gm3-sys-color-on-primary-container: @gm3-sys-color-on-primary-container;
+    --gm3-sys-color-on-primary-container-rgb: @gm3-sys-color-on-primary-container-rgb;
+    --gm3-sys-color-on-primary-fixed: @gm3-sys-color-on-primary-fixed;
+    --gm3-sys-color-on-primary-fixed-rgb: @gm3-sys-color-on-primary-fixed-rgb;
+    --gm3-sys-color-on-primary-fixed-variant: @gm3-sys-color-on-primary-fixed-variant;
+    --gm3-sys-color-on-primary-fixed-variant-rgb: @gm3-sys-color-on-primary-fixed-variant-rgb;
+    --gm3-sys-color-on-secondary: @gm3-sys-color-on-secondary;
+    --gm3-sys-color-on-secondary-rgb: @gm3-sys-color-on-secondary-rgb;
+    --gm3-sys-color-on-secondary-container: @gm3-sys-color-on-secondary-container;
+    --gm3-sys-color-on-secondary-container-rgb: @gm3-sys-color-on-secondary-container-rgb;
+    --gm3-sys-color-on-secondary-fixed: @gm3-sys-color-on-secondary-fixed;
+    --gm3-sys-color-on-secondary-fixed-rgb: @gm3-sys-color-on-secondary-fixed-rgb;
+    --gm3-sys-color-on-secondary-fixed-variant: @gm3-sys-color-on-secondary-fixed-variant;
+    --gm3-sys-color-on-secondary-fixed-variant-rgb: @gm3-sys-color-on-secondary-fixed-variant-rgb;
+    --gm3-sys-color-on-surface: @gm3-sys-color-on-surface;
+    --gm3-sys-color-on-surface-rgb: @gm3-sys-color-on-surface-rgb;
+    --gm3-sys-color-on-surface-variant: @gm3-sys-color-on-surface-variant;
+    --gm3-sys-color-on-surface-variant-rgb: @gm3-sys-color-on-surface-variant-rgb;
+    --gm3-sys-color-on-tertiary: @gm3-sys-color-on-tertiary;
+    --gm3-sys-color-on-tertiary-rgb: @gm3-sys-color-on-tertiary-rgb;
+    --gm3-sys-color-on-tertiary-container: @gm3-sys-color-on-tertiary-container;
+    --gm3-sys-color-on-tertiary-container-rgb: @gm3-sys-color-on-tertiary-container-rgb;
+    --gm3-sys-color-on-tertiary-fixed: @gm3-sys-color-on-tertiary-fixed;
+    --gm3-sys-color-on-tertiary-fixed-rgb: @gm3-sys-color-on-tertiary-fixed-rgb;
+    --gm3-sys-color-on-tertiary-fixed-variant: @gm3-sys-color-on-tertiary-fixed-variant;
+    --gm3-sys-color-on-tertiary-fixed-variant-rgb: @gm3-sys-color-on-tertiary-fixed-variant-rgb;
+    --gm3-sys-color-outline: @gm3-sys-color-outline;
+    --gm3-sys-color-outline-rgb: @gm3-sys-color-outline-rgb;
+    --gm3-sys-color-outline-variant: @gm3-sys-color-outline-variant;
+    --gm3-sys-color-outline-variant-rgb: @gm3-sys-color-outline-variant-rgb;
+    --gm3-sys-color-primary: @gm3-sys-color-primary;
+    --gm3-sys-color-primary-rgb: @gm3-sys-color-primary-rgb;
+    --gm3-sys-color-primary-container: @gm3-sys-color-primary-container;
+    --gm3-sys-color-primary-container-rgb: @gm3-sys-color-primary-container-rgb;
+    --gm3-sys-color-primary-fixed: @gm3-sys-color-primary-fixed;
+    --gm3-sys-color-primary-fixed-rgb: @gm3-sys-color-primary-fixed-rgb;
+    --gm3-sys-color-primary-fixed-dim: @gm3-sys-color-primary-fixed-dim;
+    --gm3-sys-color-primary-fixed-dim-rgb: @gm3-sys-color-primary-fixed-dim-rgb;
+    --gm3-sys-color-scrim: @gm3-sys-color-scrim;
+    --gm3-sys-color-scrim-rgb: @gm3-sys-color-scrim-rgb;
+    --gm3-sys-color-secondary: @gm3-sys-color-secondary;
+    --gm3-sys-color-secondary-rgb: @gm3-sys-color-secondary-rgb;
+    --gm3-sys-color-secondary-container: @gm3-sys-color-secondary-container;
+    --gm3-sys-color-secondary-container-rgb: @gm3-sys-color-secondary-container-rgb;
+    --gm3-sys-color-secondary-fixed: @gm3-sys-color-secondary-fixed;
+    --gm3-sys-color-secondary-fixed-rgb: @gm3-sys-color-secondary-fixed-rgb;
+    --gm3-sys-color-secondary-fixed-dim: @gm3-sys-color-secondary-fixed-dim;
+    --gm3-sys-color-secondary-fixed-dim-rgb: @gm3-sys-color-secondary-fixed-dim-rgb;
+    --gm3-sys-color-shadow: @gm3-sys-color-shadow;
+    --gm3-sys-color-shadow-rgb: @gm3-sys-color-shadow-rgb;
+    --gm3-sys-color-surface: @gm3-sys-color-surface;
+    --gm3-sys-color-surface-rgb: @gm3-sys-color-surface-rgb;
+    --gm3-sys-color-surface-bright: @gm3-sys-color-surface-bright;
+    --gm3-sys-color-surface-bright-rgb: @gm3-sys-color-surface-bright-rgb;
+    --gm3-sys-color-surface-container: @gm3-sys-color-surface-container;
+    --gm3-sys-color-surface-container-rgb: @gm3-sys-color-surface-container-rgb;
+    --gm3-sys-color-surface-container-high: @gm3-sys-color-surface-container-high;
+    --gm3-sys-color-surface-container-high-rgb: @gm3-sys-color-surface-container-high-rgb;
+    --gm3-sys-color-surface-container-highest: @gm3-sys-color-surface-container-highest;
+    --gm3-sys-color-surface-container-highest-rgb: @gm3-sys-color-surface-container-highest-rgb;
+    --gm3-sys-color-surface-container-low: @gm3-sys-color-surface-container-low;
+    --gm3-sys-color-surface-container-low-rgb: @gm3-sys-color-surface-container-low-rgb;
+    --gm3-sys-color-surface-container-lowest: @gm3-sys-color-surface-container-lowest;
+    --gm3-sys-color-surface-container-lowest-rgb: @gm3-sys-color-surface-container-lowest-rgb;
+    --gm3-sys-color-surface-dim: @gm3-sys-color-surface-dim;
+    --gm3-sys-color-surface-dim-rgb: @gm3-sys-color-surface-dim-rgb;
+    --gm3-sys-color-surface-tint: @gm3-sys-color-surface-tint;
+    --gm3-sys-color-surface-tint-rgb: @gm3-sys-color-surface-tint-rgb;
+    --gm3-sys-color-surface-variant: @gm3-sys-color-surface-variant;
+    --gm3-sys-color-surface-variant-rgb: @gm3-sys-color-surface-variant-rgb;
+    --gm3-sys-color-tertiary: @gm3-sys-color-tertiary;
+    --gm3-sys-color-tertiary-rgb: @gm3-sys-color-tertiary-rgb;
+    --gm3-sys-color-tertiary-container: @gm3-sys-color-tertiary-container;
+    --gm3-sys-color-tertiary-container-rgb: @gm3-sys-color-tertiary-container-rgb;
+    --gm3-sys-color-tertiary-fixed: @gm3-sys-color-tertiary-fixed;
+    --gm3-sys-color-tertiary-fixed-rgb: @gm3-sys-color-tertiary-fixed-rgb;
+    --gm3-sys-color-tertiary-fixed-dim: @gm3-sys-color-tertiary-fixed-dim;
+    --gm3-sys-color-tertiary-fixed-dim-rgb: @gm3-sys-color-tertiary-fixed-dim-rgb;
+    --mdc-ripple-color: var(--gm3-sys-color-primary);
+
+    --identity-common-ui-components-web-color-accordion-hover: rgba(
+      var(--gm3-sys-color-on-surface),
+      0.08
+    );
+    --identity-common-ui-components-web-color-accordion-focus: rgba(
+      var(--gm3-sys-color-on-surface),
+      0.12
+    );
+    --identity-common-ui-components-web-color-accordion-active: rgba(
+      var(--gm3-sys-color-on-surface),
+      0.12
+    );
+    --identity-common-ui-components-web-color-aclpicker-button-selected-border: var(
+      --gm3-sys-color-outline
+    );
+    --identity-common-ui-components-web-color-appbar-content-background: var(
+      --gm3-sys-color-surface-container
+    );
+    --identity-common-ui-components-web-color-appbar-title-and-back-arrow-color: var(
+      --gm3-sys-color-on-surface
+    );
+    --identity-common-ui-components-web-color-appbar-webview: var(
+      --gm3-sys-color-on-surface
+    );
+    --identity-common-ui-components-web-color-checkbox-invalid-base: var(
+      --gm3-sys-color-error
+    );
+    --identity-common-ui-components-web-color-checkbox-invalid-active: var(
+      --gm3-sys-color-error
+    );
+    --identity-common-ui-components-web-color-chevron: var(
+      --gm3-sys-color-on-surface-variant
+    );
+    --identity-common-ui-components-web-color-birthday-error: var(
+      --gm3-sys-color-error
+    );
+    --identity-common-ui-components-web-color-page-background: var(
+      --gm3-sys-color-background
+    );
+    --identity-common-ui-components-web-color-page-over-background: var(
+      --gm3-sys-color-surface-container-high
+    );
+    --identity-common-ui-components-web-color-page-background-transparent: rgba(
+      var(--gm3-sys-color-surface),
+      0
+    );
+    --identity-common-ui-components-web-color-card-background: var(
+      --gm3-sys-color-surface
+    );
+    --identity-common-ui-components-web-color-card-border-critical: transparent;
+    --identity-common-ui-components-web-color-card-background-critical: var(
+      --gm3-sys-color-error-container
+    );
+    --identity-common-ui-components-web-color-icon-red: var(
+      --gm3-sys-color-error
+    );
+    --identity-common-ui-components-web-color-icon-navigation: var(
+      --gm3-sys-color-on-surface
+    );
+    --identity-common-ui-components-web-color-icon-tertiary: var(
+      --gm3-sys-color-tertiary
+    );
+    --identity-common-ui-components-web-color-icon-secondary: var(
+      --gm3-sys-color-on-surface-variant
+    );
+    --identity-common-ui-components-web-color-icon-primary: var(
+      --gm3-sys-color-primary
+    );
+    --identity-common-ui-components-web-color-icon-background-primary: var(
+      --gm3-sys-color-primary-container
+    );
+    --identity-common-ui-components-web-color-progressbar-background: var(
+      --gm3-sys-color-surface-variant
+    );
+    --identity-common-ui-components-web-color-progressbar-primary: var(
+      --gm3-sys-color-primary
+    );
+    --identity-common-ui-components-web-color-divider: var(
+      --gm3-sys-color-surface-variant
+    );
+    --identity-common-ui-components-web-color-gutter: var(
+      --gm3-sys-color-surface-variant
+    );
+    --identity-common-ui-components-web-color-ripple: var(
+      --gm3-sys-color-on-surface
+    );
+    --identity-common-ui-components-web-color-ripple-hover: rgba(
+      var(--gm3-sys-color-on-surface-rgb),
+      0.08
+    );
+    --identity-common-ui-components-web-color-ripple-focus: rgba(
+      var(--gm3-sys-color-on-surface-rgb),
+      0.12
+    );
+    --identity-common-ui-components-web-color-skeleton-loader: var(
+      --gm3-sys-color-surface-variant
+    );
+    --identity-common-ui-components-web-color-level-1-background: var(
+      --gm3-sys-color-surface-container-low
+    );
+    --identity-common-ui-components-web-color-text-primary: var(
+      --gm3-sys-color-on-surface
+    );
+    --identity-common-ui-components-web-color-text-secondary: var(
+      --gm3-sys-color-on-surface-variant
+    );
+    --identity-common-ui-components-web-color-text-secondary-critical: var(
+      --gm3-sys-color-on-surface-variant
+    );
+    --identity-common-ui-components-web-color-text-body: var(
+      --gm3-sys-color-on-surface
+    );
+    --identity-common-ui-components-web-color-text-hint: var(
+      --gm3-sys-color-on-surface-variant
+    );
+    --identity-common-ui-components-web-color-on-background: var(
+      --gm3-sys-color-on-background
+    );
+    --identity-common-ui-components-web-color-on-background-critical: var(
+      --gm3-sys-color-on-background
+    );
+    --identity-common-ui-components-web-color-on-surface: var(
+      --gm3-sys-color-on-surface
+    );
+    --identity-common-ui-components-web-color-action-primary: var(
+      --gm3-sys-color-primary
+    );
+    --identity-common-ui-components-web-color-action-primary-stateful: var(
+      --gm3-sys-color-on-secondary-container
+    );
+    --identity-common-ui-components-web-color-action-primary-stateful-background: var(
+      --gm3-sys-color-secondary-container
+    );
+    --identity-common-ui-components-web-color-action-primary-on-error: var(
+      --gm3-sys-color-on-error
+    );
+    --identity-common-ui-components-web-color-action-primary-error: var(
+      --gm3-sys-color-error
+    );
+    --identity-common-ui-components-web-color-action-primary-error-stateful: var(
+      --gm3-sys-color-error
+    );
+    --identity-common-ui-components-web-color-action-primary-background-secondary: var(
+      --gm3-sys-color-primary
+    );
+    --identity-common-ui-components-web-color-background-secondary: var(
+      --gm3-sys-color-surface-container-low
+    );
+    --identity-common-ui-components-web-color-scrim: rgba(
+      var(--gm3-sys-color-scrim-rgb),
+      0.32
+    );
+    --identity-common-ui-components-web-color-leftnav-item-selected: var(
+      --gm3-sys-color-on-secondary-container,
+    );
+    --identity-common-ui-components-web-color-disclaimer-background: var(
+      --gm3-sys-color-surface-container-low
+    );
+    --identity-common-ui-components-web-color-icon-warning: rgb(242, 153, 0);
+    --identity-common-ui-components-web-color-icon-green: @green;
+    --identity-common-ui-components-web-color-icon-yellow: @yellow;
+    --identity-common-ui-components-web-color-icon-info: @blue;
+    --identity-common-ui-components-web-color-icon-blue: @blue;
+    --identity-common-ui-components-web-color-level-1-box-shadow:
+      0 1px 2px 0 rgba(var(--gm3-sys-color-shadow-rgb), 0.3),0 1px 3px 1px rgba(
+      var(--gm3-sys-color-shadow-rgb),
+      0.15
+    );
+    --identity-common-ui-components-web-color-level-2-background: #fff;
+    --identity-common-ui-components-web-color-level-2-background-translucent: rgba(
+      255,
+      255,
+      255,
+      0.96
+    );
+    --identity-common-ui-components-web-color-level-2-box-shadow:
+      0px 1px 2px 0px rgba(var(--gm3-sys-color-shadow-rgb), 0.3),0px 2px 6px 2px
+      rgba(
+      60,
+      64,
+      67,
+      0.15
+    );
+    --identity-common-ui-components-web-color-text-on-warning: #1f1f1f;
+    --identity-common-ui-components-web-color-text-warning: #1f1f1f;
+    --identity-common-ui-components-web-color-text-warning-stateful: #1f1f1f;
+    --identity-common-ui-components-web-color-action-primary-warning: #f09d00;
+    --identity-common-ui-components-web-color-banner-background-warning: #fff0d1;
+    --identity-common-ui-components-web-color-action-primary-disabled: rgb(
+      154,
+      160,
+      166
+    );
+
+    --boq-chrometransition-background: var(--gm3-sys-color-surface-container);
+
+    --gm-colortextbutton-ink-color: var(--gm3-sys-color-on-surface);
+    --gm-colortextbutton-ink-color--stateful: var(--gm3-sys-color-on-surface);
+    --gm-colortextbutton-state-color: var(--gm3-sys-color-on-surface);
+    --gm-fillbutton-ink-color: var(--gm3-sys-color-on-primary);
+    --gm-fillbutton-ink-color--stateful: var(--gm3-sys-color-primary);
+    --gm-fillbutton-container-color: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-outline-color: var(--gm3-sys-color-outline);
+    --gm-hairlinebutton-outline-color--stateful: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-state-color: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-ink-color: var(--gm3-sys-color-primary);
+    --gm-hairlinebutton-ink-color--stateful: var(--gm3-sys-color-primary);
+    --gm-radio-state-color: var(--gm3-sys-color-primary);
+    --gm-radio-ink-color: var(--gm3-sys-color-primary);
+    --gm-radio-ink-color--stateful: var(--gm3-sys-color-primary);
+    --gm-outlinedtextfield-caret-color: var(--gm3-sys-color-primary);
+    --gm-outlinedtextfield-ink-color: var(--gm3-sys-color-on-surface);
+    --gm-outlinedtextfield-outline-color: var(--gm3-sys-color-outline);
+    --gm-outlinedtextfield-outline-color--stateful: var(
+      --gm3-sys-color-primary
+    );
+    --gm-outlinedtextfield-label-color: var(--gm3-sys-color-on-surface-variant);
+    --gm-outlinedtextfield-label-color--stateful: var(--gm3-sys-color-primary);
+
+    --mdc-theme-surface: var(--gm3-sys-color-surface);
+    --mdc-theme-on-surface: var(--gm3-sys-color-on-surface);
+
+    --mdc-checkbox-unselected-icon-color: var(--gm3-sys-color-on-surface);
+    --mdc-checkbox-unselected-hover-icon-color: var(--gm3-sys-color-on-surface);
+    --mdc-checkbox-unselected-hover-state-layer-color: var(
+      --gm3-sys-color-on-surface
+    );
+    --mdc-checkbox-unselected-pressed-icon-color: var(
+      --gm3-sys-color-on-surface
+    );
+    --mdc-checkbox-unselected-pressed-state-layer-color: var(
+      --gm3-sys-color-on-surface
+    );
+
+    --mdc-checkbox-selected-icon-color: var(--gm3-sys-color-primary);
+    --mdc-checkbox-selected-hover-icon-color: var(--gm3-sys-color-primary);
+    --mdc-checkbox-selected-hover-state-layer-color: var(
+      --gm3-sys-color-primary
+    );
+    --mdc-checkbox-selected-pressed-icon-color: var(--gm3-sys-color-primary);
+    --mdc-checkbox-selected-pressed-state-layer-color: var(
+      --gm3-sys-color-primary
+    );
+    --mdc-checkbox-selected-checkmark-color: var(--gm3-sys-color-on-primary);
+
+    // Hyperlinks
+    a {
+      color: var(--gm3-sys-color-primary);
+    }
+
+    // Legacy tooltip text
+    .gb_Bc div:first-child,
+    .gb_Bc > *,
+    // My Ad Center Legacy tooltip text
+    .EY8ABd .VfPpkd-z59Tgd {
+      color: inherit;
+    }
+
+    // Legacy tooltips, seen in header and certain M2 components
+    .gb_Ac, .RM9ulf, .R8qYlc, .EY8ABd .VfPpkd-z59Tgd {
+      background-color: var(--gm3-sys-color-inverse-surface);
+      color: var(
+        --gm3-tooltip-plain-supporting-text-color,
+        var(--gm3-sys-color-inverse-on-surface, #f2f2f2)
+      );
+    }
+
+    // Legacy(M2) Snackbars
+    .VOBzC .VfPpkd-YAxtVc, .Mh0NNb {
+      background-color: var(--gm3-sys-color-inverse-surface);
+    }
+    .VOBzC .VfPpkd-gIZMF, .Mh0NNb {
+      color: var(--gm3-sys-color-inverse-on-surface);
+    }
+
+    // Google colours spinner
+    .VfPpkd-JGcpL-P1ekSe-OWXEXe-A9y3zc .VfPpkd-JGcpL-IdXvz-haAclf svg,
+    // Google One stat card progress ring accent
+    .mpdgo.TVtO8d {
+      stroke: var(--gm3-sys-color-primary) !important;
+    }
+
+    // Google One stat card progress ring background
+    .E8ImCd, .xapkEc, .FMK51b {
+      stroke: var(--gm3-sys-color-surface-container);
+    }
+
+    // Another Google colours spinner
+    .EmVfjc.qs41qe .ir3uv {
+      border-color: var(--gm3-sys-color-primary) !important;
+    }
+
+    // M2 ripple colours
+    .CmhoVd::before,
+    .CmhoVd::after,
+    .VfPpkd-ksKsZd-XxIAqe.VfPpkd-ksKsZd-mWPk3d::after,
+    .VfPpkd-LgbsSe.VfPpkd-ksKsZd-mWPk3d .VfPpkd-Jh9lGc::after,
+    .XFbPSe .yUa4ve.KKjvXb .VfPpkd-Jh9lGc::after,
+    .VfPpkd-EScbFb-JIbuQc .VfPpkd-FJ5hab::before,
+    .VfPpkd-EScbFb-JIbuQc .VfPpkd-FJ5hab::after,
+    .VfPpkd-Bz112c-LgbsSe.VfPpkd-ksKsZd-mWPk3d .VfPpkd-Bz112c-Jh9lGc::before,
+    .VfPpkd-Bz112c-LgbsSe.VfPpkd-ksKsZd-mWPk3d .VfPpkd-Bz112c-Jh9lGc::after,
+    .o7Osof.qs41qe > .MbhUzd,
+    .e3Duub .Vwe4Vb,
+    .oG5Srb .Vwe4Vb,
+    .zZhnYe .Vwe4Vb,
+    .HQ8yf .Vwe4Vb,
+    .PciPcd.i9xfbb > .MbhUzd,
+    .PciPcd.u3bW4e > .MbhUzd,
+    .sN5Hqb.i9xfbb > .MbhUzd,
+    .sN5Hqb.u3bW4e > .MbhUzd,
+    .ddop1d.i9xfbb > .MbhUzd,
+    .ddop1d.u3bW4e > .MbhUzd {
+      background-color: transparent;
+      background-image: radial-gradient(
+        closest-side,
+        var(
+          --gm3-ripple-pressed-color,
+          rgba(var(--gm3-sys-color-on-surface-rgb, currentColor), 0.24)
+        ) max(100% - 70px, 65%),
+        transparent 100%
+      );
+      // width: calc(160px + var(--mdc-ripple-fg-size, 100%));
+      // height: calc(160px + var(--mdc-ripple-fg-size, 100%));
+    }
+
+    // NEW CODE
+
+    // App bar wide screen
+    .gb_Fa,
+    .gb_id.gb_jd,
+    .gb_id,
+    .VOEIyf .jBmls,
+    .SrDkwc,
+    // App bar small screen
+    .oFq1lf,
+    // Secondary app bar
+    .vOPZCd,
+    // PFP picker base background
+    .Ditnlc.ftAIlf,
+    // PFP picker overlay background
+    .RZrdab,
+    // Google One sidebar
+    .utyhx {
+      background-color: var(
+        --identity-common-ui-components-web-color-page-background
+      ) !important;
+      color: var(--identity-common-ui-components-web-color-text-body);
+    }
+
+    // My Activity outlined card
+    .AaN0Dd,
+    // Google One tier selector
+    .H6gnDd,
+    // Google One tiercard border
+    .staJ7e {
+      background-color: transparent;
+    }
+
+    // PFP picker overlay selected
+    .GKldcb.LXTxRc-AznF2e-OWXEXe-auswjd,
+    // My Ad Center brand nameplate
+    .KL1PMd {
+      background-color: var(--gm3-sys-color-primary-container);
+    }
+
+    // My Ad Center sidebar background
+    .Lxqe2c,
+    // My Ad Center page background
+    .JtdFQe .UMrnmb-vyw7Sc-Psmogf,
+    .H1jTFe,
+    // My Ad Center page header image background
+    .HyEM4,
+    // My Ad Center customization page background
+    .Z7Hqcb,
+    // My Ad Center customization page tablist
+    .WrMlcd {
+      background-color: var(--gm3-sys-color-surface-container-low);
+    }
+
+    // Inactive Account Manager "Add phone number" button
+    .HQ8yf,
+    .HQ8yf a,
+    // Legacy(M2) underline text box focus text
+    .whsOnd:not([disabled]):focus ~ .AxOyFc,
+    // Legacy(M2) underline text area focus text
+    .edhGSc.u3bW4e > .RpC4Ne > .fqp6hd,
+    .edhGSc.u3bW4e.dm7YTc > .RpC4Ne > .fqp6hd,
+    // Legacy(M2) info button hover, focus
+    .hFggp.qs41qe,
+    .hFggp:hover,
+    .hFggp:focus,
+    // Legacy(M2) info button "manage third-party apps & services"
+    // hover, focus
+    .ZQdqQc.hFggp.qs41qe,
+    .ZQdqQc.hFggp:hover,
+    .ZQdqQc.hFggp:focus,
+    // My Activity "Not backing up data" cloud primary icon
+    .WC2uJc,
+    // My Activity "Manage history" button
+    .VBvtae,
+    // My Activity Checkmark icon
+    .UwMVcc,
+    // My Activity Another Checkmark icon
+    .r81Dw,
+    // My Activity Big Checkmark icon
+    .GbUMIf,
+    // My Activity active icon
+    .v9xDsf,
+    // Legacy(M2) My Ad Center active tab text color
+    .WbUJNb.VfPpkd-AznF2e-OWXEXe-auswjd .VfPpkd-jY41G-V67aGc,
+    // Google One perk dialog checkmark
+    .JdsT4d,
+    // Google One membership info icon
+    .T9KXbd .Pk6Fmf,
+    // Google One device backups trailing icon
+    .kEsltb,
+    // Google One device backups find my device icon
+    .lxOTzd,
+    // Google One storage clean up space oppurtunity number
+    .L6rvjd,
+    // Google One storage details legend item trailing icon
+    .SWKEdd.SWKEdd,
+    // Google One settings card icon
+    .JVuIO {
+      color: var(--gm3-sys-color-primary);
+      fill: currentcolor;
+      // stroke: currentcolor;
+    }
+
+    // PFP picker logo
+    .Povdxd,
+    .rqSEqc,
+    // Secondary app bar header
+    .cdaFgf,
+    // Secondary app bar icon
+    .dwUdG,
+    .fKz7Od,
+    // Legacy(M2) icon button
+    .fKz7Od,
+    .N9Ni5 .DPvwYc,
+    // Inactive Account Manager header text
+    .Lgy14b,
+    // Inactive Account Manager active step text
+    .UDhlJd.gxDgLe .Lgy14b,
+    .UDhlJd.ChRiff .Lgy14b,
+    .kB5vqd,
+    // Inactive Account Manager inital contact method text
+    .meUf6b,
+    // Account storage primary text
+    .Qtbxje,
+    // Legacy(M2) component text colour
+    input,
+    select,
+    textarea,
+    // Legacy(M2) underline text box text
+    .AxOyFc,
+    // Legacy(M2) underline text area text
+    .fqp6hd,
+    // "New sign-in on XXX" text
+    .no6oJe,
+    // Recent security activity header text
+    .XVLgLb,
+    // Recent security activity date text
+    .ccr4rb,
+    // Legacy(M2) searchbox "third-party apps & services" text
+    .WmnPA:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me) .VfPpkd-fmcmS-wGMbrd,
+    // Legacy(M2) searchbox "third-party apps & services" icon
+    .VfPpkd-fmcmS-yrriRe:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me)
+      .VfPpkd-fmcmS-TvZj5c-OWXEXe-M1Soyc,
+    // Legacy(M2) About me select dropdown menu item text
+    .s8kOBc .VfPpkd-StrnGf-rymPhb .VfPpkd-StrnGf-rymPhb-ibnC6b-OWXEXe-gk6SMd,
+    .s8kOBc .VfPpkd-StrnGf-rymPhb .VfPpkd-StrnGf-rymPhb-ibnC6b-OWXEXe-pXU01b,
+    .s8kOBc
+      .VfPpkd-StrnGf-rymPhb
+      .VfPpkd-StrnGf-rymPhb-ibnC6b-OWXEXe-gk6SMd
+      .VfPpkd-StrnGf-rymPhb-f7MjDc,
+    .s8kOBc
+      .VfPpkd-StrnGf-rymPhb
+      .VfPpkd-StrnGf-rymPhb-ibnC6b-OWXEXe-pXU01b
+      .VfPpkd-StrnGf-rymPhb-f7MjDc,
+    .s8kOBc .VfPpkd-StrnGf-rymPhb,
+    .VfPpkd-xl07Ob .VfPpkd-StrnGf-rymPhb,
+    // Legacy(M2) About me select dropdown text
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me) .VfPpkd-NLUYnc-V67aGc,
+    // Legacy(M2) About me select dropdown text state
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me):not(
+      .VfPpkd-O1htCb-OWXEXe-XpnDCe
+    ):hover
+      .VfPpkd-NLUYnc-V67aGc,
+    // About me Places list item text
+    .gWjfMb,
+    // Security Checkup header
+    .RAjCxe,
+    // Security Checkup card header text
+    .BkKHtf,
+    // Security Checkup card expanded header, main text
+    .U1lnOd,
+    .Iyifm,
+    // Security Checkup card chevron
+    .g81fxb.ROuVee .ysA0Af,
+    .lIiz3d,
+    // Security Checkup "Recent security activity" item main text
+    .XPfugc,
+    // My Activity heading text
+    .OThY8c,
+    // My Activity body text
+    .wJCOBf,
+    // My Activity header text
+    .eXSt3b,
+    // My Activity outlined card header text
+    .pPR9Bc,
+    // My Activity outlined card on/off text
+    .N3OL1c,
+    // My Activity outlined card label text
+    .skoMZe,
+    // My Activity outlined card checkbox/radio point text
+    .ZCuY4,
+    .ZCuY4 gm-checkbox[disabled] ~ .VfPpkd-V67aGc,
+    .ZCuY4 gm-radio[disabled] ~ .VfPpkd-V67aGc,
+    .ZCuY4 .VfPpkd-MPu53c-OWXEXe-OWB6Me ~ .VfPpkd-V67aGc,
+    .ZCuY4 .VfPpkd-GCYh9b-OWXEXe-OWB6Me ~ .VfPpkd-V67aGc,
+    // My Activity outlined card checkbox/radio point span text
+    .xekbpf,
+    .x8cu2d,
+    // My Actvity outlined card secondary text
+    .NDO7xd,
+    // My Activity inactive SVG icon
+    .v9xDsf,
+    .F8Oixe,
+    .ZRSaj,
+    .kd65Vd,
+    // Google One home page header
+    .ed2c9c,
+    // Google One home page heading
+    .GmmPjd,
+    // Google One home page membership info heading
+    .zjJGke,
+    .t62Ywe,
+    // Google One plan gated card title
+    .Kfmwb,
+    // Google One stat card title text
+    .V5pUU,
+    // Google One stat card backup device name
+    .TR3qOd,
+    // Google One stat card backup device icon
+    .ewveZe,
+    // Google One tier card primary text
+    .oJnzVb,
+    // Google One tier card point text
+    .staJ7e.spYkpc .hxvKGd,
+    // Google One perk description dialog primary text
+    .VVs2zc,
+    // Google One secondary points header text
+    .yoUw6d,
+    // Google One secondary point header
+    .pb5oVd,
+    // Google One device backups details heading
+    .g9RCUd,
+    // Google One device backups support heading
+    .Hs1wZd,
+    // Google One device backups support outlined card primary text
+    .JxdCGc,
+    // Google One benefits page heading
+    .kFd1gc,
+    // Google One benefits page heading helpful
+    .Eyo84e,
+    // Google One benefits details header
+    .DzkC9e,
+    // Google One benefits details T&C header
+    .CZdm0c,
+    // Google One storage progress bar header
+    .qN8oze,
+    // Google One storage legend item
+    .GHfyHe,
+    // Google One storage ways to use header
+    .DajtGc,
+    // Google One storage ways to use card primary text
+    .g1Ounb,
+    .lVwSM,
+    .zsySCd,
+    .W2qKte,
+    // Google One settings header
+    .Kcj6nc,
+    // Google One settings card header text
+    .AVEKFb,
+    // Google One settings card chevron
+    .n5kzDf {
+      color: inherit !important;
+      fill: currentcolor;
+    }
+
+    // About me PFP section secondary text
+    .kFNik,
+    // PFP picker image collection headers
+    .oLd4ob,
+    // Inactive Account Manager inactive step text
+    .UDhlJd.RDPZE .Lgy14b,
+    // Inactive Account Manager followup contact method text
+    .bKQbh,
+    // Legacy(M2) About me text box state
+    .cfWmIb:hover:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me) .VfPpkd-NLUYnc-V67aGc,
+    // Legacy(M2) dropdown select list item secondary text
+    .CO1lLb,
+    // Legacy(M2) dropdown select button icon+text
+    .jgvuAb,
+    // Legacy(M2) info button "manage third-party apps & services"
+    .ZQdqQc.hFggp,
+    // About me Places list item secondary text
+    .jRxG2c,
+    // Security Checkup subtext
+    .eqiJQ,
+    // Security Checkup card header subtext
+    .Ufndtd,
+    // My Activity secondary text
+    .gjxOad,
+    .eYGoGb,
+    // My Activity outlined card on/off secondary text
+    .D1Yuzf,
+    // My Ad Center inactive tab text
+    .VfPpkd-AznF2e .VfPpkd-jY41G-V67aGc,
+    // Google One home page header secondary text
+    .pnoY8d,
+    // Google One home page membership benefits secondary text
+    .rJmdr,
+    // Google One home page membership info description
+    .PDgw0c,
+    // Google One plan gated locked card icon
+    .aXMXge.J4HXZc,
+    // Google One plan gated locked card text
+    .tWjoFb.F5HB5b,
+    .tWjoFb.J4HXZc,
+    // Google One plan gated card description
+    .P7jf1c,
+    // Google One stat card inner text
+    .g5FrDb,
+    // Google One stat card lower text
+    .NNnMUe,
+    // Google One stat card backup device time
+    .gwe9R,
+    // Google One perk description dialog secondary text
+    .jmiCDb,
+    // Google One secondary points body text
+    .Fc9maf,
+    // Google One secondary point description
+    .FND7Ae,
+    // Google One device backups secondary text
+    .axRkMe,
+    // Google One trademark footer
+    .bIfCgf,
+    .AVSc3e,
+    // Google One device backups support outlined card secondary text
+    .fcy9qf,
+    // Google One storage clean up space secondary text
+    .e5V4cc,
+    // Google One benefits page subscribe reasons
+    .mEU0I,
+    // Google One benefits page description storage amount
+    .TdEDJf,
+    // Google One benefits details T&C description
+    .kO3yo,
+    // Google One benefits details cashback
+    .kNkidb,
+    // Google One benefits details subscribe agreement
+    .fIFAB,
+    // Google One benefits details description
+    .lu7mff,
+    .lu7mff *,
+    .mOY3jb,
+    // Google One header icon button
+    .Diclqf,
+    .ADJccb,
+    // Google One storage details header
+    .zWu4Ze,
+    // Google One storage details trailing text
+    .QHGzOe,
+    // Google One storage ways to use description
+    .gp4vTb,
+    // Google One storage ways to use card email
+    .SB0XXe,
+    // Google One storage ways to use card secondary text
+    .Qlkuob {
+      color: var(--gm3-sys-color-on-surface-variant) !important;
+    }
+
+    // PFP picker image collection count indicator
+    .z4h18b,
+    .P9KVBf .z4h18b,
+    .wfJxA .z4h18b,
+    // Legacy(M2) Legacy Account Manager dialogue background
+    .g3VIld,
+    // Legacy(M2) "lets secure your account" dialogue
+    .EenoKf,
+    // Legacy(M2) dropdown select list item background
+    .MocG8c,
+    // Legacy(M2) dropdown select background
+    .ncFHed,
+    // Legacy(M2) searchbox "third-party apps & services" background
+    .VfPpkd-fmcmS-yrriRe-OWXEXe-MFS4be:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me),
+    // Legacy rich tooltip "third-party apps & services"
+    .hXm5q,
+    .BRGwYb.hXm5q,
+    // Security Checkup card expanded
+    .g81fxb.ROuVee,
+    .g81fxb.sxlEM,
+    // Security Checkup card collapsed
+    .g81fxb,
+    // My Activity elevated card
+    .BKdRne,
+    // My Activity "turn off" dropdown
+    .P77izf .VfPpkd-StrnGf-rymPhb,
+    // My Ad Center filled card
+    .yuNNoc,
+    .hcWXyf,
+    .ZjPSKb,
+    .o9q9Fc,
+    // Legacy(m2) My Ad Center select menu background
+    .NZp2ef,
+    // Google Login language selector menu
+    .jR8x9d .dmaMHc,
+    // Google One tier card
+    .staJ7e.spYkpc.UmckSb .Y653g,
+    // Google One storage details progress bar background
+    .NDFFt,
+    // Google One storage ways to use card
+    .OnzeXc,
+    // Google One storage ways to use card contents
+    .yT1kKd,
+    // Google One storage ways to use card state
+    .OnzeXc[aria-expanded="true"],
+    .OnzeXc:hover,
+    .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="true"]:hover,
+    .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="false"]:hover,
+    .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="true"],
+    .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="true"]:focus,
+    .qSGZBb.Aqrnnd .OnzeXc[aria-expanded="false"]:focus {
+      background-color: var(--gm3-sys-color-surface-container);
+      color: var(--gm3-sys-color-on-surface);
+    }
+
+    // Legacy(M2) dropdown select hovered list item background
+    .ncFHed .MocG8c.KKjvXb,
+    // Security Checkup card sticky header
+    .g81fxb.bhe1tb .JaX6Fb,
+    .u7Uqwf.OUzXuf .g81fxb.bhe1tb .JaX6Fb {
+      background-color: var(--gm3-sys-color-surface-container-highest);
+      color: var(--gm3-sys-color-on-surface);
+    }
+
+    // My activity info toast
+    .CxAYC {
+      background-color: var(--gm3-sys-color-secondary-container);
+      color: var(--gm3-sys-color-on-secondary-container);
+    }
+
+    // Select menu item focused
+    .s8kOBc .VfPpkd-rymPhb-ibnC6b.VfPpkd-rymPhb-ibnC6b-OWXEXe-gk6SMd,
+    .r6B9Fd .VfPpkd-rymPhb-ibnC6b.VfPpkd-rymPhb-ibnC6b-OWXEXe-gk6SMd,
+    .s8kOBc
+      .VfPpkd-StrnGf-rymPhb
+      .VfPpkd-StrnGf-rymPhb-ibnC6b.VfPpkd-StrnGf-rymPhb-ibnC6b-OWXEXe-gk6SMd {
+      background-color: rgba(var(--gm3-sys-color-primary-rgb), 0.24);
+    }
+
+    // App bar logo and app chooser button
+    .gb_Fa svg,
+    .gb_Pc svg,
+    .gb_sd .gb_td,
+    .gb_2c .gb_td,
+    // Google One app bar text
+    .gb_9c.gb_ad,
+    // Help icon button
+    .Bdlund,
+    // Search icon button
+    .EXL6Le {
+      color: var(--identity-common-ui-components-web-color-text-body);
+    }
+
+    // Legacy(M2) "Lets secure your account" dialogue
+    .EenoKf,
+    // Legacy rich tooltip "third-party apps & services"
+    .hXm5q,
+    .BRGwYb.hXm5q {
+      box-shadow: var(
+        --identity-common-ui-components-web-color-level-2-box-shadow
+      );
+    }
+
+    // App bar | content vertical divider
+    .BLMscb,
+    // About me "Add more" divider
+    .NGFlFd:not(:first-child),
+    // Inactive Account Manager step divider
+    .UDhlJd,
+    .kB5vqd,
+    // Legacy(M2) About me text box state
+    .cfWmIb:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me):not(
+      .VfPpkd-fmcmS-yrriRe-OWXEXe-XpnDCe
+    ):hover
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Brv4Fb,
+    .cfWmIb:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me):not(
+      .VfPpkd-fmcmS-yrriRe-OWXEXe-XpnDCe
+    ):hover
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Ra9xwd,
+    .cfWmIb:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me):not(
+      .VfPpkd-fmcmS-yrriRe-OWXEXe-XpnDCe
+    ):hover
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-MpmGFe,
+    // Legacy (M2) About me dropdown select state
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me):not(.VfPpkd-O1htCb-OWXEXe-XpnDCe)
+      .VfPpkd-TkwUic:hover
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Brv4Fb,
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me):not(.VfPpkd-O1htCb-OWXEXe-XpnDCe)
+      .VfPpkd-TkwUic:hover
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Ra9xwd,
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me):not(.VfPpkd-O1htCb-OWXEXe-XpnDCe)
+      .VfPpkd-TkwUic:hover
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-MpmGFe,
+    // Legacy(M2) dropdown select divider
+    .ncFHed .VOUU9e,
+    // Legacy(M2) About me dropdown select divider
+    .VfPpkd-StrnGf-rymPhb-clz4Ic,
+    // Legacy(M2) "Lets secure your account" dialogue divider
+    .EKy1vc .YZIJRb,
+    // Security Checkup collapsed card border
+    .g81fxb,
+    // Security Checkup expanded card content divider
+    .g81fxb.ROuVee .HLEawd,
+    .g81fxb.sxlEM .HLEawd,
+    // Security Checkup "Recent security activity" item divider
+    .MEQ3Pd:not(:first-child),
+    // Security Checkup "Your third-party connections" item icon border
+    .HzweU,
+    // My Activity outlined card border
+    .jZjheb,
+    // Google One device backups list divider
+    .kyRO9c,
+    // Google One app bar
+    .pGxpHc > header,
+    // Generic divider
+    hr,
+    // Google One backup support card
+    .Akhvdf,
+    // Google One ways to use storage card
+    .wMO4Hd.wMO4Hd.wMO4Hd,
+    .slhDY.Aqrnnd.slhDY,
+    .qSGZBb.Aqrnnd .D6KxF,
+    // Google One settings card
+    .qSGZBb {
+      border-color: var(--gm3-sys-color-outline-variant);
+    }
+
+    // My Ad Center customization page tablist divider
+    .uY3BEb,
+    // About me Places list divider
+    .vORqbf {
+      background-color: var(--gm3-sys-color-outline-variant);
+    }
+
+    // Inactive Account Manager main card
+    .hyMrOd {
+      background-color: var(--gm3-sys-color-surface-container);
+      border-color: transparent;
+    }
+
+    // Legacy(M2) dropdown select button icon
+    .e2CuFe {
+      border-color: currentcolor transparent;
+    }
+
+    // Legacy(M2) underline text box underline
+    // .i9lrp,
+    // Legacy(M2) underline text area underline
+    .z0oSpf {
+      background-color: var(--gm3-sys-color-on-surface);
+    }
+
+    // Legacy(M2) searchbox "third-party apps & services" underline
+    .VfPpkd-fmcmS-yrriRe-OWXEXe-MFS4be:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me)
+      .VfPpkd-RWgCYc-ksKsZd::before,
+    .WmnPA:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me)
+      .VfPpkd-RWgCYc-ksKsZd::before,
+    // Legacy (M2) About me dropdown select
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me) .VfPpkd-NSFCdd-Brv4Fb,
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me) .VfPpkd-NSFCdd-Ra9xwd,
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me) .VfPpkd-NSFCdd-MpmGFe {
+      border-color: var(--gm3-sys-color-outline);
+    }
+
+    // Legacy(M2) underline text box error underline
+    .rFrNMe.k0tWj .i9lrp, .rFrNMe.k0tWj .OabDMe {
+      background-color: var(--gm3-sys-color-error);
+    }
+
+    // Legacy(M2) underline text box error text
+    .rFrNMe.k0tWj .whsOnd:not([disabled]):focus ~ .AxOyFc,
+    .dEOOab {
+      color: var(--gm3-sys-color-error);
+    }
+
+    // Inactive account manager "Start" button, links
+    .e3Duub,
+    .e3Duub a,
+    .e3Duub a:hover,
+    .e3Duub a:link,
+    .e3Duub a:visited,
+    // Recent security activity "New" badge
+    .TCnBcf {
+      background-color: var(--gm3-sys-color-primary);
+      color: var(--gm3-sys-color-on-primary);
+    }
+
+    // Chrome transition loading bar
+    .TRHLAc,
+    // Legacy(M2) underline text box focus underline
+    // .OabDMe,
+    // Legacy(M2) underline text area focus underline
+    .Bfurwb,
+    // Account storage progress bar filled segment
+    .RugJ4 > .L0R6Ub {
+      background: var(--gm3-sys-color-primary) !important;
+    }
+
+    // Chrome transition with pfp loadbar
+    [aria-label="Loading"] {
+      background-color: var(--gm3-sys-color-primary-container) !important;
+    }
+    [aria-label="Loading"] > div > span,
+    // Stepper progress bar under Privacy Checkup
+    .rxb0oe .VfPpkd-qNpTzb-P4pF8c-SmKAyb,
+    // Legacy(M2) radio
+    .ddop1d .nQOrEb,
+    .ddop1d .Id5V1,
+    .sN5Hqb.N2RpBe,
+    .PciPcd.N2RpBe .espmsb,
+    .ddop1d.N2RpBe .nQOrEb,
+    .ddop1d.N2RpBe .Id5V1,
+    .kDzhGf
+      .VfPpkd-gBXA9-bMcfAe:enabled:checked
+      + .VfPpkd-RsCWK
+      .VfPpkd-wVo5xe-LkdAo,
+    .kDzhGf .VfPpkd-gBXA9-bMcfAe:enabled + .VfPpkd-RsCWK .VfPpkd-Z5TpLc-LkdAo,
+    // Legacy(M2) searchbox "third-party apps & services" focus underline
+    .WmnPA:not(.VfPpkd-fmcmS-yrriRe-OWXEXe-OWB6Me) .VfPpkd-RWgCYc-ksKsZd::after,
+    // Legacy(M2) My Ad Center active tab underline
+    .rvBHac .VfPpkd-AznF2e-wEcVzc-OWXEXe-NowJzb,
+    // Legacy(M2) My Ad Center active select menu button border
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Brv4Fb,
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Ra9xwd,
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-MpmGFe {
+      border-color: var(--gm3-sys-color-primary) !important;
+    }
+
+    // Inactive Account Manager finished step checkmark
+    .yUKIAc,
+    // Security Checkup checkmark
+    .KWK6Nd,
+    // Google One "available with xxx" text
+    .OyOwFb.SGdsQe,
+    // Google One "reconmended" text
+    .r3qwYd {
+      color: var(--identity-common-ui-components-web-color-icon-green);
+    }
+
+    // Security Checkup info symbol
+    .r9w7Ae {
+      color: var(--identity-common-ui-components-web-color-icon-info);
+    }
+
+    // My Activity image framing vignette
+    .vVmo9e {
+      background-image: linear-gradient(
+        var(--gm3-sys-color-surface) 75%,
+        var(--gm3-sys-color-surface-container-low)
+      );
+    }
+
+    // My Ad Center text on dark image
+    .YcxLyd {
+      color: if(
+        @flavor = latte,
+        var(--gm3-sys-color-on-primary-fixed-variant),
+        var(--gm3-sys-color-primary-fixed-variant)
+      );
+    }
+
+    // My Activity greyscale images
+    .zMOhL {
+      filter: sepia(1) contrast(1.10) brightness(0.75) hue-rotate(215deg);
+    }
+
+    // Chrome transition PFP picker
+    .swsHsf {
+      background-color: var(--boq-chrometransition-background);
+    }
+    .mIM26c .Dw0WJe {
+      opacity: var(--boq-chrometransition-active-background-opacity);
+    }
+
+    // Selected list item select menu
+    .jR8x9d .dmaMHc .VfPpkd-rymPhb-ibnC6b.VfPpkd-rymPhb-ibnC6b-OWXEXe-gk6SMd {
+      background-color: rgba(var(--gm3-sys-color-primary-rgb), 0.24);
+    }
+
+    // Select menu container focused
+    .jR8x9d
+      .UAQDDf:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Brv4Fb,
+    .jR8x9d
+      .UAQDDf:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-Ra9xwd,
+    .jR8x9d
+      .UAQDDf:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-NSFCdd-i5vt6e
+      .VfPpkd-NSFCdd-MpmGFe {
+      border-color: var(--gm3-sys-color-primary);
+    }
+
+    // Select menu focused icon
+    .jR8x9d
+      .UAQDDf:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-t08AT-Bz112c,
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me).VfPpkd-O1htCb-OWXEXe-XpnDCe
+      .VfPpkd-t08AT-Bz112c {
+      fill: var(--gm3-sys-color-primary);
+    }
+
+    // Google logo
+    // Main app bar
+    .gb_Ec .gb_6d::before,
+    // Legacy
+    #logo > div:first-of-type::before,
+    // PFP picker
+    .thMxxd::before {
+      content: if(
+        @flavor = latte,
+        url("https://www.gstatic.com/images/branding/googlelogo/svg/googlelogo_dark_clr_74x24px.svg"),
+        url("https://www.gstatic.com/images/branding/googlelogo/svg/googlelogo_light_clr_74x24px.svg")
+      );
+      display: inline-block;
+      height: 24px;
+      width: 74px;
+    }
+    #logo svg {
+      display: none;
+    }
+
+    // Google One tier cards
+    .UpZXU {
+      --gm-colortextbutton-ink-color: var(--gm3-sys-color-on-surface);
+      --gm-colortextbutton-ink-color--stateful: var(--gm3-sys-color-on-surface);
+      --gm-colortextbutton-state-color: var(--gm3-sys-color-on-surface);
+    }
+
+    // Google One device backups list items
+    .OQcRhe {
+      box-shadow: var(
+        --identity-common-ui-components-web-color-level-1-box-shadow
+      );
+      --gm3-list-list-item-label-text-color: var(--gm3-sys-color-on-surface);
+      --gm3-list-list-item-supporting-text-color: var(
+        --gm3-sys-color-on-surface-variant
+      );
+      --gm3-list-list-item-trailing-supporting-text-color: var(
+        --gm3-sys-color-on-surface-variant
+      );
+    }
+
+    // Google footer links
+    .PYvTEc {
+      --gm3-button-text-focus-label-text-color: var(--gm3-sys-color-on-surface);
+      --gm3-button-text-hover-label-text-color: var(--gm3-sys-color-on-surface);
+      --gm3-button-text-hover-state-layer-color: var(
+        --gm3-sys-color-on-surface
+      );
+      --gm3-button-text-label-text-color: var(--gm3-sys-color-on-surface);
+      --gm3-button-text-pressed-label-text-color: var(
+        --gm3-sys-color-on-surface
+      );
+      --gm3-button-text-with-icon-focus-icon-color: var(
+        --gm3-sys-color-on-surface
+      );
+      --gm3-button-text-with-icon-hover-icon-color: var(
+        --gm3-sys-color-on-surface
+      );
+      --gm3-button-text-with-icon-icon-color: var(--gm3-sys-color-on-surface);
+      --gm3-button-text-with-icon-pressed-icon-color: var(
+        --gm3-sys-color-on-surface
+      );
+    }
+
+    // Google One dismiss icon button
+    .PKlnze {
+      color: var(
+        --gm3-icon-button-standard-unselected-icon-color,
+        var(--gm3-sys-color-on-surface-variant, #444746)
+      );
+    }
+
+    // Google One multicolour tier card
+    .staJ7e.spYkpc.G1TrEc {
+      background:
+        linear-gradient(90deg, @green 4%, @blue 0) top/100% 34% no-repeat,
+        linear-gradient(90deg, @yellow 50%, @blue 0) top/100% 82% no-repeat,
+        linear-gradient(90deg, @yellow 10%, @red 0) top/100% 100%;
+    }
+
+    // >M1/M2 FULL LEGACY PAGES<
+    body,
+    // Main page container
+    .VmOpGe {
+      background: var(--gm3-sys-color-surface-container);
+      color: var(--gm3-sys-color-on-surface);
+    }
+
+    // Floating card
+    .RAYh1e {
+      background: var(--gm3-sys-color-surface-container-lowest);
+      border-color: transparent;
+    }
+
+    // Main heading
+    .jXeDnc h1 {
+      color: var(--gm3-sys-color-on-surface);
+    }
+
+    // Select menu button text
+    .ReCbLb:not(.VfPpkd-O1htCb-OWXEXe-OWB6Me) .VfPpkd-uusGie-fmcmS,
+    // Select menu item text
+    .s8kOBc .VfPpkd-rymPhb-Gtdoyb,
+    .s8kOBc .VfPpkd-rymPhb-fpDzbe-fmcmS,
+    // Footer hyperlinks
+    .Bgzgmd .WgJpmf {
+      color: inherit;
+    }
+
+    // Filled button polyfill
+    .FliLIb .qIypjc:not(:disabled) {
+      color: var(--gm-fillbutton-ink-color);
+    }
+
+    // Select menu focused
+    .u7land .VfPpkd-TkwUic:focus {
+      background-color: var(--gm3-sys-color-surface-container-low);
+    }
+
+    // Select menu item focused
+    .s8kOBc .VfPpkd-rymPhb-ibnC6b.VfPpkd-rymPhb-ibnC6b-OWXEXe-gk6SMd {
+      background-color: rgba(var(--gm3-sys-color-primary-rgb), 0.24);
+    }
+
+    // Floating card primary vignette
+    .p17Urb {
+      background: linear-gradient(
+        to bottom,
+        rgba(var(--gm3-sys-color-surface-container-rgb), 0) 0%,
+        rgba(var(--gm3-sys-color-surface-container-rgb), 0) 62.22%,
+        rgba(var(--gm3-sys-color-surface-container-rgb), 1) 40.22%,
+        rgba(var(--gm3-sys-color-surface-container-rgb), 0) 100%
+      );
+    }
+    // Floating card secondary vignette
+    .p17Urb::before {
+      background: linear-gradient(
+        to bottom,
+        rgba(var(--gm3-sys-color-surface-container-rgb), 0) 0%,
+        rgba(var(--gm3-sys-color-surface-container-rgb), 0.9) 100%
+      );
+    }
+
+    // Floating card "shadow"
+    .p17Urb::after {
+      background: linear-gradient(
+        to bottom,
+        rgba(var(--gm3-sys-color-surface-container-low-rgb), 0) 0%,
+        rgba(var(--gm3-sys-color-surface-container-low-rgb), 0.9) 100%
+      );
+    }
+  }
+}
+
+@-moz-document domain("ogs.google.com") {
+  body {
+    #catppuccin(@darkFlavor);
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+    @inverse-accent: if(
+      @flavor = latte,
+      @catppuccin[@mocha][@@accentColor],
+      @catppuccin[@latte][@@accentColor]
+    );
+
+    // color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    @gm3-sys-color-error: @red;
+    @gm3-sys-color-error-rgb: #rgbify(@gm3-sys-color-error)[];
+    @gm3-sys-color-error-container: desaturate(darken(@red, 50%), 50%);
+    @gm3-sys-color-error-container-rgb: #rgbify(
+      @gm3-sys-color-error-container,
+    )[];
+
+    @gm3-sys-color-on-error: darken(desaturate(@red, 20%), 50%);
+    @gm3-sys-color-on-error-rgb: #rgbify(@gm3-sys-color-on-error)[];
+    @gm3-sys-color-on-error-container: desaturate(darken(@red, -10%), 50%);
+    @gm3-sys-color-on-error-container-rgb: #rgbify(
+      @gm3-sys-color-on-error-container,
+    )[];
+
+    @gm3-sys-color-primary: @accent;
+    @gm3-sys-color-primary-rgb: #rgbify(@gm3-sys-color-primary)[];
+    @gm3-sys-color-primary-fixed: lighten(@accent, 5%);
+    @gm3-sys-color-primary-fixed-rgb: #rgbify(@gm3-sys-color-primary-fixed)[];
+    @gm3-sys-color-primary-fixed-dim: darken(@accent, 5%);
+    @gm3-sys-color-primary-fixed-dim-rgb: #rgbify(
+      @gm3-sys-color-primary-fixed-dim,
+    )[];
+
+    @gm3-sys-color-on-primary: saturate(
+      mix(@gm3-sys-color-primary, @base, 20%),
+      25%
+    );
+    @gm3-sys-color-on-primary-rgb: #rgbify(@gm3-sys-color-on-primary)[];
+    @gm3-sys-color-on-primary-fixed: darken(@gm3-sys-color-on-primary, 5%);
+    @gm3-sys-color-on-primary-fixed-rgb: #rgbify(
+      @gm3-sys-color-on-primary-fixed,
+    )[];
+    @gm3-sys-color-on-primary-fixed-variant: lighten(
+      @gm3-sys-color-on-primary,
+      5%
+    );
+    @gm3-sys-color-on-primary-fixed-variant-rgb: #rgbify(
+      @gm3-sys-color-on-primary-fixed-variant,
+    )[];
+
+    @gm3-sys-color-primary-container: saturate(
+      mix(@gm3-sys-color-primary, @mantle, 40%),
+      20%
+    );
+    @gm3-sys-color-primary-container-rgb: #rgbify(
+      @gm3-sys-color-primary-container,
+    )[];
+    @gm3-sys-color-on-primary-container: saturate(
+      mix(@gm3-sys-color-primary, @text, 10%),
+      25%
+    );
+    @gm3-sys-color-on-primary-container-rgb: #rgbify(
+      @gm3-sys-color-on-primary-container,
+    )[];
+
+    @gm3-sys-color-secondary: desaturate(@accent, 40%);
+    @gm3-sys-color-secondary-rgb: #rgbify(@gm3-sys-color-secondary)[];
+    @gm3-sys-color-secondary-fixed: lighten(@gm3-sys-color-secondary, 5%);
+    @gm3-sys-color-secondary-fixed-rgb: #rgbify(
+      @gm3-sys-color-secondary-fixed,
+    )[];
+    @gm3-sys-color-secondary-fixed-dim: darken(@gm3-sys-color-secondary, 5%);
+    @gm3-sys-color-secondary-fixed-dim-rgb: #rgbify(
+      @gm3-sys-color-secondary-fixed-dim,
+    )[];
+
+    @gm3-sys-color-on-secondary: saturate(
+      mix(@gm3-sys-color-secondary, @base, 20%),
+      25%
+    );
+    @gm3-sys-color-on-secondary-rgb: #rgbify(@gm3-sys-color-on-secondary)[];
+    @gm3-sys-color-on-secondary-fixed: darken(@gm3-sys-color-on-secondary, 5%);
+    @gm3-sys-color-on-secondary-fixed-rgb: #rgbify(
+      @gm3-sys-color-on-secondary-fixed,
+    )[];
+    @gm3-sys-color-on-secondary-fixed-variant: lighten(
+      @gm3-sys-color-on-primary,
+      5%
+    );
+    @gm3-sys-color-on-secondary-fixed-variant-rgb: #rgbify(
+      @gm3-sys-color-on-secondary-fixed-variant,
+    )[];
+
+    @gm3-sys-color-secondary-container: saturate(
+      mix(@gm3-sys-color-secondary, @mantle, 20%),
+      10%
+    );
+    @gm3-sys-color-secondary-container-rgb: #rgbify(
+      @gm3-sys-color-secondary-container,
+    )[];
+    @gm3-sys-color-on-secondary-container: saturate(
+      mix(@gm3-sys-color-secondary, @text, 10%),
+      25%
+    );
+    @gm3-sys-color-on-secondary-container-rgb: #rgbify(
+      @gm3-sys-color-on-secondary-container,
+    )[];
+
+    @gm3-sys-color-tertiary: @accent;
+    @gm3-sys-color-tertiary-rgb: #rgbify(@gm3-sys-color-tertiary)[];
+    @gm3-sys-color-tertiary-fixed: lighten(@gm3-sys-color-tertiary, 5%);
+    @gm3-sys-color-tertiary-fixed-rgb: #rgbify(@gm3-sys-color-tertiary-fixed)[];
+    @gm3-sys-color-tertiary-fixed-dim: darken(@gm3-sys-color-tertiary, 5%);
+    @gm3-sys-color-tertiary-fixed-dim-rgb: #rgbify(
+      @gm3-sys-color-tertiary-fixed-dim,
+    )[];
+
+    @gm3-sys-color-on-tertiary: darken(
+      desaturate(@gm3-sys-color-tertiary, 25%),
+      50%
+    );
+    @gm3-sys-color-on-tertiary-rgb: #rgbify(@gm3-sys-color-on-tertiary)[];
+    @gm3-sys-color-on-tertiary-fixed: darken(@gm3-sys-color-on-tertiary, 5%);
+    @gm3-sys-color-on-tertiary-fixed-rgb: #rgbify(
+      @gm3-sys-color-on-tertiary-fixed,
+    )[];
+    @gm3-sys-color-on-tertiary-fixed-variant: lighten(
+      @gm3-sys-color-on-tertiary,
+      5%
+    );
+    @gm3-sys-color-on-tertiary-fixed-variant-rgb: #rgbify(
+      @gm3-sys-color-on-tertiary-fixed-variant,
+    )[];
+
+    @gm3-sys-color-tertiary-container: saturate(
+      mix(@gm3-sys-color-tertiary, @mantle, 20%),
+      0%
+    );
+    @gm3-sys-color-tertiary-container-rgb: #rgbify(
+      @gm3-sys-color-tertiary-container,
+    )[];
+    @gm3-sys-color-on-tertiary-container: lighten(
+      saturate(@gm3-sys-color-tertiary-container, 50%),
+      65%
+    );
+    @gm3-sys-color-on-tertiary-container-rgb: #rgbify(
+      @gm3-sys-color-on-tertiary-container,
+    )[];
+
+    @gm3-sys-color-background: @base;
+    @gm3-sys-color-background-rgb: #rgbify(@gm3-sys-color-background)[];
+    @gm3-sys-color-on-background: @text;
+    @gm3-sys-color-on-background-rgb: #rgbify(@gm3-sys-color-on-background)[];
+
+    @gm3-sys-color-surface: @base;
+    @gm3-sys-color-surface-rgb: #rgbify(@gm3-sys-color-surface)[];
+    @gm3-sys-color-surface-bright: @surface0;
+    @gm3-sys-color-surface-bright-rgb: #rgbify(@gm3-sys-color-surface-bright)[];
+    @gm3-sys-color-surface-dim: @crust;
+    @gm3-sys-color-surface-dim-rgb: #rgbify(@gm3-sys-color-surface-dim)[];
+    @gm3-sys-color-surface-variant: mix(@mantle, @accent, 87.5%);
+    @gm3-sys-color-surface-variant-rgb: #rgbify(
+      @gm3-sys-color-surface-variant,
+    )[];
+    @gm3-sys-color-surface-tint: @accent;
+    @gm3-sys-color-surface-tint-rgb: #rgbify(@gm3-sys-color-surface-tint)[];
+
+    @gm3-sys-color-on-surface: @text;
+    @gm3-sys-color-on-surface-rgb: #rgbify(@gm3-sys-color-on-surface)[];
+    @gm3-sys-color-on-surface-variant: @subtext0;
+    @gm3-sys-color-on-surface-variant-rgb: #rgbify(
+      @gm3-sys-color-on-surface-variant,
+    )[];
+
+    @gm3-sys-color-inverse-surface: @text;
+    @gm3-sys-color-inverse-surface-rgb: #rgbify(
+      @gm3-sys-color-inverse-surface,
+    )[];
+    @gm3-sys-color-inverse-on-surface: @mantle;
+    @gm3-sys-color-inverse-on-surface-rgb: #rgbify(
+      @gm3-sys-color-inverse-on-surface,
+    )[];
+    @gm3-sys-color-inverse-primary: @inverse-accent; // TODO: Colour role clarification
+    @gm3-sys-color-inverse-primary-rgb: #rgbify(
+      @gm3-sys-color-inverse-primary,
+    )[];
+
+    @gm3-sys-color-surface-container-highest: @surface1;
+    @gm3-sys-color-surface-container-highest-rgb: #rgbify(
+      @gm3-sys-color-surface-container-highest,
+    )[];
+    @gm3-sys-color-surface-container-high: @surface0;
+    @gm3-sys-color-surface-container-high-rgb: #rgbify(
+      @gm3-sys-color-surface-container-high,
+    )[];
+    @gm3-sys-color-surface-container: @surface0;
+    @gm3-sys-color-surface-container-rgb: #rgbify(
+      @gm3-sys-color-surface-container,
+    )[];
+    @gm3-sys-color-surface-container-low: @mantle;
+    @gm3-sys-color-surface-container-low-rgb: #rgbify(
+      @gm3-sys-color-surface-container-low,
+    )[];
+    @gm3-sys-color-surface-container-lowest: @crust;
+    @gm3-sys-color-surface-container-lowest-rgb: #rgbify(
+      @gm3-sys-color-surface-container-lowest,
+    )[];
+
+    @gm3-sys-color-outline: @overlay2;
+    @gm3-sys-color-outline-rgb: #rgbify(@gm3-sys-color-outline)[];
+    @gm3-sys-color-outline-variant: @overlay0;
+    @gm3-sys-color-outline-variant-rgb: #rgbify(
+      @gm3-sys-color-outline-variant,
+    )[];
+
+    @gm3-sys-color-scrim: #000;
+    @gm3-sys-color-scrim-rgb: #rgbify(@gm3-sys-color-scrim)[];
+    @gm3-sys-color-shadow: #000;
+    @gm3-sys-color-shadow-rgb: #rgbify(@gm3-sys-color-shadow)[];
+
+    --gm3-sys-color-background: @gm3-sys-color-background;
+    --gm3-sys-color-background-rgb: @gm3-sys-color-background-rgb;
+    --gm3-sys-color-error: @gm3-sys-color-error;
+    --gm3-sys-color-error-rgb: @gm3-sys-color-error-rgb;
+    --gm3-sys-color-error-container: @gm3-sys-color-error-container;
+    --gm3-sys-color-error-container-rgb: @gm3-sys-color-error-container-rgb;
+    --gm3-sys-color-inverse-on-surface: @gm3-sys-color-inverse-on-surface;
+    --gm3-sys-color-inverse-on-surface-rgb: @gm3-sys-color-inverse-on-surface-rgb;
+    --gm3-sys-color-inverse-primary: @gm3-sys-color-inverse-primary;
+    --gm3-sys-color-inverse-primary-rgb: @gm3-sys-color-inverse-primary-rgb;
+    --gm3-sys-color-inverse-surface: @gm3-sys-color-inverse-surface;
+    --gm3-sys-color-inverse-surface-rgb: @gm3-sys-color-inverse-surface-rgb;
+    --gm3-sys-color-on-background: @gm3-sys-color-on-background;
+    --gm3-sys-color-on-background-rgb: @gm3-sys-color-on-background-rgb;
+    --gm3-sys-color-on-error: @gm3-sys-color-on-error;
+    --gm3-sys-color-on-error-rgb: @gm3-sys-color-on-error-rgb;
+    --gm3-sys-color-on-error-container: @gm3-sys-color-on-error-container;
+    --gm3-sys-color-on-error-container-rgb: @gm3-sys-color-on-error-container-rgb;
+    --gm3-sys-color-on-primary: @gm3-sys-color-on-primary;
+    --gm3-sys-color-on-primary-rgb: @gm3-sys-color-on-primary-rgb;
+    --gm3-sys-color-on-primary-container: @gm3-sys-color-on-primary-container;
+    --gm3-sys-color-on-primary-container-rgb: @gm3-sys-color-on-primary-container-rgb;
+    --gm3-sys-color-on-primary-fixed: @gm3-sys-color-on-primary-fixed;
+    --gm3-sys-color-on-primary-fixed-rgb: @gm3-sys-color-on-primary-fixed-rgb;
+    --gm3-sys-color-on-primary-fixed-variant: @gm3-sys-color-on-primary-fixed-variant;
+    --gm3-sys-color-on-primary-fixed-variant-rgb: @gm3-sys-color-on-primary-fixed-variant-rgb;
+    --gm3-sys-color-on-secondary: @gm3-sys-color-on-secondary;
+    --gm3-sys-color-on-secondary-rgb: @gm3-sys-color-on-secondary-rgb;
+    --gm3-sys-color-on-secondary-container: @gm3-sys-color-on-secondary-container;
+    --gm3-sys-color-on-secondary-container-rgb: @gm3-sys-color-on-secondary-container-rgb;
+    --gm3-sys-color-on-secondary-fixed: @gm3-sys-color-on-secondary-fixed;
+    --gm3-sys-color-on-secondary-fixed-rgb: @gm3-sys-color-on-secondary-fixed-rgb;
+    --gm3-sys-color-on-secondary-fixed-variant: @gm3-sys-color-on-secondary-fixed-variant;
+    --gm3-sys-color-on-secondary-fixed-variant-rgb: @gm3-sys-color-on-secondary-fixed-variant-rgb;
+    --gm3-sys-color-on-surface: @gm3-sys-color-on-surface;
+    --gm3-sys-color-on-surface-rgb: @gm3-sys-color-on-surface-rgb;
+    --gm3-sys-color-on-surface-variant: @gm3-sys-color-on-surface-variant;
+    --gm3-sys-color-on-surface-variant-rgb: @gm3-sys-color-on-surface-variant-rgb;
+    --gm3-sys-color-on-tertiary: @gm3-sys-color-on-tertiary;
+    --gm3-sys-color-on-tertiary-rgb: @gm3-sys-color-on-tertiary-rgb;
+    --gm3-sys-color-on-tertiary-container: @gm3-sys-color-on-tertiary-container;
+    --gm3-sys-color-on-tertiary-container-rgb: @gm3-sys-color-on-tertiary-container-rgb;
+    --gm3-sys-color-on-tertiary-fixed: @gm3-sys-color-on-tertiary-fixed;
+    --gm3-sys-color-on-tertiary-fixed-rgb: @gm3-sys-color-on-tertiary-fixed-rgb;
+    --gm3-sys-color-on-tertiary-fixed-variant: @gm3-sys-color-on-tertiary-fixed-variant;
+    --gm3-sys-color-on-tertiary-fixed-variant-rgb: @gm3-sys-color-on-tertiary-fixed-variant-rgb;
+    --gm3-sys-color-outline: @gm3-sys-color-outline;
+    --gm3-sys-color-outline-rgb: @gm3-sys-color-outline-rgb;
+    --gm3-sys-color-outline-variant: @gm3-sys-color-outline-variant;
+    --gm3-sys-color-outline-variant-rgb: @gm3-sys-color-outline-variant-rgb;
+    --gm3-sys-color-primary: @gm3-sys-color-primary;
+    --gm3-sys-color-primary-rgb: @gm3-sys-color-primary-rgb;
+    --gm3-sys-color-primary-container: @gm3-sys-color-primary-container;
+    --gm3-sys-color-primary-container-rgb: @gm3-sys-color-primary-container-rgb;
+    --gm3-sys-color-primary-fixed: @gm3-sys-color-primary-fixed;
+    --gm3-sys-color-primary-fixed-rgb: @gm3-sys-color-primary-fixed-rgb;
+    --gm3-sys-color-primary-fixed-dim: @gm3-sys-color-primary-fixed-dim;
+    --gm3-sys-color-primary-fixed-dim-rgb: @gm3-sys-color-primary-fixed-dim-rgb;
+    --gm3-sys-color-scrim: @gm3-sys-color-scrim;
+    --gm3-sys-color-scrim-rgb: @gm3-sys-color-scrim-rgb;
+    --gm3-sys-color-secondary: @gm3-sys-color-secondary;
+    --gm3-sys-color-secondary-rgb: @gm3-sys-color-secondary-rgb;
+    --gm3-sys-color-secondary-container: @gm3-sys-color-secondary-container;
+    --gm3-sys-color-secondary-container-rgb: @gm3-sys-color-secondary-container-rgb;
+    --gm3-sys-color-secondary-fixed: @gm3-sys-color-secondary-fixed;
+    --gm3-sys-color-secondary-fixed-rgb: @gm3-sys-color-secondary-fixed-rgb;
+    --gm3-sys-color-secondary-fixed-dim: @gm3-sys-color-secondary-fixed-dim;
+    --gm3-sys-color-secondary-fixed-dim-rgb: @gm3-sys-color-secondary-fixed-dim-rgb;
+    --gm3-sys-color-shadow: @gm3-sys-color-shadow;
+    --gm3-sys-color-shadow-rgb: @gm3-sys-color-shadow-rgb;
+    --gm3-sys-color-surface: @gm3-sys-color-surface;
+    --gm3-sys-color-surface-rgb: @gm3-sys-color-surface-rgb;
+    --gm3-sys-color-surface-bright: @gm3-sys-color-surface-bright;
+    --gm3-sys-color-surface-bright-rgb: @gm3-sys-color-surface-bright-rgb;
+    --gm3-sys-color-surface-container: @gm3-sys-color-surface-container;
+    --gm3-sys-color-surface-container-rgb: @gm3-sys-color-surface-container-rgb;
+    --gm3-sys-color-surface-container-high: @gm3-sys-color-surface-container-high;
+    --gm3-sys-color-surface-container-high-rgb: @gm3-sys-color-surface-container-high-rgb;
+    --gm3-sys-color-surface-container-highest: @gm3-sys-color-surface-container-highest;
+    --gm3-sys-color-surface-container-highest-rgb: @gm3-sys-color-surface-container-highest-rgb;
+    --gm3-sys-color-surface-container-low: @gm3-sys-color-surface-container-low;
+    --gm3-sys-color-surface-container-low-rgb: @gm3-sys-color-surface-container-low-rgb;
+    --gm3-sys-color-surface-container-lowest: @gm3-sys-color-surface-container-lowest;
+    --gm3-sys-color-surface-container-lowest-rgb: @gm3-sys-color-surface-container-lowest-rgb;
+    --gm3-sys-color-surface-dim: @gm3-sys-color-surface-dim;
+    --gm3-sys-color-surface-dim-rgb: @gm3-sys-color-surface-dim-rgb;
+    --gm3-sys-color-surface-tint: @gm3-sys-color-surface-tint;
+    --gm3-sys-color-surface-tint-rgb: @gm3-sys-color-surface-tint-rgb;
+    --gm3-sys-color-surface-variant: @gm3-sys-color-surface-variant;
+    --gm3-sys-color-surface-variant-rgb: @gm3-sys-color-surface-variant-rgb;
+    --gm3-sys-color-tertiary: @gm3-sys-color-tertiary;
+    --gm3-sys-color-tertiary-rgb: @gm3-sys-color-tertiary-rgb;
+    --gm3-sys-color-tertiary-container: @gm3-sys-color-tertiary-container;
+    --gm3-sys-color-tertiary-container-rgb: @gm3-sys-color-tertiary-container-rgb;
+    --gm3-sys-color-tertiary-fixed: @gm3-sys-color-tertiary-fixed;
+    --gm3-sys-color-tertiary-fixed-rgb: @gm3-sys-color-tertiary-fixed-rgb;
+    --gm3-sys-color-tertiary-fixed-dim: @gm3-sys-color-tertiary-fixed-dim;
+    --gm3-sys-color-tertiary-fixed-dim-rgb: @gm3-sys-color-tertiary-fixed-dim-rgb;
+    --mdc-ripple-color: var(--gm3-sys-color-primary);
+
+    --boq-chrometransition-background: var(--gm3-sys-color-surface);
+
+    color: @text;
+
+    // Automatically generated code \/\/
+    // -- IMPORT START
+    .Lvwayc {
+      background: var(--gm3-sys-color-surface-container);
+    }
+    .aRDKUe .Lvwayc {
+      background: var(--gm3-sys-color-surface-container-high);
+    }
+    .LzIwWe {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .LzIwWe {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .fVFoBd {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .fVFoBd {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .DgDbFe .vZvJBb:not(:first-child) .BVnP4c::before {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .Z6NXed {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    @media (hover: hover) {
+      .Z6NXed:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb .Z6NXed:focus-visible, .WLjaOb .Z6NXed:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .Z6NXed:active, .Z6NXed:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    @media (hover: hover) {
+      .aRDKUe .Z6NXed:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb.aRDKUe .Z6NXed:focus-visible,
+    .WLjaOb.aRDKUe .Z6NXed:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .Z6NXed:active, .aRDKUe .Z6NXed:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    .aRDKUe .Z6NXed {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .T6SHIc {
+      border-bottom-color: var(--gm3-sys-color-secondary-container);
+    }
+    .aRDKUe .T6SHIc {
+      border-color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .H0GIIb {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .H0GIIb {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .Wdz6e {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .Wdz6e {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .KKMNAc, .Wdz6e {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .KKMNAc, .aRDKUe .Wdz6e {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .scjzPc {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .scjzPc {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .NoNCCf {
+      color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .NoNCCf {
+      color: var(--gm3-sys-color-primary);
+    }
+    .Y2rnLd {
+      background: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .KoNisf {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .Q3ao0c {
+      color: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 8%
+      );
+    }
+    .bMnvr {
+      background: var(--gm3-sys-color-surface-container-highest);
+    }
+    .aRDKUe .bMnvr {
+      background: var(--gm3-sys-color-surface-container-highest);
+    }
+    .WNTTTe {
+      color: var(--gm3-sys-color-primary);
+    }
+    .CkSNRd {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    @media (hover: hover) {
+      .CkSNRd:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb .CkSNRd:focus-visible, .WLjaOb .CkSNRd:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .CkSNRd:active, .CkSNRd:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    @media (hover: hover) {
+      .aRDKUe .CkSNRd:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb.aRDKUe .CkSNRd:focus-visible,
+    .WLjaOb.aRDKUe .CkSNRd:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .CkSNRd:active, .aRDKUe .CkSNRd:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    .aRDKUe .CkSNRd {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .O52YZb {
+      background: var(--gm3-sys-color-secondary-container);
+      color: var(--gm3-sys-color-on-secondary-container);
+    }
+    @media (hover: hover) {
+      .O52YZb:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-secondary-container),
+          var(--gm3-sys-color-on-secondary-container) 8%
+        );
+      }
+    }
+    .WLjaOb .O52YZb:focus-visible, .WLjaOb .O52YZb:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-secondary-container),
+        var(--gm3-sys-color-on-secondary-container) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .O52YZb:active, .O52YZb:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-secondary-container),
+        var(--gm3-sys-color-on-secondary-container) 12%
+      );
+    }
+    .aRDKUe .O52YZb {
+      background: var(--gm3-sys-color-secondary-container);
+      color: var(--gm3-sys-color-on-secondary-container);
+    }
+    @media (hover: hover) {
+      .aRDKUe .O52YZb:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-secondary-container),
+          var(--gm3-sys-color-on-secondary-container) 8%
+        );
+      }
+    }
+    .WLjaOb .aRDKUe .O52YZb:focus-visible,
+    .WLjaOb .aRDKUe .O52YZb:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-secondary-container),
+        var(--gm3-sys-color-on-secondary-container) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .O52YZb:active, .aRDKUe .O52YZb:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-secondary-container),
+        var(--gm3-sys-color-on-secondary-container) 12%
+      );
+    }
+    .gAlnEe, .UojMw {
+      color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .gAlnEe, .aRDKUe .UojMw {
+      color: var(--gm3-sys-color-primary);
+    }
+    @media (hover: hover) {
+      .gAlnEe:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb .gAlnEe:focus-visible, .WLjaOb .gAlnEe:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .gAlnEe:active, .gAlnEe:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    @media (hover: hover) {
+      .aRDKUe .gAlnEe:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb.aRDKUe .gAlnEe:focus-visible,
+    .WLjaOb.aRDKUe .gAlnEe:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .gAlnEe:active, .aRDKUe .gAlnEe:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    .UojMw {
+      border-color: var(--gm3-sys-color-outline);
+    }
+    @media (hover: hover) {
+      .UojMw:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb .UojMw:focus-visible, .WLjaOb .UojMw:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .UojMw:active, .UojMw:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    .aRDKUe .UojMw {
+      border-color: var(--gm3-sys-color-outline);
+    }
+    @media (hover: hover) {
+      .aRDKUe .UojMw:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb.aRDKUe .UojMw:focus-visible,
+    .WLjaOb.aRDKUe .UojMw:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .UojMw:active, .aRDKUe .UojMw:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    .B6iy6c .XdWBVd, .qUNJcb .XdWBVd {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .B6iy6c .XdWBVd, .aRDKUe .qUNJcb .XdWBVd {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .B6iy6c.qLP7kc .jFfZdd,
+    .qUNJcb.qLP7kc .jFfZdd,
+    .aRDKUe .B6iy6c.qLP7kc .jFfZdd,
+    .aRDKUe .qUNJcb.qLP7kc .jFfZdd {
+      background: var(--gm3-sys-color-primary-container);
+    }
+    .WLjaOb .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
+    .WLjaOb .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd {
+      background: var(--gm3-sys-color-primary-container);
+    }
+    .WLjaOb.aRDKUe .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
+    .WLjaOb.aRDKUe .B6iy6c.qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .B6iy6c .D2509d, .qUNJcb .D2509d {
+      color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .B6iy6c .D2509d, .aRDKUe .qUNJcb .D2509d {
+      color: var(--gm3-sys-color-primary);
+    }
+    .VfPpkd-qNpTzb-P4pF8c-SmKAyb {
+      border-color: var(--mdc-linear-progress-active-indicator-color, #6200ee);
+    }
+    .KKMNAc {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .KKMNAc {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .ut3Ak .KKMNAc.AJilCf {
+      background: var(--gm3-sys-color-secondary-container);
+    }
+    .aRDKUe .ut3Ak .KKMNAc.AJilCf {
+      background: var(--gm3-sys-color-secondary-container);
+    }
+    .aFCkf {
+      color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .aFCkf {
+      background: var(--gm3-sys-color-surface-container-high);
+      color: var(--gm3-sys-color-primary);
+    }
+    .x8mAUc .HyhVZe {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .x8mAUc .HyhVZe {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .cllK4d {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .cllK4d {
+      background: var(--gm3-sys-color-surface-container-high);
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .coHE2 {
+      border-color: var(--gm3-sys-color-outline);
+    }
+    @media (hover: hover) {
+      .coHE2:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb .coHE2:focus-visible, .WLjaOb .coHE2:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .coHE2:active, .coHE2:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    .aRDKUe .coHE2 {
+      border-color: var(--gm3-sys-color-outline);
+    }
+    @media (hover: hover) {
+      .aRDKUe .coHE2:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb.aRDKUe .coHE2:focus-visible,
+    .WLjaOb.aRDKUe .coHE2:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .coHE2:active, .aRDKUe .coHE2:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    .WkuXae {
+      color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .WkuXae {
+      color: var(--gm3-sys-color-primary);
+    }
+    .wk3GB {
+      fill: var(--gm3-sys-color-surface-container-highest);
+    }
+    .eYSAde {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .eYSAde {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .hCDve {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .G5bXNb {
+      background: var(--gm3-sys-color-surface-container-high);
+    }
+    @media (hover: hover) {
+      .Q3BXBb:hover .GXg3Le {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb .Q3BXBb:focus-visible .GXg3Le,
+    .WLjaOb .Q3BXBb:focus-visible:hover .GXg3Le {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .Q3BXBb:active .GXg3Le, .Q3BXBb:active:focus-visible .GXg3Le {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    @media (hover: hover) {
+      .aRDKUe .Q3BXBb:hover .GXg3Le {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb.aRDKUe .Q3BXBb:focus-visible .GXg3Le,
+    .WLjaOb.aRDKUe .Q3BXBb:focus-visible:hover .GXg3Le {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .Q3BXBb:active .GXg3Le,
+    .aRDKUe .Q3BXBb:active:focus-visible .GXg3Le {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    .Q3BXBb:hover .GXg3Le,
+    // .Q3BXBb:focus-visible .GXg3Le,
+    .Q3BXBb:active .GXg3Le,
+    .WLjaOb .Q3BXBb:focus-visible .GXg3Le,
+    .Q3BXBb:focus-visible .GXg3Le,
+    .GXg3Le:hover,
+    // .GXg3Le:focus-visible,
+    .GXg3Le:active,
+    .WLjaOb .GXg3Le:focus-visible,
+    .GXg3Le:focus-visible {
+      color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .Q3BXBb:hover .GXg3Le,
+    // .aRDKUe .Q3BXBb:focus-visible .GXg3Le,
+    .aRDKUe .Q3BXBb:active .GXg3Le,
+    .aRDKUe .WLjaOb .Q3BXBb:focus-visible .GXg3Le,
+    .aRDKUe .Q3BXBb:focus-visible .GXg3Le,
+    .aRDKUe .GXg3Le:hover,
+    // .aRDKUe .GXg3Le:focus-visible,
+    .aRDKUe .GXg3Le:active,
+    .aRDKUe .WLjaOb .GXg3Le:focus-visible,
+    .aRDKUe .GXg3Le:focus-visible {
+      color: var(--gm3-sys-color-primary);
+    }
+    .GXg3Le {
+      background: var(--gm3-sys-color-surface-container-highest);
+    }
+    @media (hover: hover) {
+      .pQpjR:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb .pQpjR:focus-visible, .WLjaOb .pQpjR:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .pQpjR:active, .pQpjR:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    @media (hover: hover) {
+      .aRDKUe .pQpjR:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb.aRDKUe .pQpjR:focus-visible,
+    .WLjaOb.aRDKUe .pQpjR:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .pQpjR:active, .aRDKUe .pQpjR:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    .SDV7ef {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .SDV7ef {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .qLP7kc .jFfZdd {
+      background: var(--gm3-sys-color-surface-container-low);
+    }
+    .aRDKUe .qLP7kc .jFfZdd {
+      background: var(--gm3-sys-color-surface-container-low);
+    }
+    @media (hover: hover) {
+      .qLP7kc .jFfZdd.Dn5Ezd:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb .qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
+    .WLjaOb .qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .qLP7kc .jFfZdd.Dn5Ezd:active, .qLP7kc .jFfZdd.Dn5Ezd:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    @media (hover: hover) {
+      .aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:hover {
+        background: color-mix(
+          in oklab,
+          var(--gm3-sys-color-surface-container-low),
+          var(--gm3-sys-color-on-surface) 8%
+        );
+      }
+    }
+    .WLjaOb.aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:focus-visible,
+    .WLjaOb.aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:focus-visible:hover {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:active,
+    .aRDKUe .qLP7kc .jFfZdd.Dn5Ezd:active:focus-visible {
+      background: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    .pRjiJb {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .aRDKUe .pRjiJb {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .MbHqJ {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .MbHqJ {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .DmSTqc {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .DmSTqc {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .idKC9b {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .aRDKUe .idKC9b {
+      color: var(--gm3-sys-color-on-surface-variant);
+    }
+    .C6Fnkb {
+      color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .C6Fnkb {
+      color: var(--gm3-sys-color-primary);
+    }
+    .N3AcWd {
+      background: var(--gm3-sys-color-primary);
+      color: var(--gm3-sys-color-surface-container-highest);
+    }
+    .aRDKUe .N3AcWd {
+      background: var(--gm3-sys-color-primary);
+    }
+    .GgqZjb .AHFKnd {
+      border-color: var(--gm3-sys-color-on-surface-variant);
+      border-bottom-color: var(--gm3-sys-color-surface-container-low);
+    }
+    .aRDKUe .GgqZjb .AHFKnd {
+      border-color: var(--gm3-sys-color-on-surface-variant);
+      border-bottom-color: var(--gm3-sys-color-surface-container-low);
+    }
+    .IAMa4b {
+      color: var(--gm3-sys-color-primary);
+    }
+    @media (hover: hover) {
+      .IAMa4b:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb .IAMa4b:focus-visible, .WLjaOb .IAMa4b:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .IAMa4b:active, .IAMa4b:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    .aRDKUe .IAMa4b {
+      color: var(--gm3-sys-color-primary);
+    }
+    @media (hover: hover) {
+      .aRDKUe .IAMa4b:hover {
+        background: rgba(var(--gm3-sys-color-primary-rgb), 0.08);
+      }
+    }
+    .WLjaOb.aRDKUe .IAMa4b:focus-visible,
+    .WLjaOb.aRDKUe .IAMa4b:focus-visible:hover {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+      border-color: var(--gm3-sys-color-primary);
+    }
+    .aRDKUe .IAMa4b:active, .aRDKUe .IAMa4b:active:focus-visible {
+      background: rgba(var(--gm3-sys-color-primary-rgb), 0.12);
+    }
+    .EHzcec {
+      background: var(--gm3-sys-color-surface-container-high);
+      background: var(
+        --gm3-sys-color-surface-container-high,
+        var(--gm3-sys-color-surface-container-high)
+      );
+    }
+    .nz9sqb.EHzcec {
+      background: var(--gm3-sys-color-surface-container-high);
+      background: var(
+        --gm3-sys-color-surface-container-high,
+        var(--gm3-sys-color-surface-container-high)
+      );
+    }
+    .nz9sqb.EHzcec .LVal7b {
+      background: var(--gm3-sys-color-surface-container-low);
+      background: var(
+        --gm3-sys-color-surface-container-low,
+        var(--gm3-sys-color-surface-container-low)
+      );
+      color: var(--gm3-sys-color-on-surface-variant);
+      color: var(
+        --gm3-sys-color-on-surface-variant,
+        var(--gm3-sys-color-on-surface-variant)
+      );
+    }
+    .LVal7b {
+      background: var(--gm3-sys-color-surface-container-low);
+      background: var(
+        --gm3-sys-color-surface-container-low,
+        var(--gm3-sys-color-surface-container-low)
+      );
+      color: var(--gm3-sys-color-on-surface-variant);
+      color: var(
+        --gm3-sys-color-on-surface-variant,
+        var(--gm3-sys-color-on-surface-variant)
+      );
+    }
+    .o07G5 .tX9u1b:active,
+    .o07G5 .tX9u1b:active:focus,
+    .o07G5 .tX9u1b:active .Rq5Gcb,
+    .o07G5 .tX9u1b:active:hover .Rq5Gcb {
+      background-color: var(--gm3-sys-color-surface-container-highest);
+    }
+    .nz9sqb.o07G5 .tX9u1b:active,
+    .nz9sqb.o07G5 .tX9u1b:active:focus,
+    .nz9sqb.o07G5 .tX9u1b:active .Rq5Gcb,
+    .nz9sqb.o07G5 .tX9u1b:active:hover .Rq5Gcb {
+      background-color: var(--gm3-sys-color-surface-container-highest);
+    }
+    .Rq5Gcb {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .nz9sqb .Rq5Gcb {
+      color: var(--gm3-sys-color-on-surface);
+    }
+    .dGrefb {
+      border-bottom-color: var(--gm3-sys-color-on-surface);
+    }
+    // .NQV3m {
+    //   background-color: var(--gm3-sys-color-surface-container-highest);
+    // }
+    .OunZ9c {
+      background: var(--gm3-sys-color-surface-container-highest);
+    }
+    .NPEKs {
+      background: var(--gm3-sys-color-primary);
+    }
+    .nz9sqb .NPEKs {
+      background: var(--gm3-sys-color-primary);
+    }
+    .tX9u1b:hover {
+      background-color: var(--gm3-sys-color-surface-container-high);
+      background-color: var(
+        --gm3-sys-color-surface-container-high,
+        var(--gm3-sys-color-surface-container-high)
+      );
+    }
+    .tX9u1b:active, .tX9u1b:active:focus {
+      background-color: var(--gm3-sys-color-surface-container-highest);
+      background-color: var(
+        --gm3-sys-color-surface-container-highest,
+        var(--gm3-sys-color-surface-container-highest)
+      );
+    }
+    .QgddUc .tX9u1b:focus, .QgddUc .tX9u1b:hover:focus {
+      border-color: var(--gm3-sys-color-primary);
+      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+      background-color: var(--gm3-sys-color-surface-container-highest);
+      background-color: var(
+        --gm3-sys-color-surface-container-highest,
+        var(--gm3-sys-color-surface-container-highest)
+      );
+    }
+    .NQV3m {
+      border-color: var(--gm3-sys-color-outline);
+      border-color: var(--gm3-sys-color-outline, var(--gm3-sys-color-outline));
+      color: var(--gm3-sys-color-primary);
+      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .NQV3m:focus-visible {
+      outline-color: var(--gm3-sys-color-primary);
+      outline-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    @media (forced-colors: active) {
+      .NQV3m {
+        border-color: var(--gm3-sys-color-outline);
+        border-color: var(
+          --gm3-sys-color-outline,
+          var(--gm3-sys-color-outline)
+        );
+      }
+    }
+    .nz9sqb .NQV3m {
+      border-color: var(--gm3-sys-color-outline);
+      border-color: var(--gm3-sys-color-outline, var(--gm3-sys-color-outline));
+      color: var(--gm3-sys-color-primary);
+      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .nz9sqb .NQV3m:focus-visible {
+      outline-color: var(--gm3-sys-color-primary);
+      outline-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    @media (forced-colors: active) {
+      .nz9sqb .NQV3m {
+        border-color: var(--gm3-sys-color-outline);
+        border-color: var(
+          --gm3-sys-color-outline,
+          var(--gm3-sys-color-outline)
+        );
+      }
+    }
+    .nz9sqb .tX9u1b:hover {
+      background-color: var(--gm3-sys-color-surface-container-high);
+      background-color: var(
+        --gm3-sys-color-surface-container-high,
+        var(--gm3-sys-color-surface-container-high)
+      );
+    }
+    .nz9sqb .tX9u1b:active, .nz9sqb .tX9u1b:active:focus {
+      background-color: var(--gm3-sys-color-surface-container-highest);
+      background-color: var(
+        --gm3-sys-color-surface-container-highest,
+        var(--gm3-sys-color-surface-container-highest)
+      );
+    }
+    .nz9sqb.QgddUc .tX9u1b:focus, .nz9sqb.QgddUc .tX9u1b:hover:focus {
+      border-color: var(--gm3-sys-color-primary);
+      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .kibP6b, .lHtSbd {
+      background: var(--gm3-sys-color-surface-container-low);
+      background: var(
+        --gm3-sys-color-surface-container-low,
+        var(--gm3-sys-color-surface-container-low)
+      );
+      color: var(--gm3-sys-color-primary);
+      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .lHtSbd {
+      color: var(--gm3-sys-color-on-surface-variant);
+      color: var(
+        --gm3-sys-color-on-surface-variant,
+        var(--gm3-sys-color-on-surface-variant)
+      );
+    }
+    .kibP6b:hover {
+      background-color: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 8%
+      );
+    }
+    .kibP6b:focus:active {
+      background-color: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    .EuVUud, .rn8xOd {
+      fill: var(--gm3-sys-color-primary);
+      fill: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .rn8xOd {
+      fill: var(--gm3-sys-color-on-surface-variant);
+      fill: var(
+        --gm3-sys-color-on-surface-variant,
+        var(--gm3-sys-color-on-surface-variant)
+      );
+    }
+    .p37w9e {
+      color: var(--gm3-sys-color-on-surface-variant);
+      color: var(
+        --gm3-sys-color-on-surface-variant,
+        var(--gm3-sys-color-on-surface-variant)
+      );
+    }
+    .bOwcqf {
+      background-color: var(--gm3-sys-color-primary);
+      background-color: var(
+        --gm3-sys-color-primary,
+        var(--gm3-sys-color-primary)
+      );
+      color: var(--gm3-sys-color-surface-container-low);
+      color: var(
+        --gm3-sys-color-surface-container-low,
+        var(--gm3-sys-color-surface-container-low)
+      );
+      border-color: var(--gm3-sys-color-surface-container-low);
+      border-color: var(
+        --gm3-sys-color-surface-container-low,
+        var(--gm3-sys-color-surface-container-low)
+      );
+    }
+    .QgddUc .kibP6b:focus, .QgddUc .lHtSbd:focus {
+      background: var(--gm3-sys-color-surface-container-highest);
+      background: var(
+        --gm3-sys-color-surface-container-highest,
+        var(--gm3-sys-color-surface-container-highest)
+      );
+      border-color: var(--gm3-sys-color-primary);
+      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .nz9sqb .kibP6b, .nz9sqb .lHtSbd {
+      background: var(--gm3-sys-color-surface-container-low);
+      background: var(
+        --gm3-sys-color-surface-container-low,
+        var(--gm3-sys-color-surface-container-low)
+      );
+      color: var(--gm3-sys-color-primary);
+      color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .nz9sqb .kibP6b:focus:active, .nz9sqb .lHtSbd:focus:active {
+      background-color: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+    .nz9sqb .EuVUud, .nz9sqb .rn8xOd {
+      fill: var(--gm3-sys-color-primary);
+      fill: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+    }
+    .nz9sqb .p37w9e {
+      color: var(--gm3-sys-color-on-surface);
+      color: var(
+        --gm3-sys-color-on-background,
+        var(--gm3-sys-color-on-surface)
+      );
+    }
+    .nz9sqb .JI4QMc {
+      stroke: var(--gm3-sys-color-on-surface-variant);
+      stroke: var(
+        --gm3-sys-color-surface-variant,
+        var(--gm3-sys-color-on-surface-variant)
+      );
+    }
+    .nz9sqb .bOwcqf {
+      background-color: var(--gm3-sys-color-primary);
+      background-color: var(
+        --gm3-sys-color-primary,
+        var(--gm3-sys-color-primary)
+      );
+      border-color: var(--gm3-sys-color-surface-container, #1e1f20);
+    }
+    .nz9sqb.QgddUc .kibP6b:focus, .nz9sqb.QgddUc .lHtSbd:focus {
+      border-color: var(--gm3-sys-color-primary);
+      border-color: var(--gm3-sys-color-primary, var(--gm3-sys-color-primary));
+      background-color: color-mix(
+        in oklab,
+        var(--gm3-sys-color-surface-container-low),
+        var(--gm3-sys-color-on-surface) 12%
+      );
+    }
+
+    // -- IMPORT END
+
+    // ## Legacy(M2) code \/ \/
+
+    // Password reset started alert dialog
+    .QsXJJ.vQ43Ie {
+      background: var(--gm3-sys-color-error-container);
+      color: var(--gm3-sys-color-on-error-container);
+    }
+    // Password reset started alert dialog main text
+    .hXhhq {
+      color: inherit;
+    }
+    // Password reset started alert dialog secondary text
+    .TnugZc,
+    // Password reset started alert dialog dismiss action
+    .xFITmb {
+      color: inherit;
+    }
+    // Password reset started alert dialog primary action
+    .QsXJJ .yZqNl,
+    .amE0Md .yZqNl,
+    // Password reset started alert dialog primary action states
+    .QsXJJ .yZqNl:hover,
+    .QsXJJ .yZqNl:hover:focus,
+    .QsXJJ .yZqNl:focus,
+    .QsXJJ .yZqNl:active,
+    .amE0Md .yZqNl:hover,
+    .amE0Md .yZqNl:hover:focus,
+    .amE0Md .yZqNl:focus,
+    .amE0Md .yZqNl:active {
+      background-color: var(--gm3-sys-color-error);
+      outline-color: var(--gm3-sys-color-error);
+    }
+    .yZqNl {
+      color: var(--gm3-sys-color-on-error);
+    }
+  }
+}
+
+/* deno-fmt-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+};

--- a/styles/google-account/preview.webp
+++ b/styles/google-account/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:014091e8a1a975428e195cbb2bff1ef845d2ca5240c37535b91dda2fb5f6be6e
+size 62046


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [Google Account](https://myaccount.google.com/), [Google Account](https://accounts.google.com/), [Google One](http://one.google.com/), [Google My Ad Center](https://myadcenter.google.com) 🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

Google Account is the account management hub of the Google Workspace suite. It is used for login, authentication, and the such. Google One is another hub of the Google Workspace suite, for storage, Gemini, choosing Google Workspace plans. Google My Ad Center is a center where personalized ads can be personalized, and where you can turn off unwanted sensitive content see ad.

![preview](https://github.com/user-attachments/assets/fe6346fa-2200-42f9-ac4c-5243ab764786)
_Google Account catwalk_

![preview](https://github.com/user-attachments/assets/2a0c15a9-ca7f-4990-8ae3-2f5d4e0ca4cc)
_Google One catwalk_

![preview](https://github.com/user-attachments/assets/e41d4634-8815-49eb-8391-b68f8d633511)
_Google Login catwalk_

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

>Include any difficulties you had theming this port

A lot of stuff, the generated class lists everywhere on Google One were main thing.

Make sure to review how apps inject into the ogs.google.com account popup, like google search and google drive. Make sure the PFP customizer works everywhere, including from products like Google Classroom, and Google Maps.

Google ogs is automatically generated from a deno script I wrote and is just manually fixed up to fit the linter by me. 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
