### PR TITLE
fix(pinterest): loading screen logo

### DIFF
--- a/styles/pinterest/catppuccin.user.less
+++ b/styles/pinterest/catppuccin.user.less
@@ -234,6 +234,16 @@
     /* the void (parts not loaded yet) */
     background: @base !important;
 
+    /* Loading screen logo */
+    .animatedLogo {
+      [fill="#E60023"] {
+        fill: @accent !important;
+      }
+      [fill="white"] {
+        fill: @crust !important;
+      }
+    }
+
     .EmojiPickerReact {
       --epr-bg-color: @base;
       --epr-text-color: @text;
@@ -273,10 +283,6 @@
       .WhU {
         background-color: @surface1;
       }
-    }
-
-    svg circle[fill="white"] ~ path[fill="#e60023"] {
-      fill: @accent !important;
     }
 
     div#mweb-unauth-container,


### PR DESCRIPTION
Themes the bouncing pinterest logo you can see briefly when (re)loading the tab.