### PR TITLE
fix(wikipedia): disable logo invert filter on dark appearance

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -40,9 +40,9 @@
     #catppuccin(@lightFlavor);
   }
 
-  html.skin-theme-clientpref-os .skin-invert-image img,
-  html.skin-theme-clientpref-os .skin-invert,
-  html.skin-theme-clientpref-os
+  html.skin-theme-clientpref-night, html.skin-theme-clientpref-os {
+    .skin-invert-image img,
+    .skin-invert,
     .oo-ui-iconElement-icon:not(
       .oo-ui-image-progressive,
       .oo-ui-image-destructive,
@@ -50,8 +50,9 @@
       .oo-ui-image-invert,
       .mw-no-invert
     ),
-  html.skin-theme-clientpref-os .oo-ui-indicatorElement-indicator {
-    filter: none;
+    .oo-ui-indicatorElement-indicator {
+      filter: none;
+    }
   }
 
   #catppuccin(@flavor) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes #1684. Previously the filter was only disabled on automatic ("os") appearance, now it is also disabled for dark ("night") appearance.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
