### PR TITLE
fix(wikipedia): apply on new auth domain

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -18,7 +18,8 @@
 
 @-moz-document domain("wikipedia.org"),
   domain("wiktionary.org"),
-  domain("www.mediawiki.org") {
+  domain("www.mediawiki.org"),
+  domain("auth.wikimedia.org") {
   @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
 
   :root.skin-theme-clientpref-os,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Noticed in https://github.com/catppuccin/userstyles/issues/1684#issuecomment-2763798809 that Wikipedia's login button now takes you to the auth.wikimedia.org domain for authentication. The userstyle is capable of theming the page entirely already, so this just adds the domain to the list of applicators.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
