### PR TITLE
fix(wikipedia): misc

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -41,6 +41,7 @@
   }
 
   html.skin-theme-clientpref-night, html.skin-theme-clientpref-os {
+    /* Logo */
     .skin-invert-image img,
     .skin-invert,
     .oo-ui-iconElement-icon:not(
@@ -53,6 +54,50 @@
     .oo-ui-indicatorElement-indicator {
       filter: none;
     }
+  }
+
+  /* MediaWiki only applies the following overrides on dark and automatic appearance settings, leaving broken elements with the light appearance. */
+
+  .hatnote:not(.notheme),
+  .dablink:not(.notheme),
+  .rellink:not(.notheme),
+  .infobox:not(.notheme) {
+    color: var(--color-base) !important;
+    background-color: var(--background-color-interactive-subtle) !important;
+  }
+  .infobox td:not(.notheme),
+  .infobox th:not(.notheme),
+  .infobox-above:not(.notheme),
+  .infobox p:not(.notheme),
+  .infobox > div:not(.notheme),
+  .infobox caption:not(.notheme),
+  .infobox--frwiki td:not(.notheme),
+  .infobox--frwiki th:not(.notheme),
+  .infobox--frwiki p:not(.notheme),
+  .infobox--frwiki > div:not(.notheme),
+  .infobox--frwiki caption:not(.notheme),
+  .sinottico th:not(.notheme),
+  .infobox-header:not(.notheme),
+  .skin-nightmode-reset-color:not(.notheme),
+  .navigation-box:not(.notheme),
+  .metadata:not(.notheme),
+  .quotebox:not(.notheme),
+  .side-box:not(.notheme),
+  .side-box div:not(.notheme),
+  .navbox:not(.notheme),
+  .navbox-subgroup:not(.notheme),
+  .navbox-group:not(.notheme),
+  .navbox-even:not(.notheme),
+  .navbox-abovebelow:not(.notheme),
+  .navbox-title:not(.notheme) {
+    background: inherit !important;
+    color: inherit !important;
+    border-color: var(--border-color-subtle) !important;
+  }
+  .ns-100 .mw-parser-output :not(.notheme, a) {
+    background: inherit !important;
+    color: inherit !important;
+    border-color: var(--border-color-subtle) !important;
   }
 
   #catppuccin(@flavor) {
@@ -195,7 +240,7 @@
     --border-color-interactive--hover: @overlay0;
     --border-color-disabled: #54595d;
     --border-color-subtle: @surface1;
-    --border-color-muted: #404244;
+    --border-color-muted: @surface0;
     --border-color-inverted: #101418;
     --border-color-error: @red;
     --border-color-error--hover: @maroon;
@@ -278,9 +323,13 @@
           border-color: fade(@lavender, 40%);
         }
       }
-      #mp-bottom .mp-h2 {
-        background-color: fade(@accent, 40%);
-        border-color: fade(@accent, 40%);
+      #mp-bottom {
+        border-color: @overlay0;
+
+        .mp-h2 {
+          background-color: fade(@accent, 40%);
+          border-color: fade(@accent, 40%);
+        }
       }
       .wikipedia-languages-prettybars {
         background-color: @surface2;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

MediaWiki only applies some overrides (involving inheriting colors and using variables) on dark and automatic appearance settings, leaving broken elements with the light appearance. This copies those overrides and applies them all the time, which should fix the issue outlined in https://github.com/catppuccin/userstyles/issues/1684#issuecomment-2763830548.

I also applied to small fixes to a variable and a box border that I noticed while investigating.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
