### PR TITLE
fix(cinny): blue links

### DIFF
--- a/styles/cinny/catppuccin.user.less
+++ b/styles/cinny/catppuccin.user.less
@@ -111,7 +111,7 @@
     --tc-primary-low: @subtext1;
     --tc-tooltip: @subtext0;
     --tc-code: @mauve;
-    --tc-link: @rosewater;
+    --tc-link: @blue;
     --tc-badge: @crust;
     --tc-positive-high: @green;
     --tc-positive-normal: @green;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Makes links blue instead of rosewater.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
