### PR TITLE
feat(kagi): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -125,6 +125,8 @@ collaborators:
     url: https://github.com/nuexq
   - &WalkQuackBack
     url: https://github.com/WalkQuackBack
+  - &cfbender
+    url: https://github.com/cfbender
 
 userstyles:
   advent-of-code:
@@ -544,6 +546,13 @@ userstyles:
     readme:
       app-link: https://jisho.org
     current-maintainers: [*Lichthagel]
+  kagi:
+    name: Kagi
+    categories: [search_engine, artificial_intelligence]
+    color: yellow
+    readme:
+      app-link: https://kagi.com
+    current-maintainers: [*cfbender]
   keybr.com:
     name: keybr.com
     categories: [productivity]

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -14,7 +14,7 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
-@-moz-document domain("kagi.com") {
+@-moz-document regexp("^(?!https:\\/\\/kagi\\.com\\/signin$)https:\\/\\/kagi\\.com\\/.*$") {
   :root.theme_light:not(.theme_moon_dark_conditional),
   :root.theme_light:not(.theme_dark_conditional) {
     #catppuccin(@lightFlavor);
@@ -423,12 +423,8 @@
 @-moz-document domain("translate.kagi.com") {
   :root.dark {
     #catppuccin(@darkFlavor);
-    // image filter because the logo is imported as an image with an svg source
-    // don't lighten on light mode
-    img[alt="doggo"] {
-      filter: invert(5%) brightness(110%) contrast(80%);
-    }
   }
+
   :root.light {
     #catppuccin(@lightFlavor);
   }
@@ -503,6 +499,12 @@
       );
     }
 
+    & when not(@flavor = latte) {
+      img[alt="doggo"] {
+        filter: invert(5%) brightness(110%) contrast(80%);
+      }
+    }
+
     --color-yellow: @yellow;
     --color-purple-500: fade(@accent, 80%);
     --color-purple-600: @accent;
@@ -517,6 +519,96 @@
     --color-zinc-700: if(@flavor = latte, @overlay2, @overlay0);
     --color-zinc-800: if(@flavor = latte, @subtext1, @surface1);
     --color-zinc-900: if(@flavor = latte, @text, @mantle);
+  }
+}
+@-moz-document url-prefix("https://kagi.com/signin")
+{
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    .login_page_asset_box {
+      background-color: @surface0;
+      color: @text;
+    }
+    .login_page_form_box {
+      background-color: @base;
+      color: @text;
+    }
+    #signInForm input:focus-visible {
+      outline: 3px solid @accent;
+    }
+    .signup-doggo-mobile,
+    .signup-doggo-desktop {
+      *[fill="#FFB319"] {
+        fill: @yellow;
+      }
+
+      *[fill="#18181A"] {
+        fill: if(@flavor =latte, @text, @crust);
+      }
+      *[stroke="#18181A"] {
+        stroke: if(@flavor =latte, @text, @crust);
+      }
+      *[fill="white"] {
+        fill: if(@flavor =latte, @crust, @text);
+      }
+      *[stroke="white"] {
+        stroke: if(@flavor =latte, @crust, @text);
+      }
+      #shadow-filter > feFlood {
+        flood-color: if(@flavor =latte, @crust, @text);
+      }
+    }
+    --primary: @text;
+    --primary-hover: @accent;
   }
 }
 

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -70,19 +70,133 @@
       }
     }
 
-    /* Start styling your website here: */
-    background-color: @base;
+    --secondary: @crust;
+    --primary-25: @crust;
+    --primary-50: @mantle;
+    --primary-70: @base;
+    --primary-100: @surface0;
+    --primary-200: @surface1;
+    --primary-300: @surface2;
+    --primary-400: @overlay0;
+    --primary-600: @overlay1;
+    --primary-700: @overlay2;
+    --primary-800: @subtext0;
+    --primary-850: @subtext1;
+    --primary-900: @text;
+    --primary-950: @text;
+    --primary: @text;
 
-    /* If you need to specify an overwrite specific to a flavor
-     *  (e.g. only when the flavor is set to latte), you can use a `when` guard clause. */
-    & when (@flavor = latte) {
-      /* ... */
-    }
-    /* You can also negate the statement above by using
-     *  a `when not` guard clause. */
-    & when not(@flavor = latte) {
-      /* ... */
-    }
+    --graphite: @text;
+    --graphite-25: @text;
+    --graphite-50: @text;
+    --graphite-70: @subtext1;
+    --graphite-100: @subtext0;
+    --graphite-200: @overlay2;
+    --graphite-300: @overlay1;
+    --graphite-400: @overlay0;
+    --graphite-600: @surface2;
+    --graphite-700: @surface1;
+    --graphite-800: @surface0;
+    --graphite-850: @base;
+    --graphite-900: @mantle;
+    --graphite-950: @crust;
+    --graphite-1000: @crust;
+    --chrome-25: @text;
+    --chrome-50: @text;
+    --chrome-70: @subtext1;
+    --chrome-100: @subtext0;
+    --chrome-200: @overlay2;
+    --chrome-300: @overlay1;
+    --chrome-400: @overlay0;
+    --chrome-600: @surface2;
+    --chrome-700: @surface1;
+    --chrome-800: @surface0;
+    --chrome-850: @base;
+    --chrome-900: @mantle;
+    --chrome-950: @crust;
+    --chrome-1000: @crust;
+
+    --ai_chat_buble_a_bg: #16171c;
+    --ai_chat_buble_dd_a_bg: #191a21;
+    --app-bg: @base;
+    --app-frame-bg: var(--app-bg);
+    --app-logo: var(--primary);
+    --app-text: var(--primary);
+    --billing-svg-bg-premium_1: var(--inline-widget-bg);
+    --blue: @blue;
+    --bottom-bar-bg: @mantle;
+    --box-shadow-15: rgba(0, 0, 0, 0.15);
+    --box-shadow: rgba(0, 0, 0, 0.09);
+    --btn-primary-bg: @text;
+    --btn-primary-color: @surface0;
+    --calm: @surface1;
+    --cheatsh_background: #22242f;
+    --cheatsh_ef148: #afd700;
+    --cheatsh_ef15: #fdf6e3;
+    --cheatsh_ef186: #d7d787;
+    --cheatsh_ef81: #5fd7ff;
+    --code-bg: #282c34;
+    --code-border: #4d4d4d;
+    --code-cm-c1: #fd6820;
+    --code-k: #e06c75;
+    --code-n: #61afef;
+    --code-p: #e06c75;
+    --code-s: #e5c07b;
+    --color-danger: @maroon;
+    --color-search-input-border: @surface2;
+    --danger: @maroon;
+    --doggo-color-1: @subtext1;
+    --doggo-color-1: @text;
+    --domain-rank-icon-color-scam-hover: @peach;
+    --domain-rank-icon-color-scam: @maroon;
+    --domain-rank-icon-color-trackers-hover: @peach;
+    --domain-rank-icon-color-trackers: @maroon;
+    --filter-dd-bg: @crust;
+    --filter-dd-bg: @subtext1;
+    --info: @sapphire;
+    --inline-domain-tag-bg: @mantle;
+    --input-bg: @surface0;
+    --k-tooltip-text: @text;
+    --kagi-orange: @peach;
+    --landing-bg: @base;
+    --link: @lavender;
+    --nav_n_im_line: @blue;
+    --nav_n_ma_line: @green;
+    --nav_n_ne_line: @mauve;
+    --nav_n_se_line: @peach;
+    --nav_n_vi_line: @red;
+    --not-found-bubble-bg: @subtext1;
+    --primary-hover: @blue;
+    --primary-hover-hover: @lavender;
+    --primary-visited: @mauve;
+    --primary-visited: @lavender;
+    --purple-300: @lavender;
+    --purple-400: @lavender;
+    --purple-500: @lavender;
+    --purple-600: @lavender;
+    --purple-800: @mauve;
+    --purple-900: @mauve;
+    --quick-search-bg: @text;
+    --quick-search-icon: @text;
+    --ranked-box-connection-insecure: @peach;
+    --ranked-box-connection-secure: @green;
+    --ranked-box-tracker-desc-clear: @green;
+    --ranked-box-tracker-desc-danger: @maroon;
+    --rating-star_background: @overlay2;
+    --result-item-highlight: @blue;
+    --result-item-title-visited-border: @subtext1;
+    --resultsummary-highlight: @lavender;
+    --search-result-content-text: @subtext0;
+    --search-result-date-bg: @surface0;
+    --search-result-date-new-bg: @subtext1;
+    --search-result-date-new: @overlay1;
+    --search-result-title: @text;
+    --success: @green;
+    --translate-fc_icon: @surface0;
+    --warning: @yellow;
+    --white: @text;
+    --widget-progress_bar: @subtext0;
+    --yellow: @yellow;
   }
 }
 

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -14,7 +14,6 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
-
 @-moz-document domain("kagi.com") {
   :root.theme_moon_dark,
   :root.theme_dark {
@@ -60,7 +59,7 @@
     @crust: @catppuccin[@@flavor][@crust];
     @accent: @catppuccin[@@flavor][@@accentColor];
 
-    color-scheme: if(@flavor = latte, light, dark);
+    color-scheme: if(@flavor =latte, light, dark);
 
     ::selection {
       background-color: fade(@accent, 30%);
@@ -71,6 +70,46 @@
       &::placeholder {
         color: @subtext0 !important;
       }
+    }
+
+    .cth_settings_content_box {
+      background-color: @surface0;
+    }
+
+    nav .cth_settings_nav_menu .nav-link.--active {
+      color: @crust;
+      & > i {
+        color: @crust;
+      }
+    }
+
+    .k_ui_toggle_switch input:checked ~ .k_ui_toggle_switch_bar,
+    #_0_lens_table_active .k_ui_toggle_switch .k_ui_toggle_switch_bar {
+      background-color: @surface2;
+      border-color: @overlay0;
+    }
+    .k_ui_toggle_switch input:checked ~ .k_ui_toggle_switch_bar:after {
+      border-color: @overlay0;
+    }
+    .interface-scale input:checked + label:after {
+      background: @blue;
+    }
+
+    .interface-scale label:hover:after {
+      background: @mauve;
+    }
+
+    .btn.--danger {
+      background-color: @red;
+    }
+
+    .btn.--danger-transp {
+      color: @surface0;
+      background-color: @red;
+    }
+
+    .member-count-box {
+      background: @surface0;
     }
 
     --secondary: @crust;

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -109,9 +109,74 @@
     }
 
     .member-count-box {
-      background: @surface0;
+      background: @surface1;
     }
 
+    .k_ui_tab_switch.tab-switch-purple input[type="checkbox"]:checked ~ .tab-1,
+    .k_ui_tab_switch.tab-switch-purple
+      input[type="checkbox"]:not(:checked)
+      ~ .tab-0 {
+      background-color: @lavender !important;
+      color: @surface0 !important;
+    }
+
+    .team_member_badge.--owner {
+      background-color: @lavender;
+      color: @surface0;
+    }
+
+    .cth_settings_content_box input:focus-visible {
+      outline: 3px solid @blue;
+    }
+
+    .otp-bubble {
+      color: @surface0;
+    }
+    .quick-settings .service-status-light {
+      background-color: @green;
+    }
+
+    .quick-settings .service-status-light.--red {
+      background-color: @red;
+    }
+
+    // Image Preview
+    .image-preview-wrapper {
+      background-color: @surface2;
+    }
+    .image-preview-footer {
+      background-color: @base;
+    }
+    #PreviewImageTitle {
+      color: @text;
+    }
+    #PreviewImageUrl {
+      color: @blue;
+    }
+    #PreviewImageViewImageBtn {
+      background-color: @text !important;
+      color: @surface0 !important;
+    }
+    #PreviewImageViewImageBtn:hover {
+      background-color: @blue !important;
+    }
+    #PreviewImageDownloadImageBtn {
+      border: 1px solid @text;
+      color: @text;
+    }
+    #PreviewImageDownloadImageBtn:hover {
+      border: 1px solid @blue;
+      color: @blue;
+    }
+    .image-preview-info-body {
+      background-color: @surface2;
+    }
+
+    .image-preview-info-item__title {
+      color: @text !important;
+    }
+
+    // variable overrides
     --secondary: @crust;
     --primary-25: @crust;
     --primary-50: @mantle;
@@ -158,32 +223,13 @@
     --chrome-950: @crust;
     --chrome-1000: @crust;
 
-    --ai_chat_buble_a_bg: #16171c;
-    --ai_chat_buble_dd_a_bg: #191a21;
     --app-bg: @base;
-    --app-frame-bg: var(--app-bg);
-    --app-logo: var(--primary);
-    --app-text: var(--primary);
     --billing-svg-bg-premium_1: var(--inline-widget-bg);
     --blue: @blue;
     --bottom-bar-bg: @mantle;
-    --box-shadow-15: rgba(0, 0, 0, 0.15);
-    --box-shadow: rgba(0, 0, 0, 0.09);
     --btn-primary-bg: @text;
     --btn-primary-color: @surface0;
     --calm: @surface1;
-    --cheatsh_background: #22242f;
-    --cheatsh_ef148: #afd700;
-    --cheatsh_ef15: #fdf6e3;
-    --cheatsh_ef186: #d7d787;
-    --cheatsh_ef81: #5fd7ff;
-    --code-bg: #282c34;
-    --code-border: #4d4d4d;
-    --code-cm-c1: #fd6820;
-    --code-k: #e06c75;
-    --code-n: #61afef;
-    --code-p: #e06c75;
-    --code-s: #e5c07b;
     --color-danger: @maroon;
     --color-search-input-border: @surface2;
     --danger: @maroon;
@@ -239,6 +285,221 @@
     --white: @text;
     --widget-progress_bar: @subtext0;
     --yellow: @yellow;
+  }
+}
+@-moz-document url-prefix("https://kagi.com/fastgpt")
+{
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    color-scheme: if(@flavor =latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+    background-color: @base !important;
+    body {
+      background-color: @base !important;
+      color: @text;
+    }
+    .footer_note_box_inner {
+      background-color: @surface0 !important;
+      color: @subtext1;
+    }
+
+    div.doggo_image_1 path[fill="#18181A"] {
+      fill: @surface0;
+    }
+    div.doggo_image_1 path[stroke="#18181A"] {
+      stroke: @surface0;
+    }
+    div.doggo_image_1 path[fill="white"] {
+      fill: @text;
+    }
+    div.doggo_image_1 path[stroke="white"] {
+      stroke: @text;
+    }
+    div.doggo_image_1 path[fill="#FFB319"] {
+      fill: @yellow;
+    }
+
+    --secondary: @crust;
+    --primary-25: @crust;
+    --primary-50: @mantle;
+    --primary-70: @base;
+    --primary-100: @surface0;
+    --primary-200: @surface1;
+    --primary-300: @surface2;
+    --primary-400: @overlay0;
+    --primary-600: @overlay1;
+    --primary-700: @overlay2;
+    --primary-800: @subtext0;
+    --primary-850: @subtext1;
+    --primary-900: @text;
+    --primary-950: @text;
+    --primary: @text;
+    --primary-hover: @mauve;
+
+    --c_page_link: @blue;
+    --c_page_bg: @base;
+    --c_white: @text;
+  }
+}
+@-moz-document domain("translate.kagi.com") {
+  :root.dark {
+    #catppuccin(@darkFlavor);
+    // flipped zinc to make replacements easier
+    --color-zinc-50: @text;
+    --color-zinc-100: @text;
+    --color-zinc-100: @text;
+    --color-zinc-200: @subtext1;
+    --color-zinc-300: @subtext0;
+    --color-zinc-400: @overlay2;
+    --color-zinc-600: @overlay1;
+    --color-zinc-700: @overlay0;
+    --color-zinc-800: @surface1;
+    --color-zinc-900: @mantle;
+    img[alt="doggo"] {
+      filter: invert(5%) brightness(110%) contrast(80%);
+    }
+  }
+  :root.light {
+    #catppuccin(@lightFlavor);
+    --color-zinc-50: @crust;
+    --color-zinc-100: @mantle;
+    --color-zinc-100: @surface0;
+    --color-zinc-200: @surface1;
+    --color-zinc-300: @surface2;
+    --color-zinc-400: @overlay0;
+    --color-zinc-600: @overlay1;
+    --color-zinc-700: @overlay2;
+    --color-zinc-800: @subtext1;
+    --color-zinc-900: @text;
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+    body {
+      color: @text;
+    }
+
+    // manual color overrides
+    .dark\:bg-\[\#232325\]:where(.dark, .dark *) {
+      background-color: @base;
+    }
+    .dark\:bg-\[\#2F2F31\]:where(.dark, .dark *) {
+      background-color: @surface0;
+    }
+    .bookmarklet-container a {
+      color: @mauve;
+    }
+    .dark\:text-\[\#FFB319\]:where(.dark, .dark *) {
+      color: @yellow;
+    }
+    .text-\[#c3870e\] {
+      color: @yellow;
+    }
+
+    .partial-ring:before {
+      background: conic-gradient(
+        from var(--border-angle),
+        @peach 0 50%,
+        transparent 50% 100%
+      );
+    }
+    --color-yellow: @yellow;
+    --color-purple-500: @lavender;
+    --color-purple-600: @mauve;
+    --color-zinc-50: @text;
+    --color-zinc-100: @text;
+    --color-zinc-100: @text;
+    --color-zinc-200: @subtext1;
+    --color-zinc-300: @subtext0;
+    --color-zinc-400: @overlay2;
+    --color-zinc-600: @overlay1;
+    --color-zinc-700: @overlay0;
+    --color-zinc-800: @surface1;
+    --color-zinc-900: @mantle;
   }
 }
 

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -92,11 +92,11 @@
       border-color: @overlay0;
     }
     .interface-scale input:checked + label:after {
-      background: @blue;
+      background: @accent;
     }
 
     .interface-scale label:hover:after {
-      background: @mauve;
+      background: @accent;
     }
 
     .btn.--danger {
@@ -116,17 +116,17 @@
     .k_ui_tab_switch.tab-switch-purple
       input[type="checkbox"]:not(:checked)
       ~ .tab-0 {
-      background-color: @lavender !important;
+      background-color: @accent !important;
       color: @surface0 !important;
     }
 
     .team_member_badge.--owner {
-      background-color: @lavender;
+      background-color: @accent;
       color: @surface0;
     }
 
     .cth_settings_content_box input:focus-visible {
-      outline: 3px solid @blue;
+      outline: 3px solid @accent;
     }
 
     .otp-bubble {
@@ -151,22 +151,22 @@
       color: @text;
     }
     #PreviewImageUrl {
-      color: @blue;
+      color: @accent;
     }
     #PreviewImageViewImageBtn {
       background-color: @text !important;
       color: @surface0 !important;
     }
     #PreviewImageViewImageBtn:hover {
-      background-color: @blue !important;
+      background-color: @accent !important;
     }
     #PreviewImageDownloadImageBtn {
       border: 1px solid @text;
       color: @text;
     }
     #PreviewImageDownloadImageBtn:hover {
-      border: 1px solid @blue;
-      color: @blue;
+      border: 1px solid @accent;
+      color: @accent;
     }
     .image-preview-info-body {
       background-color: @surface2;
@@ -224,7 +224,6 @@
     --chrome-1000: @crust;
 
     --app-bg: @base;
-    --billing-svg-bg-premium_1: var(--inline-widget-bg);
     --blue: @blue;
     --bottom-bar-bg: @mantle;
     --btn-primary-bg: @text;
@@ -233,7 +232,6 @@
     --color-danger: @maroon;
     --color-search-input-border: @surface2;
     --danger: @maroon;
-    --doggo-color-1: @subtext1;
     --doggo-color-1: @text;
     --domain-rank-icon-color-scam-hover: @peach;
     --domain-rank-icon-color-scam: @maroon;
@@ -254,10 +252,9 @@
     --nav_n_se_line: @peach;
     --nav_n_vi_line: @red;
     --not-found-bubble-bg: @subtext1;
-    --primary-hover: @blue;
-    --primary-hover-hover: @lavender;
-    --primary-visited: @mauve;
-    --primary-visited: @lavender;
+    --primary-hover: @accent;
+    --primary-hover-hover: fade(@accent, 80%);
+    --primary-visited: darken(@accent, 5%);
     --purple-300: @lavender;
     --purple-400: @lavender;
     --purple-500: @lavender;
@@ -379,9 +376,9 @@
     --primary-900: @text;
     --primary-950: @text;
     --primary: @text;
-    --primary-hover: @mauve;
+    --primary-hover: @accent;
 
-    --c_page_link: @blue;
+    --c_page_link: @accent;
     --c_page_bg: @base;
     --c_white: @text;
   }
@@ -471,7 +468,7 @@
       background-color: @surface0;
     }
     .bookmarklet-container a {
-      color: @mauve;
+      color: @accent;
     }
     .dark\:text-\[\#FFB319\]:where(.dark, .dark *) {
       color: @yellow;
@@ -488,8 +485,8 @@
       );
     }
     --color-yellow: @yellow;
-    --color-purple-500: @lavender;
-    --color-purple-600: @mauve;
+    --color-purple-500: fade(@accent, 80%);
+    --color-purple-600: @accent;
     --color-zinc-50: @text;
     --color-zinc-100: @text;
     --color-zinc-100: @text;

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -140,6 +140,15 @@
       background-color: @red;
     }
 
+    .onb_plan.__highlighted .onb_plan_choose_btn_box > .btn {
+      color: @base;
+    }
+    .onboarding_plans_box {
+      background: linear-gradient(180deg, var(--app-bg) 40%, @peach 40%);
+    }
+    .onb_plans_wrapper {
+      background-color: @peach;
+    }
     // Image Preview
     .image-preview-wrapper {
       background-color: @surface2;
@@ -193,7 +202,7 @@
     --primary-950: @text;
     --primary: @text;
 
-    --graphite: @text;
+    --graphite: @base;
     --graphite-25: @text;
     --graphite-50: @text;
     --graphite-70: @subtext1;
@@ -232,6 +241,7 @@
     --color-danger: @maroon;
     --color-search-input-border: @surface2;
     --danger: @maroon;
+    --doggo-color-1: @subtext1;
     --doggo-color-1: @text;
     --domain-rank-icon-color-scam-hover: @peach;
     --domain-rank-icon-color-scam: @maroon;

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -1,0 +1,203 @@
+/* ==UserStyle==
+@name Kagi Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/kagi
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/kagi
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/kagi/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Akagi
+@description Soothing pastel theme for kagi
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain("kagi.com") {
+  :root.theme_moon_dark {
+    #catppuccin(@darkFlavor);
+  }
+
+  :root.theme_light:not(.theme_moon_dark_conditional) {
+    #catppuccin(@lightFlavor);
+  }
+
+  :root.theme_moon_dark_conditional {
+    #catppuccin(@darkFlavor);
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    /* Start styling your website here: */
+    background-color: @base;
+
+    /* If you need to specify an overwrite specific to a flavor
+     *  (e.g. only when the flavor is set to latte), you can use a `when` guard clause. */
+    & when (@flavor = latte) {
+      /* ... */
+    }
+    /* You can also negate the statement above by using
+     *  a `when not` guard clause. */
+    & when not(@flavor = latte) {
+      /* ... */
+    }
+  }
+}
+
+/* deno-fmt-ignore */
+@catppuccin: {
+  @latte: {
+    @rosewater: #dc8a78;
+    @flamingo: #dd7878;
+    @pink: #ea76cb;
+    @mauve: #8839ef;
+    @red: #d20f39;
+    @maroon: #e64553;
+    @peach: #fe640b;
+    @yellow: #df8e1d;
+    @green: #40a02b;
+    @teal: #179299;
+    @sky: #04a5e5;
+    @sapphire: #209fb5;
+    @blue: #1e66f5;
+    @lavender: #7287fd;
+    @text: #4c4f69;
+    @subtext1: #5c5f77;
+    @subtext0: #6c6f85;
+    @overlay2: #7c7f93;
+    @overlay1: #8c8fa1;
+    @overlay0: #9ca0b0;
+    @surface2: #acb0be;
+    @surface1: #bcc0cc;
+    @surface0: #ccd0da;
+    @base: #eff1f5;
+    @mantle: #e6e9ef;
+    @crust: #dce0e8;
+  };
+  @frappe: {
+    @rosewater: #f2d5cf;
+    @flamingo: #eebebe;
+    @pink: #f4b8e4;
+    @mauve: #ca9ee6;
+    @red: #e78284;
+    @maroon: #ea999c;
+    @peach: #ef9f76;
+    @yellow: #e5c890;
+    @green: #a6d189;
+    @teal: #81c8be;
+    @sky: #99d1db;
+    @sapphire: #85c1dc;
+    @blue: #8caaee;
+    @lavender: #babbf1;
+    @text: #c6d0f5;
+    @subtext1: #b5bfe2;
+    @subtext0: #a5adce;
+    @overlay2: #949cbb;
+    @overlay1: #838ba7;
+    @overlay0: #737994;
+    @surface2: #626880;
+    @surface1: #51576d;
+    @surface0: #414559;
+    @base: #303446;
+    @mantle: #292c3c;
+    @crust: #232634;
+  };
+  @macchiato: {
+    @rosewater: #f4dbd6;
+    @flamingo: #f0c6c6;
+    @pink: #f5bde6;
+    @mauve: #c6a0f6;
+    @red: #ed8796;
+    @maroon: #ee99a0;
+    @peach: #f5a97f;
+    @yellow: #eed49f;
+    @green: #a6da95;
+    @teal: #8bd5ca;
+    @sky: #91d7e3;
+    @sapphire: #7dc4e4;
+    @blue: #8aadf4;
+    @lavender: #b7bdf8;
+    @text: #cad3f5;
+    @subtext1: #b8c0e0;
+    @subtext0: #a5adcb;
+    @overlay2: #939ab7;
+    @overlay1: #8087a2;
+    @overlay0: #6e738d;
+    @surface2: #5b6078;
+    @surface1: #494d64;
+    @surface0: #363a4f;
+    @base: #24273a;
+    @mantle: #1e2030;
+    @crust: #181926;
+  };
+  @mocha: {
+    @rosewater: #f5e0dc;
+    @flamingo: #f2cdcd;
+    @pink: #f5c2e7;
+    @mauve: #cba6f7;
+    @red: #f38ba8;
+    @maroon: #eba0ac;
+    @peach: #fab387;
+    @yellow: #f9e2af;
+    @green: #a6e3a1;
+    @teal: #94e2d5;
+    @sky: #89dceb;
+    @sapphire: #74c7ec;
+    @blue: #89b4fa;
+    @lavender: #b4befe;
+    @text: #cdd6f4;
+    @subtext1: #bac2de;
+    @subtext0: #a6adc8;
+    @overlay2: #9399b2;
+    @overlay1: #7f849c;
+    @overlay0: #6c7086;
+    @surface2: #585b70;
+    @surface1: #45475a;
+    @surface0: #313244;
+    @base: #1e1e2e;
+    @mantle: #181825;
+    @crust: #11111b;
+  };
+};

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -15,18 +15,15 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 @-moz-document domain("kagi.com") {
-  :root.theme_moon_dark,
-  :root.theme_dark {
-    #catppuccin(@darkFlavor);
-  }
-
   :root.theme_light:not(.theme_moon_dark_conditional),
   :root.theme_light:not(.theme_dark_conditional) {
     #catppuccin(@lightFlavor);
   }
 
   :root.theme_moon_dark_conditional,
-  :root.theme_dark_conditional {
+  :root.theme_dark_conditional,
+  :root.theme_moon_dark,
+  :root.theme_dark {
     #catppuccin(@darkFlavor);
   }
 
@@ -83,6 +80,30 @@
       }
     }
 
+    // Logo colors
+    div.doggo_sit_a path[fill="#FFB319"] {
+      fill: @yellow;
+    }
+
+    #shadow-filter > feFlood {
+      flood-color: if(@flavor =latte, @crust, @text);
+    }
+
+    div.doggo_sit_a *[fill="#18181A"] {
+      fill: if(@flavor =latte, @text, @crust);
+    }
+    div.doggo_sit_a *[stroke="#18181A"] {
+      stroke: if(@flavor =latte, @text, @crust);
+    }
+    div.doggo_sit_a *[fill="white"] {
+      fill: if(@flavor =latte, @crust, @text);
+    }
+    div.doggo_sit_a *[stroke="white"] {
+      stroke: if(@flavor =latte, @crust, @text);
+    }
+
+    // Element color overrides
+
     .k_ui_toggle_switch input:checked ~ .k_ui_toggle_switch_bar,
     #_0_lens_table_active .k_ui_toggle_switch .k_ui_toggle_switch_bar {
       background-color: @surface2;
@@ -108,6 +129,7 @@
       background-color: @red;
     }
 
+    // Settings page
     .member-count-box {
       background: @surface1;
     }
@@ -132,6 +154,8 @@
     .otp-bubble {
       color: @surface0;
     }
+
+    // Control center (hamburger menu)
     .quick-settings .service-status-light {
       background-color: @green;
     }
@@ -139,6 +163,8 @@
     .quick-settings .service-status-light.--red {
       background-color: @red;
     }
+
+    // Onboarding page
 
     .onb_plan.__highlighted .onb_plan_choose_btn_box > .btn {
       color: @base;
@@ -149,6 +175,7 @@
     .onb_plans_wrapper {
       background-color: @peach;
     }
+
     // Image Preview
     .image-preview-wrapper {
       background-color: @surface2;
@@ -294,6 +321,7 @@
     --yellow: @yellow;
   }
 }
+
 @-moz-document url-prefix("https://kagi.com/fastgpt")
 {
   :root {
@@ -345,30 +373,28 @@
         color: @subtext0 !important;
       }
     }
-    background-color: @base !important;
-    body {
-      background-color: @base !important;
-      color: @text;
-    }
+
     .footer_note_box_inner {
       background-color: @surface0 !important;
       color: @subtext1;
     }
 
-    div.doggo_image_1 path[fill="#18181A"] {
-      fill: @surface0;
-    }
-    div.doggo_image_1 path[stroke="#18181A"] {
-      stroke: @surface0;
-    }
-    div.doggo_image_1 path[fill="white"] {
-      fill: @text;
-    }
-    div.doggo_image_1 path[stroke="white"] {
-      stroke: @text;
-    }
-    div.doggo_image_1 path[fill="#FFB319"] {
+    // Logo colors
+    div.doggo_image_1 *[fill="#FFB319"] {
       fill: @yellow;
+    }
+
+    div.doggo_image_1 *[fill="#18181A"] {
+      fill: if(@flavor =latte, @text, @crust);
+    }
+    div.doggo_image_1 *[stroke="#18181A"] {
+      stroke: if(@flavor =latte, @text, @crust);
+    }
+    div.doggo_image_1 *[fill="white"] {
+      fill: if(@flavor =latte, @crust, @text);
+    }
+    div.doggo_image_1 *[stroke="white"] {
+      stroke: if(@flavor =latte, @crust, @text);
     }
 
     --secondary: @crust;
@@ -393,36 +419,18 @@
     --c_white: @text;
   }
 }
+
 @-moz-document domain("translate.kagi.com") {
   :root.dark {
     #catppuccin(@darkFlavor);
-    // flipped zinc to make replacements easier
-    --color-zinc-50: @text;
-    --color-zinc-100: @text;
-    --color-zinc-100: @text;
-    --color-zinc-200: @subtext1;
-    --color-zinc-300: @subtext0;
-    --color-zinc-400: @overlay2;
-    --color-zinc-600: @overlay1;
-    --color-zinc-700: @overlay0;
-    --color-zinc-800: @surface1;
-    --color-zinc-900: @mantle;
+    // image filter because the logo is imported as an image with an svg source
+    // don't lighten on light mode
     img[alt="doggo"] {
       filter: invert(5%) brightness(110%) contrast(80%);
     }
   }
   :root.light {
     #catppuccin(@lightFlavor);
-    --color-zinc-50: @crust;
-    --color-zinc-100: @mantle;
-    --color-zinc-100: @surface0;
-    --color-zinc-200: @surface1;
-    --color-zinc-300: @surface2;
-    --color-zinc-400: @overlay0;
-    --color-zinc-600: @overlay1;
-    --color-zinc-700: @overlay2;
-    --color-zinc-800: @subtext1;
-    --color-zinc-900: @text;
   }
 
   #catppuccin(@flavor) {
@@ -470,7 +478,7 @@
       color: @text;
     }
 
-    // manual color overrides
+    // Manual color overrides
     .dark\:bg-\[\#232325\]:where(.dark, .dark *) {
       background-color: @base;
     }
@@ -494,19 +502,21 @@
         transparent 50% 100%
       );
     }
+
     --color-yellow: @yellow;
     --color-purple-500: fade(@accent, 80%);
     --color-purple-600: @accent;
-    --color-zinc-50: @text;
-    --color-zinc-100: @text;
-    --color-zinc-100: @text;
-    --color-zinc-200: @subtext1;
-    --color-zinc-300: @subtext0;
-    --color-zinc-400: @overlay2;
-    --color-zinc-600: @overlay1;
-    --color-zinc-700: @overlay0;
-    --color-zinc-800: @surface1;
-    --color-zinc-900: @mantle;
+
+    --color-zinc-50: if(@flavor = latte, @crust, @text);
+    --color-zinc-100: if(@flavor = latte, @mantle, @text);
+    --color-zinc-100: if(@flavor = latte, @surface0, @text);
+    --color-zinc-200: if(@flavor = latte, @surface1, @subtext1);
+    --color-zinc-300: if(@flavor = latte, @surface2, @subtext0);
+    --color-zinc-400: if(@flavor = latte, @overlay0, @overlay2);
+    --color-zinc-600: if(@flavor = latte, @overlay1, @overlay1);
+    --color-zinc-700: if(@flavor = latte, @overlay2, @overlay0);
+    --color-zinc-800: if(@flavor = latte, @subtext1, @surface1);
+    --color-zinc-900: if(@flavor = latte, @text, @mantle);
   }
 }
 

--- a/styles/kagi/catppuccin.user.less
+++ b/styles/kagi/catppuccin.user.less
@@ -16,15 +16,18 @@
 ==/UserStyle== */
 
 @-moz-document domain("kagi.com") {
-  :root.theme_moon_dark {
+  :root.theme_moon_dark,
+  :root.theme_dark {
     #catppuccin(@darkFlavor);
   }
 
-  :root.theme_light:not(.theme_moon_dark_conditional) {
+  :root.theme_light:not(.theme_moon_dark_conditional),
+  :root.theme_light:not(.theme_dark_conditional) {
     #catppuccin(@lightFlavor);
   }
 
-  :root.theme_moon_dark_conditional {
+  :root.theme_moon_dark_conditional,
+  :root.theme_dark_conditional {
     #catppuccin(@darkFlavor);
   }
 

--- a/styles/kagi/preview.webp
+++ b/styles/kagi/preview.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:676bd77f20e746524ea7b3ccab01bb124546246d5f880e754f61109fc4191305
+size 21134

--- a/styles/kagi/preview.webp
+++ b/styles/kagi/preview.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:676bd77f20e746524ea7b3ccab01bb124546246d5f880e754f61109fc4191305
-size 21134
+oid sha256:abd1a483de52cbd4f9f0ded61976da4142b16684f1194c4c63a698c35080da78
+size 200786


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [Kagi](https://kagi.com) 🎉

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->
Kagi is a search engine that has some AI and translation features.

![preview](https://github.com/user-attachments/assets/c2ac3531-ab4b-4acb-831b-95d38f25626d)


## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->
This is my first time porting something, so hopefully I didn't make any grave errors. I tried to keep things as variables where possible and keep everything consistent. I dug through as many menus and clicked as many things as I could think of but it's likely I missed at least something. Hopefully someone who is a reviewer uses Kagi or it could be difficult to see! They have a free trial so there is that option as well.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
  - [x] `preview.webp` - composite image of all four individual flavor screenshots (taken with the default accent color of mauve) stitched together, generated via [Catwalk](https://github.com/catppuccin/catwalk).
