### PR TITLE
fix(pinterest): avoid formatter syntax errors

### DIFF
--- a/styles/pinterest/catppuccin.user.less
+++ b/styles/pinterest/catppuccin.user.less
@@ -209,6 +209,8 @@
     --color-background-warning-base: @peach;
     --color-background-success-base: @green;
 
+    // Currently unsupported syntax by the Less parser the Deno formatter uses, see https://github.com/g-plane/raffia/issues/9.
+    
     // @colors: {
     //   01: @blue;
     //   02: @teal;
@@ -224,6 +226,30 @@
     //   --color-background-searchguide-default-@{key}: @value;
     //   --color-background-searchguide-hover-@{key}: if(@key = 11, @value, lighten(@value, 4%));
     // });
+
+    --color-background-searchguide-default-01: @blue;
+    --color-background-searchguide-hover-01: lighten(@blue, 4%);
+
+    --color-background-searchguide-default-02: @teal;
+    --color-background-searchguide-hover-02: lighten(@teal, 4%);
+
+    --color-background-searchguide-default-06: @sapphire;
+    --color-background-searchguide-hover-06: lighten(@sapphire, 4%);
+
+    --color-background-searchguide-default-07: @green;
+    --color-background-searchguide-hover-07: lighten(@green, 4%);
+
+    --color-background-searchguide-default-08: @yellow;
+    --color-background-searchguide-hover-08: lighten(@yellow, 4%);
+
+    --color-background-searchguide-default-09: @pink;
+    --color-background-searchguide-hover-09: lighten(@pink, 4%);
+
+    --color-background-searchguide-default-10: @mauve;
+    --color-background-searchguide-hover-10: lighten(@mauve, 4%);
+
+    --color-background-searchguide-default-11: @crust;
+    --color-background-searchguide-hover-11: @crust;
 
     body {
       background-color: @base;

--- a/styles/pinterest/catppuccin.user.less
+++ b/styles/pinterest/catppuccin.user.less
@@ -209,22 +209,21 @@
     --color-background-warning-base: @peach;
     --color-background-success-base: @green;
 
-    @colors: {
-      01: @blue;
-      02: @teal;
-      06: @sapphire;
-      07: @green;
-      08: @yellow;
-      09: @pink;
-      10: @mauve;
-      11: @crust;
-    };
-    
-    each(@colors, {
-      --color-background-searchguide-default-@{key}: @value;
-      --color-background-searchguide-hover-@{key}: if(@key = 11, @value, lighten(@value, 4%));
-    });
+    // @colors: {
+    //   01: @blue;
+    //   02: @teal;
+    //   06: @sapphire;
+    //   07: @green;
+    //   08: @yellow;
+    //   09: @pink;
+    //   10: @mauve;
+    //   11: @crust;
+    // };
 
+    // each(@colors, {
+    //   --color-background-searchguide-default-@{key}: @value;
+    //   --color-background-searchguide-hover-@{key}: if(@key = 11, @value, lighten(@value, 4%));
+    // });
 
     body {
       background-color: @base;
@@ -690,7 +689,10 @@
           background-image: url("data:image/svg+xml,@{svg}") !important;   
         }
         div[style*='background-image: url("https://s.pinimg.com/webapp/loveStatic-31fc2a99.svg")'] {
-          @svg: escape('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120"><path fill="@{red}" d="M66.72 17.122 60 23.897l-6.72-6.775c-12.196-12.163-31.975-12.163-44.171 0-12.145 12.209-12.145 32.014 0 44.223L60 111.636l50.891-50.291c12.145-12.209 12.145-32.014 0-44.223C104.793 11.041 96.799 8 88.805 8s-15.987 3.041-22.085 9.122"/><path fill="@{darken(@red, 50%)}" d="M32.727 48.909a8.182 8.182 0 1 0 16.365 0 8.182 8.182 0 0 0-16.365 0m38.182 0a8.18 8.18 0 0 0 8.182 8.182 8.182 8.182 0 1 0 0-16.364 8.18 8.18 0 0 0-8.182 8.182M60 66.8c-5.9 0-11.4-1.3-16.3-3.7.2 8.9 7.4 16 16.3 16s16.2-7.2 16.3-16c-4.9 2.3-10.4 3.7-16.3 3.7"/></svg>');
+          @darkened-red: darken(@red, 50%);
+          @svg: escape(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120"><path fill="@{red}" d="M66.72 17.122 60 23.897l-6.72-6.775c-12.196-12.163-31.975-12.163-44.171 0-12.145 12.209-12.145 32.014 0 44.223L60 111.636l50.891-50.291c12.145-12.209 12.145-32.014 0-44.223C104.793 11.041 96.799 8 88.805 8s-15.987 3.041-22.085 9.122"/><path fill="@{darkened-red}" d="M32.727 48.909a8.182 8.182 0 1 0 16.365 0 8.182 8.182 0 0 0-16.365 0m38.182 0a8.18 8.18 0 0 0 8.182 8.182 8.182 8.182 0 1 0 0-16.364 8.18 8.18 0 0 0-8.182 8.182M60 66.8c-5.9 0-11.4-1.3-16.3-3.7.2 8.9 7.4 16 16.3 16s16.2-7.2 16.3-16c-4.9 2.3-10.4 3.7-16.3 3.7"/></svg>'
+          );
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
       }


### PR DESCRIPTION
Updates some syntax in the Pinterest userstyle to avoid errors the Deno formatter was throwing.