### PR TITLE
fix(snapchat-web): change domain

### DIFF
--- a/styles/snapchat-web/catppuccin.user.less
+++ b/styles/snapchat-web/catppuccin.user.less
@@ -15,7 +15,7 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document domain("web.snapchat.com") {
+@-moz-document domain("snapchat.com") {
   :root[theme="dark"] {
     #catppuccin(@darkFlavor);
   }

--- a/styles/snapchat-web/catppuccin.user.less
+++ b/styles/snapchat-web/catppuccin.user.less
@@ -15,7 +15,7 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document domain("snapchat.com") {
+@-moz-document url-prefix("https://snapchat.com/web") {
   :root[theme="dark"] {
     #catppuccin(@darkFlavor);
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

`web.snapchat.com` appears to redirect to `snapchat.com/web` now:

```sh
$ curl https://web.snapchat.com hv
* Host web.snapchat.com:443 was resolved.
* IPv6: (none)
* IPv4: 34.149.46.130
*   Trying 34.149.46.130:443...
...
> GET / HTTP/2
> Host: web.snapchat.com
> User-Agent: curl/8.12.1
> Accept: */*
> 
* Request completely sent off
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/2 301 
...
* Connection #0 to host web.snapchat.com left intact
Moved Permanently. Redirecting to https://www.snapchat.com/web/%   
```

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
