### PR TITLE
fix(youtube): changed fade of --yt-spec-themed-overlay-background

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -158,7 +158,7 @@
       --yt-spec-themed-blue: @accent !important;
       --yt-spec-themed-green: @green !important;
       --yt-spec-ad-indicator: @teal !important;
-      --yt-spec-themed-overlay-background: fade(@crust, 20%) !important;
+      --yt-spec-themed-overlay-background: fade(@crust, 80%) !important;
       --yt-spec-commerce-badge-background: @green !important;
       --yt-spec-static-brand-red: @accent !important;
       --yt-spec-static-brand-white: @text !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
Fixes overlay background on youtube thumbnails when downloading a video!

Original:
![original](https://github.com/user-attachments/assets/0b4d0628-11ad-491d-99bb-b69dff766785)

Before:
![before](https://github.com/user-attachments/assets/8a0b12c1-4957-4b2e-b834-00f9f49eb30a)

After:
![after](https://github.com/user-attachments/assets/3aec8cf9-370d-46ac-9b2b-c0bb4afcfce4)


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
