### PR TITLE
fix(hackage): new subdomain and inline code

### DIFF
--- a/styles/hackage/catppuccin.user.less
+++ b/styles/hackage/catppuccin.user.less
@@ -15,7 +15,8 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 
-@-moz-document domain("hackage.haskell.org") {
+@-moz-document domain("hackage.haskell.org"),
+  domain("hackage-content.haskell.org") {
   :root {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);

--- a/styles/hackage/catppuccin.user.less
+++ b/styles/hackage/catppuccin.user.less
@@ -279,7 +279,12 @@
       background-color: @mantle;
     }
 
-    #table-of-contents {
+    h2#table-of-contents {
+      background-color: @mantle;
+      color: @text;
+    }
+
+    div#table-of-contents {
       background-color: @base;
       border-color: @surface1;
     }

--- a/styles/hackage/catppuccin.user.less
+++ b/styles/hackage/catppuccin.user.less
@@ -134,7 +134,8 @@
     .declname,
     .declbut,
     .topdecl,
-    .arg {
+    .arg,
+    .inline-code {
       background-color: @mantle;
       color: @text;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Looks like most (if not all) new packages have their documentations hosted on `hackage-content.haskell.org` now, so I added that to the domains ([example link](https://hackage-content.haskell.org/package/containers-0.8/docs/Data-Map.html)). Maybe related to https://github.com/haskell/hackage-server/pull/1379 or something.

Other than that, new packages have inline code blocks (finally), and there is a **single** package I came across that has a table of contents in the index so I made its background match the style of the original Hackage:

| example | old | fixed |
| :-----: | :-: | :---: |
| [link](https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-List.html) | ![An inline code block in wrong colors.](https://github.com/user-attachments/assets/d6c28794-7189-47de-8fbf-ec5a75c08cba) | ![The same code block colored properly.](https://github.com/user-attachments/assets/688c3369-2577-4e04-b70b-6e9c48c3ae18) |
| [link](https://hackage.haskell.org/package/miso-1.8.7.0) | ![The table of contents box without a background.](https://github.com/user-attachments/assets/568c1816-641c-46d7-85f1-27066bfa5f77) | ![The same box with proper background.](https://github.com/user-attachments/assets/6e4ba284-d75c-420b-917c-03e8fa52b6ad) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
