### PR TITLE
fix(stack-overflow): fix background on askubuntu.com

### DIFF
--- a/styles/stack-overflow/catppuccin.user.less
+++ b/styles/stack-overflow/catppuccin.user.less
@@ -49,10 +49,6 @@
     }
   }
 
-  body {
-    background-image: none;
-  }
-
   #catppuccin(@flavor) {
     @rosewater: @catppuccin[@@flavor][@rosewater];
     @flamingo: @catppuccin[@@flavor][@flamingo];
@@ -474,6 +470,8 @@
       content: url("data:image/svg+xml,@{svg}");
     }
     &:has([alt="Ask Ubuntu"]) {
+      background-image: none;
+
       .site-header {
         background: @accent;
       }

--- a/styles/stack-overflow/catppuccin.user.less
+++ b/styles/stack-overflow/catppuccin.user.less
@@ -49,6 +49,10 @@
     }
   }
 
+  body {
+    background-image: none;
+  }
+
   #catppuccin(@flavor) {
     @rosewater: @catppuccin[@@flavor][@rosewater];
     @flamingo: @catppuccin[@@flavor][@flamingo];
@@ -106,10 +110,6 @@
     --ctp-crust: @crust;
 
     color-scheme: if(@flavor = latte, light, dark);
-
-    body {
-      background-image: none;
-    }
 
     ::selection {
       background-color: fade(@accent, 30%);

--- a/styles/stack-overflow/catppuccin.user.less
+++ b/styles/stack-overflow/catppuccin.user.less
@@ -107,6 +107,10 @@
 
     color-scheme: if(@flavor = latte, light, dark);
 
+    body {
+      background-image: none;
+    }
+
     ::selection {
       background-color: fade(@accent, 30%);
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

askubuntu.com has repeating gray dots in its background:
![image](https://github.com/user-attachments/assets/0df79136-2424-4677-8b9e-cb9c3a611124)

The current userstyle does not take these into account. This results in a horrible contrast throughout the entire background:
![image](https://github.com/user-attachments/assets/db5b6592-32e5-4a39-b884-72d4767ee6d8)

This fix removes the dots (which are implemented as a repeating 4x4 pixel image), setting the background-image of the body to `none` which does not affect the normal stackoverflow website but removes the pattern on askubuntu.com:
![image](https://github.com/user-attachments/assets/327be59a-274a-48a0-8a2b-3c48285e5884)


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
