### PR TITLE
fix(wikipedia): unset `--background-color-base-fixed` var

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -229,7 +229,6 @@
     --background-color-backdrop-light: rgba(0, 0, 0, 0.65);
     --background-color-backdrop-dark: rgba(255, 255, 255, 0.65);
     --background-color-base: @base;
-    --background-color-base-fixed: @base;
     --background-color-neutral: @base;
     --background-color-neutral-subtle: @surface0;
     --background-color-inverted: @text;


### PR DESCRIPTION
Leads to image backgrounds like at https://en.wikipedia.org/wiki/Chernobyl_New_Safe_Confinement#Structural_design not having contrast. I think the default (#fff or something) is good, this change doesn't seem to affect anything else.