### PR TITLE
fix(youtube): new ui header background

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 2025.04.20
+@version 2025.04.22
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube
@@ -423,7 +423,7 @@
       --iron-icon-fill-color: @text !important;
     }
 
-    #background.ytd-masthead {
+    #frosted-glass {
       --yt-frosted-glass-desktop: @base !important;
     }
 

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -423,6 +423,7 @@
       --iron-icon-fill-color: @text !important;
     }
 
+    #background.ytd-masthead,
     #frosted-glass {
       --yt-frosted-glass-desktop: @base !important;
     }

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/youtube
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/youtube
-@version 2025.04.22
+@version 2025.04.20
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/youtube/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ayoutube
 @description Soothing pastel theme for YouTube


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes black header, closes #1533 

It's seems like a new `div#frosted-glass` was introduces on main page.
The old one is still required for other pages such as the history.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
