### PR TITLE
feat(youtube): optional sponsorblock recoloring

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -16,7 +16,7 @@
 
 @var checkbox logo "Enable YouTube logo" 1
 @var checkbox oled "Enable black bars" 0
-@var checkbox sponsorblock "Recolor SponsorBlock segments" 1
+@var checkbox sponsorBlock "Recolor SponsorBlock segments" 1
 ==/UserStyle== */
 
 @-moz-document domain("youtube.com") {
@@ -350,7 +350,7 @@
       --sb-grey-fg-color: @subtext0 !important;
       --sb-red-bg-color: @accent !important;
 
-      & when (@sponsorblock = 1) {
+      & when (@sponsorBlock = 1) {
         --sb-category-sponsor: @green;
         --sb-category-selfpromo: @yellow;
         --sb-category-exclusive_access: @teal;

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -16,7 +16,7 @@
 
 @var checkbox logo "Enable YouTube logo" 1
 @var checkbox oled "Enable black bars" 0
-@var checkbox sponsorBlock "Recolor SponsorBlock segments" 1
+@var checkbox sponsorBlock "Enable SponsorBlock segments" 1
 ==/UserStyle== */
 
 @-moz-document domain("youtube.com") {

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -16,6 +16,7 @@
 
 @var checkbox logo "Enable YouTube logo" 1
 @var checkbox oled "Enable black bars" 0
+@var checkbox sponsorblock "Recolor SponsorBlock segments" 1
 ==/UserStyle== */
 
 @-moz-document domain("youtube.com") {
@@ -349,16 +350,18 @@
       --sb-grey-fg-color: @subtext0 !important;
       --sb-red-bg-color: @accent !important;
 
-      --sb-category-sponsor: @green;
-      --sb-category-selfpromo: @yellow;
-      --sb-category-exclusive_access: @teal;
-      --sb-category-interaction: @mauve;
-      --sb-category-poi_highlight: @pink;
-      --sb-category-intro: @sky;
-      --sb-category-outro: @blue;
-      --sb-category-preview: @sapphire;
-      --sb-category-filler: @lavender;
-      --sb-category-music_offtopic: @peach;
+      & when (@sponsorblock = 1) {
+        --sb-category-sponsor: @green;
+        --sb-category-selfpromo: @yellow;
+        --sb-category-exclusive_access: @teal;
+        --sb-category-interaction: @mauve;
+        --sb-category-poi_highlight: @pink;
+        --sb-category-intro: @sky;
+        --sb-category-outro: @blue;
+        --sb-category-preview: @sapphire;
+        --sb-category-filler: @lavender;
+        --sb-category-music_offtopic: @peach;
+      }
     }
 
     &:not(.style-scope) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Makes recoloring SponsorBlock segments (from #1722) optional.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
