### PR TITLE
fix(canvas-lms): buttons & misc

### DIFF
--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -1894,9 +1894,11 @@
     .discussions-container__wrapper [class$="summaryText"] {
       color: @text;
     }
-    .ic-unread-badge__total-count,
     .ic-unread-badge__unread-count {
       color: @mantle;
+    }
+    .ic-unread-badge__total-count {
+      background-color: @surface1;
     }
     hr[data-testid="post-separator"] {
       border-color: @surface1 !important;

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -445,14 +445,6 @@
     .accent-button() {
       background-color: @accent;
       border-color: @surface1;
-      &:disabled {
-        filter: brightness(85%);
-      }
-      &:not(:disabled):hover {
-        > [class$="baseButton__content"] {
-          filter: brightness(115%);
-        }
-      }
       path[fill="#000000"] {
         fill: @mantle;
       }

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -1390,6 +1390,22 @@
     .quiz-header {
       border-color: @surface2;
     }
+
+    .attachment_wrapper {
+      [class$="fileDrop__labelContent"] {
+        border-color: @text;
+        &:hover {
+          border-color: @accent;
+        }
+      }
+      [class$="fileDrop__layout"] * {
+        background-color: transparent;
+      }
+      label > span::before {
+        border-color: @accent;
+      }
+    }
+
     .question.fill_in_multiple_blanks_question .answer_group,
     .question.multiple_dropdowns_question .answer_group {
       border-color: @surface1;
@@ -1587,9 +1603,6 @@
     .file-upload-submission {
       background-color: @surface0;
     }
-    /* #upload_media_tab { */
-    /*   img  */
-    /* } */
     .submission-details-header__heading-and-grades {
       border-color: @surface1;
     }
@@ -2308,6 +2321,7 @@
     .page-action-list a {
       border-bottom-color: @surface1;
     }
+
   }
 }
 

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -416,13 +416,10 @@
       }
     }
 
-    // .PlannerItem-styles__secondary button,
-    // .discussions-index-manage-menu > button,
     .searchButton__container button,
     span[type="button"],
     a:has(.css-1rpus1y-baseButton__content),
-    button:has(.css-1rpus1y-baseButton__content),
-    .testing {
+    button:has(.css-1rpus1y-baseButton__content) {
       .neutral-button();
     }
 
@@ -903,6 +900,12 @@
     }
 
     /* color picker menu (e.g. on dashboard) */
+    .ColorPicker__Actions button[class$="baseButton"]:not([id$="Apply"]) {
+      .neutral-button();
+    }
+    #ColorPicker__Apply {
+      .accent-button();
+    }
     span[data-position-content^="Popover"]:has(
       div[class$="view-tabs__container"]
     ) {
@@ -926,12 +929,6 @@
       label span {
         color: @subtext0;
       }
-    }
-    .ColorPicker__Actions button[class$="baseButton"]:not([id$="Apply"]) {
-      .neutral-button();
-    }
-    #ColorPicker__Apply {
-      .accent-button();
     }
 
     span[data-testid="RCE_RestoreAutoSaveModal"] {
@@ -2352,8 +2349,7 @@
     .page-action-list a {
       border-bottom-color: @surface1;
     }
-
-
+  }
 }
 
 /* deno-fmt-ignore */

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -73,6 +73,9 @@
         color: @subtext0 !important;
       }
     }
+    textarea + span[class$="textArea__outline"] {
+      border-color: @accent;
+    }
 
     /* GLOBALS/VARIABLES */
     --ic-brand-primary: @accent;
@@ -199,7 +202,12 @@
 
     a[class$="link"]:not(.btn, .ic-DashboardCard__link),
     a[class$="link"] > span,
-    button[class$="link"]:not(.btn),
+    button[class$="link"]:not(.btn) {
+      color: @blue;
+      &:focus {
+        outline-color: @accent;
+      }
+    }
     a.external span {
       color: @blue;
     }
@@ -223,13 +231,17 @@
     /* fullscreen background for modal popups */
     body > span > span[class*="mask"] {
       background-color: fade(@overlay0, 75%);
+      /* modals */
       > span {
         color: @text;
         background-color: @base;
         border-color: @surface1;
-        > div[class$="modalHeader"] {
+        div[class$="modalHeader"] {
           background-color: transparent;
           border-color: @surface1;
+          button:has(svg[name="IconX"]) {
+            .flush-button();
+          }
         }
         img {
           background-color: transparent;
@@ -291,7 +303,13 @@
         .menu-item__text {
           background-color: transparent;
         }
+        .ic-app-header__menu-list-link:focus {
+          box-shadow: inset 0 0 0 .125rem @base,inset 0 0 0 .25rem var(--ic-brand-global-nav-menu-item__text-color--active);
+        }
       }
+    }
+    .ic-app-header__menu-list-link:focus {
+      box-shadow: inset 0 0 0 .125rem @surface1, inset 0 0 0 .25rem @surface2;
     }
     --ic-brand-global-nav-menu-item__text-color--active: @accent;
     --ic-brand-global-nav-menu-item__badge-text--active: @mantle;
@@ -396,6 +414,9 @@
 
     /* filled-in buttons - this auto-generated class covers a lot of them */
     .neutral-button() {
+      color: @text;
+      background-color: @surface0;
+      border-color: @surface1;
       &:hover {
         background-color: @hover-button;
         > [class$="baseButton__content"] {
@@ -629,13 +650,20 @@
     }
 
     /* checkboxes */
-    input:not(:checked) + label span[class$="checkboxFacade__facade"] {
+    [class$="checkboxFacade__facade"] {
+      &::before {
+        border-color: @accent;
+      }
+    }
+    input + label span[class$="checkboxFacade__facade"] {
       border-color: @surface2;
       background-color: @base;
     }
-    /* input:checked + label span[class$="checkboxFacade__facade"] { */
-    /*   background-color: @surface2; */
-    /* } */
+    input:checked + label span[class$="checkboxFacade__facade"] {
+      border-color: @surface2;
+      background-color: @text;
+      color: @base;
+    }
     input + label span[class$="label"] {
       color: @text;
     }
@@ -647,6 +675,9 @@
       border-color: @surface2;
       input {
         color: @text !important;
+      }
+      &::before {
+        border-color: @accent;
       }
     }
     select {
@@ -1288,6 +1319,9 @@
     button[data-testid="address-button"] {
       .neutral-button();
     }
+    svg[name="IconEmail"] {
+      color: @text;
+    }
 
     /* left side */
     [data-testid="conversation"] {
@@ -1376,9 +1410,9 @@
       border-color: @surface2;
     }
 
-    .attachment_wrapper {
+    span:has(> [class$="fileDrop__labelContent"]) {
       [class$="fileDrop__labelContent"] {
-        border-color: @text;
+        border-color: @overlay1;
         &:hover {
           border-color: @accent;
         }
@@ -2123,6 +2157,12 @@
         '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="36" viewBox="0 0 28 36"><title>folder</title><path d="M14.43 10.81 11.23 6H.43v21.58A2.4 2.4 0 0 0 2.82 30h22.36a2.4 2.4 0 0 0 2.4-2.4V10.81ZM26 27.58a.8.8 0 0 1-.8.8H2.82a.8.8 0 0 1-.8-.8v-20h8.35l2.13 3.19H3.62v1.6H26Z" fill="@{text}" fill-rule="evenodd"/></svg>'
       );
       background-image: url("data:image/svg+xml,@{svg}");
+    }
+    .ef-big-icon {
+      filter: @text-filter;
+    }
+    .al-trigger-gray {
+      color: @overlay1;
     }
 
     /* CHAT */

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -755,6 +755,9 @@
     .ic-item-row__meta-content-timestamp > p {
       color: @subtext0;
     }
+    #mark_all_announcement_read {
+      .neutral-button();
+    }
 
     /* DASHBOARD */
     .StickyButton-styles__root {
@@ -1851,6 +1854,19 @@
         color: @text;
       }
     }
+
+    #DrawerLayoutTray {
+      /* split screen layout */
+      background-color: @base;
+      border-color: @surface1;
+    }
+    button:has(svg[name="IconX"]) {
+      .flush-button();
+    }
+    button:has(svg[name="IconMore"]) {
+      .flush-button();
+    }
+
     .communication_message {
       border-color: @surface1;
     }
@@ -1891,6 +1907,30 @@
     }
     #add_discussion {
       .accent-button();
+    }
+    .discussions-editor + div {
+      button[data-testid="attach-btn"] {
+        .flush-button();
+      }
+      .discussions-editor-cancel button {
+        .neutral-button();
+      }
+      .discussions-editor-submit button {
+        .accent-button();
+      }
+    }
+    .discussion-topic-reply-button button {
+      .accent-button();
+    }
+    .discussion-post-manage-discussion button {
+      .flush-button;
+    }
+    .discussion-post-subscribe button {
+      .flush-button();
+    }
+    button[data-testid="splitscreenButton"],
+    button[data-testid="ExpandCollapseThreads-button"] {
+      .neutral-button();
     }
 
     /* author profile picture placeholder */

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -505,11 +505,20 @@
       &:active {
         background-color: darken(@hover-button, 3%);
       }
-      &.active,
-      &.Button--active {
+      &.active, &.Button--active {
         background-color: @subtext0;
         border-color: lighten(@surface1, 10%);
         color: @mantle;
+      }
+    }
+
+    .btn-link,
+    .Button--link {
+      &.active, &.Button--active, &.ui-button.ui-state-active, &:active {
+        background: @surface0;
+      }
+      &.disabled, &.ui-button.ui-state-disabled, &[disabled] {
+        background: transparent;
       }
     }
 
@@ -527,27 +536,9 @@
     --ic-brand-button--primary-bgd-darkened-5: darken(@accent, 5%);
     --ic-brand-button--primary-bgd-darkened-15: darken(@accent, 15%);
 
-    .btn-link.active,
-    .btn-link.Button--active,
-    .btn-link.ui-button.ui-state-active,
-    .btn-link:active,
-    .Button--link.active,
-    .Button--link.Button--active,
-    .Button--link.ui-button.ui-state-active,
-    .Button--link:active
     .ui-progressbar .btn-link.ui-button.ui-widget-header,
     .ui-progressbar .Button--link.ui-button.ui-widget-header {
       background: @surface0;
-    }
-
-    .btn-link.disabled,
-    .btn-link.ui-button.ui-state-disabled,
-    .btn-link[disabled],
-    .Button--link.disabled,
-    .Button--link.ui-button.ui-state-disabled,
-    .Button--link[disabled] {
-      color: var(--ic-brand-font-color-dark);
-      background: transparent;
     }
 
     .btn-published,

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -1860,10 +1860,10 @@
       background-color: @base;
       border-color: @surface1;
     }
-    button:has(svg[name="IconX"]) {
+    button[class$="baseButton"]:has(svg[name="IconX"]) {
       .flush-button();
     }
-    button:has(svg[name="IconMore"]) {
+    button[class$="baseButton"]:has(svg[name="IconMore"]) {
       .flush-button();
     }
 

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -59,7 +59,7 @@
     @blue-filter: @catppuccin-filters[@@flavor][@blue];
     @green-filter: @catppuccin-filters[@@flavor][@green];
     @yellow-filter: @catppuccin-filters[@@flavor][@yellow];
-    @surface2-filter: @catppuccin-filters[@@flavor][@surface2];
+    @surface1-filter: @catppuccin-filters[@@flavor][@surface1];
 
     color-scheme: if(@flavor = latte, light, dark);
 
@@ -876,13 +876,10 @@
     }
 
     /* popup menus */
-    /* extra selectors are to avoid styling tooltips because their arrows are hard to style */
-    span[data-position-content^="Menu"]:not(
-      [data-position-content^="Menu__label"]
-    ),
+    span[data-position-content^="Menu"],
     span[data-position-content^="Popover"] {
-      span[class$="arrow"]::after {
-        filter: @surface2-filter;
+      span[class$="arrow"] {
+        filter: @surface1-filter;
       }
       > span {
         color: @text;
@@ -1009,13 +1006,11 @@
     }
 
     /* dropdown menu */
-    span[data-position-content^="Menu"]:not(
-      [data-position-content^="Menu__label"]
-    ) {
+    span[data-position-content^="Menu___"] {
       span {
         color: @text;
       }
-      ul[role="menu"] {
+      [role="menu"] {
         &::before {
           border-color: @accent;
         }

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -304,12 +304,15 @@
           background-color: transparent;
         }
         .ic-app-header__menu-list-link:focus {
-          box-shadow: inset 0 0 0 .125rem @base,inset 0 0 0 .25rem var(--ic-brand-global-nav-menu-item__text-color--active);
+          box-shadow:
+            inset 0 0 0 0.125rem @base,
+            inset 0 0 0 0.25rem
+            var(--ic-brand-global-nav-menu-item__text-color--active);
         }
       }
     }
     .ic-app-header__menu-list-link:focus {
-      box-shadow: inset 0 0 0 .125rem @surface1, inset 0 0 0 .25rem @surface2;
+      box-shadow: inset 0 0 0 0.125rem @surface1, inset 0 0 0 0.25rem @surface2;
     }
     --ic-brand-global-nav-menu-item__text-color--active: @accent;
     --ic-brand-global-nav-menu-item__badge-text--active: @mantle;
@@ -461,14 +464,9 @@
       }
     }
 
-    .searchButton__container button,
     span[type="button"] {
       .neutral-button();
     }
-    // a:has(.css-1rpus1y-baseButton__content),
-    // button:has(.css-1rpus1y-baseButton__content) {
-    //   .neutral-button();
-    // }
 
     /* this is for buttons that have no border/background until hovered */
     .flush-button() {
@@ -493,8 +491,6 @@
         color: @text;
       }
     }
-
-
 
     /* the below styles are taken from canvas's common css sheet */
     .btn:not(.btn-primary, .btn-link),
@@ -636,16 +632,20 @@
       border-color: @accent;
     }
 
-
     .ActionButtons button[id^="Drilldown"] {
       .accent-button();
     }
 
-    .Button--icon-action:hover,.Button--icon-action-danger:hover,.Button--icon-action-rev:hover,.Button--icon-action:focus,.Button--icon-action-danger:focus,.Button--icon-action-rev:focus {
+    .Button--icon-action:hover,
+    .Button--icon-action-danger:hover,
+    .Button--icon-action-rev:hover,
+    .Button--icon-action:focus,
+    .Button--icon-action-danger:focus,
+    .Button--icon-action-rev:focus {
       background: transparent !important;
     }
 
-    .btn-primary:focus,.Button--primary:focus {
+    .btn-primary:focus, .Button--primary:focus {
       box-shadow: inset 0 0 0 2px @crust;
     }
 
@@ -1885,6 +1885,7 @@
     hr[data-testid="post-separator"] {
       border-color: @surface1 !important;
     }
+    .searchButton__container button,
     .discussions-index-manage-menu > button {
       .neutral-button();
     }
@@ -2028,7 +2029,6 @@
         }
       }
     }
-
 
     #grades_summary {
       th.title {

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -416,22 +416,13 @@
       }
     }
 
-    .PlannerItem-styles__secondary button,
-    .discussions-index-manage-menu > button,
-    span[type="button"],
-    [data-testid="compose-modal-desktop"]
-      button[class$="baseButton"]:not([data-testid="send-button"]),
-    #immersive_reader_mount_point button,
-    #immersive_reader_mobile_mount_point button,
-    .ColorPicker__Actions button[class$="baseButton"]:not([id$="Apply"]),
-    #grades_summary a[role="button"],
-    #planner-today-btn,
-    form[action="/logout"] button,
-    button[data-testid="address-button"],
-    button[data-testid="gradebook-settings-button"],
+    // .PlannerItem-styles__secondary button,
+    // .discussions-index-manage-menu > button,
     .searchButton__container button,
+    span[type="button"],
     a:has(.css-1rpus1y-baseButton__content),
-    button:has(.css-1rpus1y-baseButton__content) {
+    button:has(.css-1rpus1y-baseButton__content),
+    .testing {
       .neutral-button();
     }
 
@@ -641,10 +632,7 @@
       }
     }
 
-    #apply_select_menus,
-    #ColorPicker__Apply,
-    .ActionButtons button[id^="Drilldown"],
-    #send-message-button {
+    .ActionButtons button[id^="Drilldown"] {
       .accent-button();
     }
 
@@ -782,6 +770,10 @@
         color: @subtext0;
       }
     }
+    #planner-today-btn,
+    .PlannerItem-styles__secondary button {
+      .neutral-button();
+    }
 
     .CompletedItemsFacade-styles__root {
       border-color: @surface1;
@@ -868,6 +860,9 @@
         border-color: @surface1;
       }
     }
+    form[action="/logout"] button {
+      .neutral-button();
+    }
     .PlannerHeader [id^="Badge"] {
       background-color: @accent;
       color: @crust;
@@ -931,6 +926,12 @@
       label span {
         color: @subtext0;
       }
+    }
+    .ColorPicker__Actions button[class$="baseButton"]:not([id$="Apply"]) {
+      .neutral-button();
+    }
+    #ColorPicker__Apply {
+      .accent-button();
     }
 
     span[data-testid="RCE_RestoreAutoSaveModal"] {
@@ -1313,6 +1314,9 @@
         }
       }
     }
+    button[data-testid="address-button"] {
+      .neutral-button();
+    }
 
     /* left side */
     [data-testid="conversation"] {
@@ -1321,6 +1325,9 @@
         color: @text;
         background-color: @surface1;
       }
+    }
+    #send-message-button {
+      .accent-button();
     }
     #inbox-conversation-holder > div > div > div {
       /* each email entry */
@@ -1373,6 +1380,9 @@
       }
       span[data-testid="past-messages"] div[class$="view"] {
         border-color: @surface1;
+      }
+      button[class$="baseButton"]:not([data-testid="send-button"]) {
+        .neutral-button();
       }
     }
 
@@ -1867,6 +1877,9 @@
     hr[data-testid="post-separator"] {
       border-color: @surface1 !important;
     }
+    .discussions-index-manage-menu > button {
+      .neutral-button();
+    }
 
     /* author profile picture placeholder */
     [data-testid="author_avatar"] {
@@ -2005,12 +2018,16 @@
       }
     }
 
+
     #grades_summary {
       th.title {
         border-color: @surface1;
       }
       tr.final_grade {
         border-color: @surface2;
+      }
+      a[role="button"] {
+        .neutral-button();
       }
     }
 
@@ -2031,6 +2048,12 @@
         color: @text;
         background-color: @surface0;
       }
+    }
+    #apply_select_menus {
+      .accent-button();
+    }
+    #GradeSummarySelectMenuGroup label > span {
+      color: @text;
     }
 
     /* PEOPLE */
@@ -2064,6 +2087,11 @@
     #syllabus tr.detail_list td.not_last {
       border-color: @surface0;
     }
+    #immersive_reader_mount_point button,
+    #immersive_reader_mobile_mount_point button {
+      .neutral-button();
+    }
+
     .mini_calendar {
       .day {
         color: @subtext0;
@@ -2211,6 +2239,9 @@
     .ui-widget-header {
       color: @subtext1;
     }
+    button[data-testid="gradebook-settings-button"] {
+      .neutral-button();
+    }
     #gradebook-assignment-search,
     #gradebook-student-search {
       label span {
@@ -2322,7 +2353,7 @@
       border-bottom-color: @surface1;
     }
 
-  }
+
 }
 
 /* deno-fmt-ignore */

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -492,63 +492,42 @@
       }
     }
 
-    /* the below styles are taken from canvas's common css sheet */
     .btn:not(.btn-primary, .btn-link),
     .Button:not(.Button--link, .Button--primary),
     .ui-button {
       background-color: @surface0;
       color: @text;
       border-color: @surface1;
+      &:focus {
+        color: @text;
+      }
+      &:hover {
+        background-color: @hover-button;
+        color: @text;
+      }
+      &.ui-state-hover {
+        background-color: @hover-button;
+        color: @text;
+        border-color: darken(@surface1, 5%);
+      }
+      &:active {
+        background-color: darken(@hover-button, 3%);
+      }
+      &.active,
+      &.Button--active {
+        background-color: @subtext0;
+        border-color: lighten(@surface1, 10%);
+        color: @mantle;
+      }
     }
 
-    .btn:not(.btn-primary, .btn-link):focus,
-    .Button:not(.Button--link, .Button--primary):focus,
-    .ui-button:focus {
-      color: @text;
-    }
-
-    .btn:not(.btn-primary, .btn-link):hover,
-    .Button:not(.Button--link, .Button--primary):hover,
-    .ui-button:hover {
-      background-color: @hover-button;
-      color: @text;
-    }
-
-    .btn:not(.btn-primary, .btn-link):hover.ui-state-hover,
-    .Button:not(.Button--link, .Button--primary):hover.ui-state-hover,
-    .ui-button:hover.ui-state-hover {
-      background-color: @hover-button;
-      color: @text;
-      border-color: darken(@surface1, 5%);
-    }
-
-    .btn:not(.btn-primary, .btn-link).active,
-    .btn:not(.btn-primary, .btn-link).Button--active,
-    .Button:not(.Button--link, .Button--primary).active,
-    .active.ui-button,
-    .Button:not(.Button--link, .Button--primary).Button--active,
-    .Button--active.ui-button,
+    /* the below styles are taken from canvas's common css sheet */
     .ui-button.ui-state-active:hover,
     .ui-button.ui-state-active,
     .ui-progressbar .ui-button.ui-widget-header {
       background-color: @subtext0;
       border-color: lighten(@surface1, 10%);
       color: @mantle;
-    }
-
-    .btn:not(.btn-primary, .btn-link):active,
-    .Button:not(.Button--link, .Button--primary):active,
-    .ui-button:active {
-      background-color: darken(@hover-button, 3%);
-    }
-
-    .btn-link,
-    .btn-link:active,
-    .btn-link[disabled],
-    .Button--link,
-    .Button--link:active,
-    .Button--link[disabled] {
-      background: transparent;
     }
 
     --ic-brand-button--primary-bgd: @accent;
@@ -559,16 +538,14 @@
     .btn-link.active,
     .btn-link.Button--active,
     .btn-link.ui-button.ui-state-active,
-    .ui-progressbar .btn-link.ui-button.ui-widget-header,
     .btn-link:active,
     .Button--link.active,
     .Button--link.Button--active,
     .Button--link.ui-button.ui-state-active,
-    .ui-progressbar .Button--link.ui-button.ui-widget-header,
-    .Button--link:active {
+    .Button--link:active
+    .ui-progressbar .btn-link.ui-button.ui-widget-header,
+    .ui-progressbar .Button--link.ui-button.ui-widget-header {
       background: @surface0;
-      border-color: transparent;
-      color: var(--ic-link-color);
     }
 
     .btn-link.disabled,

--- a/styles/canvas-lms/catppuccin.user.less
+++ b/styles/canvas-lms/catppuccin.user.less
@@ -90,6 +90,7 @@
     @hover-regular: fade(@surface2, 50%);
     @hover-accent: mix(@base, @accent, 70%);
     @hover-button: @surface1;
+    @hover-flush-button: fade(@surface1, 30%);
 
     /* GENERAL UI CHANGES */
 
@@ -236,6 +237,9 @@
         > div[class$="modalFooter"] {
           background-color: @surface0;
           border-color: @surface1;
+          button {
+            .neutral-button();
+          }
         }
       }
     }
@@ -399,9 +403,6 @@
         }
         color: @text;
       }
-      color: @text;
-      background-color: @surface0;
-      border-color: @surface1;
       path[fill="#000000"] {
         fill: @text;
       }
@@ -416,48 +417,99 @@
       }
     }
 
-    .searchButton__container button,
-    span[type="button"],
-    a:has(.css-1rpus1y-baseButton__content),
-    button:has(.css-1rpus1y-baseButton__content) {
-      .neutral-button();
+    /* this is for buttons that are accent-colored */
+    .accent-button() {
+      background-color: @accent;
+      border-color: @surface1;
+      &:disabled {
+        filter: brightness(85%);
+      }
+      &:not(:disabled):hover {
+        > [class$="baseButton__content"] {
+          filter: brightness(115%);
+        }
+      }
+      path[fill="#000000"] {
+        fill: @mantle;
+      }
+      > [class$="baseButton__content"] {
+        transition-property: all;
+        color: @mantle;
+        background-color: @accent;
+        border-color: @surface1;
+      }
     }
 
+    .searchButton__container button,
+    span[type="button"] {
+      .neutral-button();
+    }
+    // a:has(.css-1rpus1y-baseButton__content),
+    // button:has(.css-1rpus1y-baseButton__content) {
+    //   .neutral-button();
+    // }
+
+    /* this is for buttons that have no border/background until hovered */
+    .flush-button() {
+      color: @text;
+      background-color: transparent;
+      border-color: transparent;
+      &:hover {
+        background-color: @hover-flush-button;
+        > [class$="baseButton__content"] {
+          background-color: @hover-flush-button;
+        }
+        color: @text;
+      }
+      path[fill="#000000"] {
+        fill: @text;
+      }
+      > [class$="baseButton__content"] {
+        color: @text;
+        transition-property: background, transform, filter;
+      }
+      [class$="text"] {
+        color: @text;
+      }
+    }
+
+
+
     /* the below styles are taken from canvas's common css sheet */
-    .btn,
-    .Button,
+    .btn:not(.btn-primary, .btn-link),
+    .Button:not(.Button--link, .Button--primary),
     .ui-button {
       background-color: @surface0;
       color: @text;
       border-color: @surface1;
     }
 
-    .btn:focus,
-    .Button:focus,
+    .btn:not(.btn-primary, .btn-link):focus,
+    .Button:not(.Button--link, .Button--primary):focus,
     .ui-button:focus {
       color: @text;
     }
 
-    .btn:hover,
-    .Button:hover,
+    .btn:not(.btn-primary, .btn-link):hover,
+    .Button:not(.Button--link, .Button--primary):hover,
     .ui-button:hover {
       background-color: @hover-button;
       color: @text;
     }
 
-    .btn:hover.ui-state-hover,
-    .Button:hover.ui-state-hover,
+    .btn:not(.btn-primary, .btn-link):hover.ui-state-hover,
+    .Button:not(.Button--link, .Button--primary):hover.ui-state-hover,
     .ui-button:hover.ui-state-hover {
       background-color: @hover-button;
       color: @text;
       border-color: darken(@surface1, 5%);
     }
 
-    .btn.active,
-    .btn.Button--active,
-    .Button.active,
+    .btn:not(.btn-primary, .btn-link).active,
+    .btn:not(.btn-primary, .btn-link).Button--active,
+    .Button:not(.Button--link, .Button--primary).active,
     .active.ui-button,
-    .Button.Button--active,
+    .Button:not(.Button--link, .Button--primary).Button--active,
     .Button--active.ui-button,
     .ui-button.ui-state-active:hover,
     .ui-button.ui-state-active,
@@ -467,8 +519,8 @@
       color: @mantle;
     }
 
-    .btn:active,
-    .Button:active,
+    .btn:not(.btn-primary, .btn-link):active,
+    .Button:not(.Button--link, .Button--primary):active,
     .ui-button:active {
       background-color: darken(@hover-button, 3%);
     }
@@ -482,55 +534,10 @@
       background: transparent;
     }
 
-    /* filled-in buttons with colored bg */
     --ic-brand-button--primary-bgd: @accent;
     --ic-brand-button--primary-text: @crust;
     --ic-brand-button--primary-bgd-darkened-5: darken(@accent, 5%);
     --ic-brand-button--primary-bgd-darkened-15: darken(@accent, 15%);
-    .btn-primary,
-    .Button--primary {
-      background: var(--ic-brand-button--primary-bgd);
-      color: var(--ic-brand-button--primary-text);
-      border-color: var(--ic-brand-button--primary-bgd-darkened-15);
-    }
-    .btn-primary.active,
-    .btn-primary.Button--active,
-    .btn-primary.ui-button.ui-state-active,
-    .ui-progressbar .btn-primary.ui-button.ui-widget-header,
-    .btn-primary:active,
-    .Button--primary.active,
-    .Button--primary.Button--active,
-    .Button--primary.ui-button.ui-state-active,
-    .ui-progressbar .Button--primary.ui-button.ui-widget-header,
-    .Button--primary:active {
-      background: var(--ic-brand-button--primary-bgd-darkened-5);
-    }
-    .btn-primary:hover,
-    .Button--primary:hover {
-      background: var(--ic-brand-button--primary-bgd-darkened-5);
-      color: var(--ic-brand-button--primary-text);
-    }
-    .btn-link,
-    .Button--link {
-      border-color: transparent;
-      cursor: pointer;
-      color: var(--ic-link-color);
-    }
-
-    .btn-link:hover:focus,
-    .Button--link:hover:focus {
-      color: var(--ic-link-color);
-    }
-    .btn-link:hover,
-    .Button--link:hover {
-      color: var(--ic-link-color-darkened-10);
-      background: transparent;
-    }
-
-    .btn-link:focus,
-    .Button--link:focus {
-      color: var(--ic-link-color);
-    }
 
     .btn-link.active,
     .btn-link.Button--active,
@@ -603,39 +610,22 @@
     }
     /* end of copy-pasted styles */
 
+    span[role="button"]::before, /* drag handle */
     :is(button, a)[class$="baseButton"]::before {
       border-color: @accent;
     }
 
-    .accent-button() {
-      &:disabled {
-        filter: brightness(85%);
-      }
-      &:not(:disabled):hover {
-        > [class$="baseButton__content"] {
-          filter: brightness(115%);
-        }
-      }
-      background-color: @accent;
-      border-color: @surface1;
-      path[fill="#000000"] {
-        fill: @mantle;
-      }
-      > [class$="baseButton__content"] {
-        transition-property: all;
-        color: @mantle;
-        background-color: @accent;
-        border-color: @surface1;
-      }
-    }
 
     .ActionButtons button[id^="Drilldown"] {
       .accent-button();
     }
 
-    .Button--icon-action,
-    .Button--icon-action-rev {
-      background-color: transparent;
+    .Button--icon-action:hover,.Button--icon-action-danger:hover,.Button--icon-action-rev:hover,.Button--icon-action:focus,.Button--icon-action-danger:focus,.Button--icon-action-rev:focus {
+      background: transparent !important;
+    }
+
+    .btn-primary:focus,.Button--primary:focus {
+      box-shadow: inset 0 0 0 2px @crust;
     }
 
     /* checkboxes */
@@ -796,10 +786,9 @@
         color: @text;
       }
     }
-    #DashboardOptionsMenu_Container svg {
-      color: @text;
+    #DashboardOptionsMenu_Container button {
+      .flush-button();
     }
-
     .ic-DashboardCard {
       background-color: @surface0;
       .ic-DashboardCard__header_content {
@@ -1293,17 +1282,7 @@
       background-color: @mantle;
       border-color: @surface2;
       button {
-        &::before {
-          /* on-click-outline */
-          border-color: var(--ic-link-color);
-        }
-        svg {
-          color: @text;
-        }
-        span {
-          background-color: @surface0;
-          border-color: @surface1;
-        }
+        .neutral-button();
       }
     }
     button[data-testid="address-button"] {
@@ -1317,9 +1296,6 @@
         color: @text;
         background-color: @surface1;
       }
-    }
-    #send-message-button {
-      .accent-button();
     }
     #inbox-conversation-holder > div > div > div {
       /* each email entry */
@@ -1341,9 +1317,7 @@
       }
       button[data-testid="visible-not-starred"],
       button[data-testid="visible-starred"] {
-        svg {
-          color: @text;
-        }
+        .flush-button();
       }
     }
     [data-testid="unread-badge"] span svg {
@@ -1354,27 +1328,36 @@
     }
 
     /* right side */
-    span:has(> #inbox-conversation-holder) + span > div > div {
-      border-color: @surface1;
+    span:has(> #inbox-conversation-holder) + span {
+      > div > div {
+        border-color: @surface1;
+      }
+      button {
+        .flush-button();
+      }
     }
     /* compose message overlay */
     span[data-testid="compose-modal-desktop"] {
       background-color: @surface0;
       border-color: @surface1;
-      span:has(> label[for^="TextArea"]) {
+      span[class$="view"]:has(label[for^="TextArea"]) {
         border-color: @surface1;
         textarea {
           color: @text;
-        }
-        span[class$="textArea__outline"] {
-          border-color: @accent;
         }
       }
       span[data-testid="past-messages"] div[class$="view"] {
         border-color: @surface1;
       }
-      button[class$="baseButton"]:not([data-testid="send-button"]) {
-        .neutral-button();
+      > div[class$="modalBody"] {
+        button {
+          .neutral-button();
+        }
+      }
+      > div[class$="modalFooter"] {
+        #send-message-button {
+          .accent-button();
+        }
       }
     }
 
@@ -1564,6 +1547,9 @@
     .module-sequence-footer .module-sequence-footer-content {
       background-color: @base;
       border-color: @surface1;
+      a {
+        .neutral-button();
+      }
     }
 
     /* submitting */
@@ -1842,12 +1828,8 @@
     }
     [data-testid="RCEStatusBar"] {
       color: @subtext0;
-      /* .css-1kjxjg4-view--inlineBlock-baseButton */
-      button > span {
-        color: @text;
-      }
-      button:hover > span {
-        background-color: fade(@surface0, 50%);
+      button {
+        .flush-button();
       }
       > span > div {
         border-color: @surface1 !important;
@@ -1871,6 +1853,9 @@
     }
     .discussions-index-manage-menu > button {
       .neutral-button();
+    }
+    #add_discussion {
+      .accent-button();
     }
 
     /* author profile picture placeholder */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Reorganizes button styling to not rely on autogenerated classnames as much
  - Mixins are used for easier organization
  - Some buttons that became unstyled with recent canvas css changes will now stay styled (hopefully)
  - Many buttons now look better/react properly to hover (modals, inbox, discussions, etc)
- Revises tooltip styling
- Styles the new file upload component on assignment submission
- misc:
  - Tooltip arrows are the proper color
  - Checkboxes are styled
  - Some icons are fixed

(It's pretty late for me but if preview screenshots are wanted, or if this PR should be split into pieces, I can do that later)

another thing to resolve: how should outlines on focused buttons/links/etc like these be colored:

![image](https://github.com/user-attachments/assets/9c524c7c-06c0-4325-b9a8-49fb22fef6fb)

![image](https://github.com/user-attachments/assets/35104256-3ebb-426b-8e88-a3fdbd9b9bef)

in canvas I think they just use blue for everything. since in this userstyle we have the extra accent color i'm not sure whether to use only `@blue` or only `@accent`.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).