### PR TITLE
fix(youtube): sidebar streaming indicator

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -105,6 +105,7 @@
       --yt-brand-light-red: @accent !important;
       --yt-spec-red-30: @peach !important;
       --yt-spec-red-70: @red !important;
+      --yt-spec-red-indicator: @red;
       --yt-spec-pale-blue: @sky !important;
       --yt-spec-light-blue: @sky !important;
       --yt-spec-dark-blue: @sapphire !important;

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -105,7 +105,7 @@
       --yt-brand-light-red: @accent !important;
       --yt-spec-red-30: @peach !important;
       --yt-spec-red-70: @red !important;
-      --yt-spec-red-indicator: @red;
+      --yt-spec-red-indicator: @accent !important;
       --yt-spec-pale-blue: @sky !important;
       --yt-spec-light-blue: @sky !important;
       --yt-spec-dark-blue: @sapphire !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

fixes unthemed streaming indicator in sidebar.

![before-image](https://github.com/user-attachments/assets/01d4b3d1-9d89-44cd-8b95-51b68627337c)

![after-image](https://github.com/user-attachments/assets/d27f7f0b-b559-468b-b210-101c34634e23)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
