### PR TITLE
fix(gmail): tab selector

### DIFF
--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -581,7 +581,7 @@
     }
     /* No drafts message, trash 30 days message */
     .TD,
-    .Tm .ya {
+    .Tm {
       background-color: @surface1;
       color: @text;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Gmail frontend has been updated. It disabled the tab selector with a new confused `classname`: `.Tm > .ya` → `.Tm > .aeF`. It's better to select the parent element `.Tm` directly.

It's promised that there's only one `.Tm` element.
![image](https://github.com/user-attachments/assets/251e4833-7278-4d53-b1a4-43f622757cf1)

### Before:

![image](https://github.com/user-attachments/assets/f412141a-b090-4579-857a-a16fdab972ad)


### After:

![image](https://github.com/user-attachments/assets/bc5ab0f7-7dff-43b8-aea6-86b7c1d52444)


<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [-] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
