### PR TITLE
chore(keybr.com): change category to `education`

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -442,7 +442,7 @@ userstyles:
   keybr.com:
     name: keybr.com
     link: https://keybr.com
-    categories: [productivity]
+    categories: [education]
     color: text
     current-maintainers: [*TadoTheMiner]
   keyoxide:


### PR DESCRIPTION
I was adding [catppuccin/keybr](https://github.com/catppuccin/keybr) and I think `education` makes more sense.
