### PR TITLE
fix(chatgpt): sidebar headers bg

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -154,6 +154,7 @@
       --sidebar-surface-primary: var(--gray-900);
       --sidebar-surface-secondary: var(--gray-800);
       --sidebar-surface-tertiary: var(--gray-700);
+      --bg-elevated-secondary: var(--gray-900);
       .popover,
       .dark,
       .dark .popover,
@@ -191,6 +192,7 @@
       --sidebar-surface-primary: var(--gray-100);
       --sidebar-surface-secondary: var(--gray-200);
       --sidebar-surface-tertiary: var(--gray-300);
+      --bg-elevated-secondary: var(--gray-100);
       .popover,
       .dark .popover,
       .dark.popover,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed sidebar header backgrounds

|**Before**|**After**|
|---|---|
|![image](https://github.com/user-attachments/assets/9d4b34a1-fecf-4388-a60c-d899f7708547)|![image](https://github.com/user-attachments/assets/2a6fb59b-ed29-42e3-915e-be63161e1556)|

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
