### PR TITLE
fix(pinterest): menus & saved pin info colors

### DIFF
--- a/styles/pinterest/catppuccin.user.less
+++ b/styles/pinterest/catppuccin.user.less
@@ -616,7 +616,7 @@
     button[aria-label="Pin Saved"] {
       // text
       .B1n {
-        color: @text;
+        color: var(--color-text-light);
       }
       // background
       .kJo {

--- a/styles/pinterest/catppuccin.user.less
+++ b/styles/pinterest/catppuccin.user.less
@@ -555,7 +555,7 @@
       background-color: transparent !important;
 
       div {
-        color: var(--color-text-light) !important;
+        color: if(@flavor = latte, var(--color-text-inverse), @text) !important;
       }
     }
 

--- a/styles/pinterest/catppuccin.user.less
+++ b/styles/pinterest/catppuccin.user.less
@@ -1153,6 +1153,15 @@
         background: @surface0;
       }
     }
+
+    // mobile mask
+    [data-test-id="mobile-signup-mask"] {
+      background-color: @base !important;
+      border-color: @base !important;
+      div[style*="border"] {
+        border-color: var(--color-border-container) !important;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes #1748 & saved pin info colors

| before | after |
|---|---|
| ![image](https://github.com/user-attachments/assets/e4037b22-b62b-4666-93a4-5d26b920d841) | ![image](https://github.com/user-attachments/assets/bda9944f-6d15-4007-9b86-7894cad886ab) |

mask/menus:
![image](https://github.com/user-attachments/assets/68eed9f1-1b02-4af0-85ca-56a0405b808a)



## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
