### PR TITLE
feat(zen-browser): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -919,4 +919,10 @@ userstyles:
     color: red
     current-maintainers: [*isabelroses, *uncenter]
     past-maintainers: [*elkrien]
+  zen-browser:
+    name: Zen Browser
+    link: https://zen-browser.app
+    categories: [browsers]
+    color: text
+    current-maintainers: [*ashish0kumar]
 # yaml-language-server: $schema=userstyles.schema.json

--- a/styles/zen-browser/catppuccin.user.less
+++ b/styles/zen-browser/catppuccin.user.less
@@ -1,0 +1,122 @@
+/* ==UserStyle==
+@name Zen Browser Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/zen-browser
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/zen-browser
+@version 2025.05.13
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/zen-browser/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Azen-browser
+@description Soothing pastel theme for Zen Browser
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain("zen-browser.app") {
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  :root[data-theme="dark"],
+  :root.dark {
+    #catppuccin(@darkFlavor);
+  }
+  :root {
+    #catppuccin(@lightFlavor);
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    --zen-paper: @mantle !important;
+    --zen-dark: @subtext1 !important;
+
+    --color-fd-background: @mantle !important;
+    --color-fd-popover: @mantle !important;
+    --color-fd-secondary: @base !important;
+    --color-fd-accent: @surface0 !important;
+    --color-fd-card: @crust !important;
+    --color-fd-border: @surface0 !important;
+    --color-fd-ring: @overlay0 !important;
+
+    --color-fd-primary: @peach !important;
+    --color-fd-muted: fade(@subtext1, 5%) !important;
+
+    --color-fd-foreground: @subtext1 !important;
+    --color-fd-accent-foreground: @subtext1 !important;
+    --color-fd-card-foreground: @subtext1 !important;
+    --color-fd-primary-foreground: @subtext1 !important;
+    --color-fd-secondary-foreground: @subtext1 !important;
+    --color-fd-popover-foreground: @subtext1 !important;
+    --color-fd-muted-foreground: @subtext1 !important;
+
+    --color-blue-500: @blue !important;
+    --color-red-500: @red !important;
+    --color-orange-500: @peach !important;
+
+    .text-coral {
+      color: @peach !important;
+    }
+
+    #nd-sidebar {
+      --color-fd-secondary: @base !important;
+      --color-fd-muted: fade(@subtext1, 5%) !important;
+      --color-fd-muted-foreground: @text !important;
+    }
+  }
+}
+
+/* deno-fmt-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+};


### PR DESCRIPTION
## 🎉 Theme for [Zen Browser](https://zen-browser.app) 🎉

Zen Browser is a free and open-source web browser for Windows, macOS, and Linux, forked from Mozilla Firefox. It prioritizes user privacy, extensive customizability, and a serene Browse experience. Designed with a focus on productivity and a clean aesthetic.

This port is built for [zen-browser.app](https://zen-browser.app) and its [docs.zen-browser.app](https://docs.zen-browser.app)

## Screenshot

### Website

|**Mocha**|**Macchiato**|
|---|---|
|![image](https://github.com/user-attachments/assets/d534274c-5f0b-4e31-8225-8bb0e8fd90b4)|![image](https://github.com/user-attachments/assets/5a5cebda-6db0-4bf5-b6ca-bc870b7e8f52)|

|**Frappe**|**Latte**|
|---|---|
|![image](https://github.com/user-attachments/assets/ee14dc30-b927-4af0-9a18-51ef3a6e1812)|![image](https://github.com/user-attachments/assets/c62d2243-d49d-4fe8-bd1f-b5771b203e3d)|

### Docs

|**Mocha**|**Macchiato**|
|---|---|
|![image](https://github.com/user-attachments/assets/713f8766-0db3-4060-92f3-e0347dcd7694)|![image](https://github.com/user-attachments/assets/7f4ab261-e074-4e40-bb03-79064ba3eee6)|

|**Frappe**|**Latte**|
|---|---|
|![image](https://github.com/user-attachments/assets/8cf9c0f5-2387-41ca-b55b-a265424221eb)|![image](https://github.com/user-attachments/assets/0f8d4d79-f09a-4b9a-9839-615b84188120)|

## 💬 Additional Comments 💬

As there was no immediately relevant category for browser website themes, the `browsers` category was used as a suitable option when adding the metadata for this port.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
