### PR TITLE
chore(nixos-manual): update nix-darwin url

### DIFF
--- a/styles/nixos-manual/catppuccin.user.less
+++ b/styles/nixos-manual/catppuccin.user.less
@@ -16,7 +16,7 @@
 ==/UserStyle== */
 
 @-moz-document url-prefix("https://nixos.org/manual/"),
-  url-prefix("https://daiderd.com/nix-darwin/manual/") {
+  url-prefix("https://nix-darwin.github.io/nix-darwin/manual/") {
   @import url("https://unpkg.com/@catppuccin/highlightjs@1.0.0/css/catppuccin-variables.important.css");
 
   :root {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

they moved nix-darwin to a org.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
