### PR TITLE
fix(cinny): prism syntax highlighting

### DIFF
--- a/styles/cinny/catppuccin.user.less
+++ b/styles/cinny/catppuccin.user.less
@@ -17,6 +17,7 @@
 
 @-moz-document domain("cinny.in") {
   @import url("https://prismjs.catppuccin.com/variables.important.css");
+  code .token { opacity: 1 !important; }
 
   :root,
   .silver-theme {

--- a/styles/cinny/catppuccin.user.less
+++ b/styles/cinny/catppuccin.user.less
@@ -16,6 +16,8 @@
 ==/UserStyle== */
 
 @-moz-document domain("cinny.in") {
+  @import url("https://prismjs.catppuccin.com/variables.important.css");
+
   :root,
   .silver-theme {
     #catppuccin(@lightFlavor);
@@ -54,6 +56,33 @@
     @mantle: @catppuccin[@@flavor][@mantle];
     @crust: @catppuccin[@@flavor][@crust];
     @accent: @catppuccin[@@flavor][@@accentColor];
+      
+    --ctp-rosewater: @rosewater;
+    --ctp-flamingo: @flamingo;
+    --ctp-pink: @pink;
+    --ctp-mauve: @mauve;
+    --ctp-red: @red;
+    --ctp-maroon: @maroon;
+    --ctp-peach: @peach;
+    --ctp-yellow: @yellow;
+    --ctp-green: @green;
+    --ctp-teal: @teal;
+    --ctp-sky: @sky;
+    --ctp-sapphire: @sapphire;
+    --ctp-blue: @blue;
+    --ctp-lavender: @lavender;
+    --ctp-text: @text;
+    --ctp-subtext1: @subtext1;
+    --ctp-subtext0: @subtext0;
+    --ctp-overlay2: @overlay2;
+    --ctp-overlay1: @overlay1;
+    --ctp-overlay0: @overlay0;
+    --ctp-surface2: @surface2;
+    --ctp-surface1: @surface1;
+    --ctp-surface0: @surface0;
+    --ctp-base: @base;
+    --ctp-mantle: @mantle;
+    --ctp-crust: @crust;
 
     color-scheme: if(@flavor = latte, light, dark);
 
@@ -190,7 +219,7 @@
       --oq6d07v: @surface1;
       --oq6d07w: @surface2;
       --oq6d07x: @overlay0;
-      --oq6d07y: @subtext0;
+      --oq6d07y: @text;
 
       --oq6d07z: fade(@green, 90%);
       --oq6d0710: fade(@green, 95%);
@@ -229,21 +258,6 @@
       --oq6d071t: fade(@text, 50%);
       --oq6d071u: @crust;
       --oq6d071v: fade(@crust, 60%);
-    }
-
-    /* Syntax highlighting */
-    body.prism-light,
-    &.prism-light,
-    &.prism-dark {
-      --prism-comment: @overlay2;
-      --prism-punctuation: @overlay2;
-      --prism-property: @yellow;
-      --prism-boolean: @peach;
-      --prism-selector: @green;
-      --prism-operator: @sky;
-      --prism-atrule: @mauve;
-      --prism-keyword: @mauve;
-      --prism-regex: @pink;
     }
 
     /* Search results */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Uses the proper Catppuccin port source for Prism syntax highlighting (https://github.com/catppuccin/userstyles/blob/main/docs/guide/syntax-highlighting.md) :)

| Before | After |
| --- | --- |
| ![CleanShot 2025-05-17 at 07 46 35](https://github.com/user-attachments/assets/c4f72d31-4529-4a1a-924d-4b79e6fa2218) | ![CleanShot 2025-05-17 at 07 45 45](https://github.com/user-attachments/assets/0e0e8548-55f8-45fa-8baa-bdc7ef03b61b) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
