### PR TITLE
fix(lichess): misc

### DIFF
--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -279,9 +279,9 @@
     }
 
     /* Chess Game */
-    .brown .is2d cg-board {
+    .is2d cg-board::before {
       @svg: escape(
-        '<svg shape-rendering="crispEdges" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="f"><g id="e"><g id="d"><g id="c"><path id="a" d="M0 0h1v1H0z" fill="@{subtext0}"/><use x="1" xlink:href="#a" y="1"/><path id="b" d="M0 1h1v1H0z" fill="@{crust}"/><use x="1" xlink:href="#b" y="-1"/></g><use x="2" xlink:href="#c"/></g><use x="4" xlink:href="#d"/></g><use xlink:href="#e" y="2"/></g><use xlink:href="#f" y="4"/></svg>'
+        '<svg shape-rendering="crispEdges" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="f"><g id="e"><g id="d"><g id="c"><path id="a" d="M0 0h1v1H0z" fill="@{accent}"/><use x="1" xlink:href="#a" y="1"/><path id="b" d="M0 1h1v1H0z" fill="@{surface0}"/><use x="1" xlink:href="#b" y="-1"/></g><use x="2" xlink:href="#c"/></g><use x="4" xlink:href="#d"/></g><use xlink:href="#e" y="2"/></g><use xlink:href="#f" y="4"/></svg>'
       );
       background-image: url("data:image/svg+xml,@{svg}") !important;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

### Board

- [x] Broken board background theming
- [ ] Piece inversion on latte/mocha (https://github.com/catppuccin/userstyles/pull/1625 equivalent, and maybe https://github.com/catppuccin/userstyles/pull/1605?)
- Squares:
  - [ ] Selected squares
  - [ ] Move dest(ination) squares
  - [ ] Last move squares
  - [x] Squares with circle shapes (from shift + click)
- [ ] Outdated/incorrectly colored piece SVGs?
- [ ] Contrast of board rank numbers

### UI

- [ ] Hamburger menu icon
- [ ] Hamburger menu headers/sections
- [ ] Settings menu item hovers
- [ ] Stockfish configuration buttons
- [ ] Sign in, register page (input borders, sign in button)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
