### PR TITLE
feat(proton): Proton Docs logo

### DIFF
--- a/styles/proton/catppuccin.user.less
+++ b/styles/proton/catppuccin.user.less
@@ -83,15 +83,17 @@
       }
 
       /* deno-fmt-ignore */
-      > path {
+      path {
         .replaceColor(#B8D7FF, fill);
         .replaceColor(#8F69FF, fill);
         .replaceColor(#6D4AFF, fill);
         .replaceColor(#FFBB93, fill);
+        .replaceColor(#85D4F5, fill);
+        .replaceColor(#D6F1FC, fill);
       }
 
       /* deno-fmt-ignore */
-      > defs stop {
+      defs stop {
         .replaceColor(#E3D9FF, stop-color);
         .replaceColor(#7341FF, stop-color);
         .replaceColor(#6D4AFF, stop-color);
@@ -122,6 +124,7 @@
         .replaceColor(#FA528E, stop-color);
         .replaceColor(#FF8065, stop-color);
         .replaceColor(#FFA51F, stop-color);
+        .replaceColor(#34B8EE, stop-color);
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

adds color replacements for Proton Docs logo
![Screenshot From 2025-05-25 14-23-11](https://github.com/user-attachments/assets/98d432df-c914-4d26-9333-4edc76c18b77)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
