### PR TITLE
fix(wikipedia): preferences checkboxes

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -389,10 +389,13 @@
     }
 
     /* OOUI */
-    .oo-ui-iconElement-icon,
     .oo-ui-indicator-down {
       filter: @text-filter !important;
     }
+      .oo-ui-image-invert.oo-ui-icon-check, .mw-ui-icon-check-invert::before {
+        @svg: escape('<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path d="M7 14.2 2.8 10l-1.4 1.4L7 17 19 5l-1.4-1.4z" fill="@{crust}"/></svg>');
+          background-image: url("data:image/svg+xml,@{svg}");
+      }
 
     /* View source */
     textarea {


### PR DESCRIPTION
They were being filtered before but this should unfilter them and use a check mark on the background with high contrast.

https://en.wikipedia.org/wiki/Special:Preferences