### PR TITLE
fix(cobalt): processing queue toast

### DIFF
--- a/styles/cobalt/catppuccin.user.less
+++ b/styles/cobalt/catppuccin.user.less
@@ -71,6 +71,7 @@
     --blue: @blue;
     --green: @green;
     --red: @maroon;
+    --medium-red: @red;
     --dark-red: @red;
     --white: @crust;
     --button: @surface0;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<img width="485" alt="image" src="https://github.com/user-attachments/assets/8405549c-9144-4583-a477-c2076e0bc6ce" />

Themes the `--medium-red` text shown in the above processing queue toast.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
