### PR TITLE
fix(github): higher specificity of auto/system theme selector

### DIFF
--- a/styles/github/catppuccin.user.less
+++ b/styles/github/catppuccin.user.less
@@ -22,7 +22,7 @@ regexp(
   domain("gist.github.com"),
   domain("docs.github.com"),
   domain("viewscreen.githubusercontent.com") {
-  [data-color-mode="auto"] {
+  [data-color-mode][data-color-mode="auto"] {
     @media (prefers-color-scheme: light) {
       &[data-light-theme="light"] {
         #catppuccin(@lightFlavor);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #1778 and supersedes #1779 (closes #1779).

As @sillowww [pointed out in Discord](https://discord.com/channels/907385605422448742/1030437391607025765/1380647724617306164), the issue can be reproduced on the "sync with system" appearance mode, even more specifically when you have prefers-color-scheme: dark. In that one specific scenario, GitHub's selectors target `data-color-mode][data-color-mode="auto"]`, unlike their light selectors and our userstyle's selectors that use just `[data-color-mode="auto"]`.

![CleanShot 2025-06-06 at 17 02 08](https://github.com/user-attachments/assets/6f20186b-e04c-4d47-aa7d-cbe8af6c0d65)

![CleanShot 2025-06-06 at 17 01 44](https://github.com/user-attachments/assets/7a1df36b-85ee-41cc-9a13-e5ab64afe252)

This fix copies their extra/redundant selector to increase the specificity and seems to correct the issue on my end.


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
