### PR TITLE
fix(twitch): live badge color

### DIFF
--- a/styles/twitch/catppuccin.user.less
+++ b/styles/twitch/catppuccin.user.less
@@ -18,7 +18,7 @@
 @-moz-document domain("twitch.tv") {
   @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
 
-  .tw-root--theme-dark {
+  .tw-root--theme-dark, .dark-theme {
     #catppuccin(@darkFlavor);
   }
   .tw-root--theme-light {
@@ -72,7 +72,8 @@
     }
 
     &,
-    .tw-dialog-layer {
+    .tw-dialog-layer,
+    [class*="ScLayoutCssVars-sc-"] {
       --color-background-input-focus: @crust;
       --color-background-interactable-hover: fade(@surface0, 48%);
       --color-background-interactable-alpha-hover: @surface0;
@@ -1251,6 +1252,24 @@
         color: if(@flavor = latte, @base, @text) !important;
       }
     }
+
+    article {
+      .tw-callout-message {
+        color: @base;
+      }
+      .tw-callout__close svg {
+        fill: @base !important;
+      }
+      div.tw-root--theme-dark {
+        .tw-callout-message {
+          color: @subtext0;
+        }
+
+        .tw-callout__close svg {
+          fill: @text !important;
+        }
+      }
+    }
   }
 }
 
@@ -1293,17 +1312,6 @@
 
     .edit-video-properties-modal__content {
       --color-background-float: @base;
-    }
-
-    article button {
-      --color-fill-current: @base !important;
-      --color-background-button-overlay: @base !important;
-      --color-background-button-overlay-hover: @base !important;
-      --color-background-button-icon-overlay-hover: fade(@base, 13%);
-      --color-background-button-overlay-primary-hover: fade(
-        @base,
-        13%
-      ) !important;
     }
 
     .simplebar-content {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #1783 

- Fixes Live badge color as well as other variables.
![image](https://github.com/user-attachments/assets/d0dcc20b-d226-4292-9221-cf82ac043676)

- Fixes balloon text color.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c2c87926-af99-4949-a206-558abf10d9ad) | ![image](https://github.com/user-attachments/assets/16e1fa2f-3f76-4464-bcf5-5b54ae895c6f) |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
