### PR TITLE
fix(claude): consistent code blocks

### DIFF
--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -113,7 +113,7 @@
     }
 
     /* Code blocks */
-    pre.code-block__code {
+    .code-block__code {
       background: @crust !important;
 
       code {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Claude uses both `pre` and `div` elements to display code blocks. Previously with the `pre.code-block__code` selector we were only changing the color of `pre` code blocks. This update makes sure `div` code blocks are selected as well.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
