### PR TITLE
fix(chatgpt): main bg

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -122,6 +122,10 @@
       background-color: @mantle;
     }
 
+    #main {
+      background-color: @base !important;   
+    }
+
     color: @text;
 
     @white: if(@flavor = latte, @crust, @text);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Fixes unthemed main background

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/7a209d99-7b4a-4510-bbe4-2a6b13b0753d)|![image](https://github.com/user-attachments/assets/354a36c8-831b-49f3-abb5-1b0ff6db5087)|

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
