### PR TITLE
fix: ChatGPT userstyle (Fixes background and collapsed sidebar)

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -446,6 +446,15 @@
     }
 
     /* Main message input box, popup menus, and dropdowns */
+    /* Background  */
+    main {
+      background-color: @base;
+    }
+
+    #stage-sidebar-tiny-bar {
+      background-color: @mantle;
+    }
+
     .bg-\[\#303030\],
     .dark\:bg-\[\#303030\],
     .dark\:bg-\[\#353535\] {


### PR DESCRIPTION
Background color was not applying

## 🔧 What does this fix? 🔧
Fixes unthemed background and sidebar in ChatGPT when the sidebar is closed.

Previously, some parts of the ChatGPT UI—specifically the main background area and the tiny sidebar when collapsed—did not correctly apply the Catppuccin Mocha colors. This update ensures consistent theming by explicitly targeting those elements.

## Before:
![image](https://github.com/user-attachments/assets/5a337ce2-aa17-41b1-9b9a-d532964a8b82)
## After:
![image](https://github.com/user-attachments/assets/32c06c75-c1a5-42f7-a85c-02036b7a1c6b)


<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
- [x] I used Catppuccin color variables (e.g., @base, @mantle, etc.).
