### PR TITLE
fix(youtube): player option tooltips

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -17,27 +17,14 @@
 @var checkbox logo "Enable YouTube logo" 1
 @var checkbox oled "Enable black bars" 0
 @var checkbox sponsorBlock "Enable SponsorBlock segments" 1
-@var checkbox systemTheme "Enable system theme" 0
 ==/UserStyle== */
 
 @-moz-document domain("youtube.com") {
-  & when (@systemTheme = 0) {
-    :root[dark] {
-      #catppuccin(@darkFlavor);
-    }
-    :root:not([dark]) {
-      #catppuccin(@lightFlavor);
-    }
+  :root[dark] {
+    #catppuccin(@darkFlavor);
   }
-
-  & when (@systemTheme = 1) {
-    :root {
-      #catppuccin(@lightFlavor);
-
-      @media(prefers-color-scheme: dark){
-        #catppuccin(@darkFlavor);
-      }
-    }
+  :root:not([dark]) {
+    #catppuccin(@lightFlavor);
   }
 
   #catppuccin(@flavor) {
@@ -1279,23 +1266,11 @@
 }
 
 @-moz-document url-prefix("https://studio.youtube.com") {
-  & when (@systemTheme = 0) {
-    :root[dark] {
-      #catppuccin(@darkFlavor);
-    }
-    :root {
-      #catppuccin(@lightFlavor);
-    }
+  :root[dark] {
+    #catppuccin(@darkFlavor);
   }
-
-  & when (@systemTheme = 1) {
-    :root {
-      #catppuccin(@lightFlavor);
-
-      @media(prefers-color-scheme: dark){
-        #catppuccin(@darkFlavor);
-      }
-    }
+  :root {
+    #catppuccin(@lightFlavor);
   }
 
   #catppuccin(@flavor) {
@@ -1457,23 +1432,11 @@
 }
 
 @-moz-document domain("m.youtube.com") {
-  & when (@systemTheme = 0) {
-    html[darker-dark-theme] {
-      #catppuccin(@darkFlavor);
-    }
-    html {
-      #catppuccin(@lightFlavor);
-    }
+  html[darker-dark-theme] {
+    #catppuccin(@darkFlavor);
   }
-
-  & when (@systemTheme = 1) {
-    html {
-      #catppuccin(@lightFlavor);
-
-      @media(prefers-color-scheme: dark){
-        #catppuccin(@darkFlavor);
-      }
-    }
+  html {
+    #catppuccin(@lightFlavor);
   }
 
   #catppuccin(@flavor) {

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -863,7 +863,7 @@
 
     /* Panels, popups, tooltips */
 
-    .ytp-tooltip-text {
+    .ytp-tooltip-bottom-text {
       background: fade(@surface0, 90%) !important;
       color: @text;
       text-shadow: none !important;

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -17,14 +17,27 @@
 @var checkbox logo "Enable YouTube logo" 1
 @var checkbox oled "Enable black bars" 0
 @var checkbox sponsorBlock "Enable SponsorBlock segments" 1
+@var checkbox systemTheme "Enable system theme" 0
 ==/UserStyle== */
 
 @-moz-document domain("youtube.com") {
-  :root[dark] {
-    #catppuccin(@darkFlavor);
+  & when (@systemTheme = 0) {
+    :root[dark] {
+      #catppuccin(@darkFlavor);
+    }
+    :root:not([dark]) {
+      #catppuccin(@lightFlavor);
+    }
   }
-  :root:not([dark]) {
-    #catppuccin(@lightFlavor);
+
+  & when (@systemTheme = 1) {
+    :root {
+      #catppuccin(@lightFlavor);
+
+      @media(prefers-color-scheme: dark){
+        #catppuccin(@darkFlavor);
+      }
+    }
   }
 
   #catppuccin(@flavor) {
@@ -1266,11 +1279,23 @@
 }
 
 @-moz-document url-prefix("https://studio.youtube.com") {
-  :root[dark] {
-    #catppuccin(@darkFlavor);
+  & when (@systemTheme = 0) {
+    :root[dark] {
+      #catppuccin(@darkFlavor);
+    }
+    :root {
+      #catppuccin(@lightFlavor);
+    }
   }
-  :root {
-    #catppuccin(@lightFlavor);
+
+  & when (@systemTheme = 1) {
+    :root {
+      #catppuccin(@lightFlavor);
+
+      @media(prefers-color-scheme: dark){
+        #catppuccin(@darkFlavor);
+      }
+    }
   }
 
   #catppuccin(@flavor) {
@@ -1432,11 +1457,23 @@
 }
 
 @-moz-document domain("m.youtube.com") {
-  html[darker-dark-theme] {
-    #catppuccin(@darkFlavor);
+  & when (@systemTheme = 0) {
+    html[darker-dark-theme] {
+      #catppuccin(@darkFlavor);
+    }
+    html {
+      #catppuccin(@lightFlavor);
+    }
   }
-  html {
-    #catppuccin(@lightFlavor);
+
+  & when (@systemTheme = 1) {
+    html {
+      #catppuccin(@lightFlavor);
+
+      @media(prefers-color-scheme: dark){
+        #catppuccin(@darkFlavor);
+      }
+    }
   }
 
   #catppuccin(@flavor) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This should fix #1766 as it has also been bothering me for a while.

It also adds a new settings called `systemTheme` that probably almost no one would find useful but its another thing that bothers me. Whenever you change your system theme from light/dark, you wont see it until you refresh the page or navigate to another one. Enabling this setting should follow the system theme. I think it could interfere if you have a preferred theme selected on youtube other than `Device theme`. Thats why its disabled by default.

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
