### PR TITLE
fix(mdn): use imported prismjs syntax highlighting

### DIFF
--- a/styles/mdn/catppuccin.user.less
+++ b/styles/mdn/catppuccin.user.less
@@ -44,6 +44,33 @@
   @crust: @catppuccin[@@flavor][@crust];
   @accent: @catppuccin[@@flavor][@@accentColor];
 
+  --ctp-rosewater: @rosewater;
+  --ctp-flamingo: @flamingo;
+  --ctp-pink: @pink;
+  --ctp-mauve: @mauve;
+  --ctp-red: @red;
+  --ctp-maroon: @maroon;
+  --ctp-peach: @peach;
+  --ctp-yellow: @yellow;
+  --ctp-green: @green;
+  --ctp-teal: @teal;
+  --ctp-sky: @sky;
+  --ctp-sapphire: @sapphire;
+  --ctp-blue: @blue;
+  --ctp-lavender: @lavender;
+  --ctp-text: @text;
+  --ctp-subtext1: @subtext1;
+  --ctp-subtext0: @subtext0;
+  --ctp-overlay2: @overlay2;
+  --ctp-overlay1: @overlay1;
+  --ctp-overlay0: @overlay0;
+  --ctp-surface2: @surface2;
+  --ctp-surface1: @surface1;
+  --ctp-surface0: @surface0;
+  --ctp-base: @base;
+  --ctp-mantle: @mantle;
+  --ctp-crust: @crust;
+
   color-scheme: if(@flavor = latte, light, dark);
 
   ::selection {
@@ -101,18 +128,6 @@
   --shadow-02: 0 1px 6px fade(@text, 20%);
   --focus-01: 0 0 0 3px fade(@text, 50%);
   --field-focus-border: @text;
-  --code-token-tag: @mauve;
-  --code-token-punctuation: @overlay2;
-  --code-token-attribute-name: @blue;
-  --code-token-attribute-value: @peach;
-  --code-token-comment: @overlay2;
-  --code-token-default: @text;
-  --code-token-selector: @lavender;
-  --code-token-class-selector: @yellow;
-  --code-token-pseudo-class: @pink;
-  --code-token-variable-2: @rosewater;
-  --code-token-at-rule: @flamingo;
-  --code-token-meta: @overlay1;
   --code-background-inline: @mantle;
   --code-background-block: @mantle;
   --notecard-link-color: @subtext1;
@@ -207,6 +222,8 @@
 }
 
 @-moz-document domain("developer.mozilla.org") {
+  @import url("https://prismjs.catppuccin.com/variables.css");
+
   .light {
     #catppuccin(@lightFlavor);
   }
@@ -228,6 +245,8 @@
 }
 
 @-moz-document domain("interactive-examples.mdn.mozilla.net") {
+  @import url("https://prismjs.catppuccin.com/variables.css");
+
   .theme-light {
     #catppuccin(@lightFlavor);
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Uses the syntax highlighting steps from https://github.com/catppuccin/userstyles/blob/main/docs/guide/syntax-highlighting.md to replace the somewhat inaccurate CSS variables used for token highlighting with an import to our accurate PrismJS port.

> [!NOTE]
> I'm not sure if it is necessary to import on `interactive-examples.mdn.mozilla.net`? I'm guessing not but I'm not sure what goes on there.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
