### PR TITLE
fix(archwiki): respect site-configured color scheme

### DIFF
--- a/styles/arch-wiki/catppuccin.user.less
+++ b/styles/arch-wiki/catppuccin.user.less
@@ -16,13 +16,24 @@
 ==/UserStyle== */
 
 @-moz-document domain("wiki.archlinux.org") {
-  :root {
+  :root.skin-theme-clientpref-os,
+  .vector-feature-night-mode-enabled,
+  .skin-invert,
+  .notheme {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);
     }
     @media (prefers-color-scheme: dark) {
       #catppuccin(@darkFlavor);
     }
+  }
+  
+  :root.skin-theme-clientpref-night {
+    #catppuccin(@darkFlavor);
+  }
+
+  :root.skin-theme-clientpref-day {
+    #catppuccin(@lightFlavor);
   }
 
   #catppuccin(@flavor) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

It uses some variables for automatic light/dark mode.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
