### PR TITLE
feat(google): added styling for AI Overview

### DIFF
--- a/styles/google/catppuccin.user.less
+++ b/styles/google/catppuccin.user.less
@@ -553,6 +553,117 @@
       }
     }
 
+    /* AI Overview */
+    .ULSxyf {
+      /* outermost container wrapping AI Overview */
+      .NN8h5c {
+        /* gradient when waiting for summary to be generated */
+        background-color: @base;
+      }
+      .RDmXvc {
+        /* AI summary continuation gradient */
+        background-image: linear-gradient(
+          transparent,
+          fade(@base, 90%) 52px,
+          @base 80px
+        );
+      }
+
+      /* Show More button */
+      .zNsLfb {
+        background-color: transparent;
+
+        .in7vHe.oQOpie.btku5b.fCrZyc.NQYJvc.FR7ZSc.qVhvac {
+          background-color: @surface0;
+          border-color: @surface1;
+
+          :hover {
+            background-color: @surface1 !important;
+            border-color: @surface1 !important;
+          }
+        }
+      }
+
+      /* Code examples */
+      .ecCNFc {
+        /* container */
+        border-color: fade(@blue, 50%);
+        background-color: @base;
+
+        .dDrxod {
+          /* header */
+          background-color: fade(@blue, 12%);
+          border-color: fade(@blue, 50%);
+          .x7ndcb {
+            /* text */
+            color: @text;
+          }
+
+          .hqI3tf.B4zsNc:hover .z1asCe.wm4nBd {
+            /* copy codeblock button */
+            color: @blue !important;
+          }
+        }
+        .QQjpRc {
+          /* body */
+          background-color: fade(@blue, 4%);
+          color: @text;
+        }
+      }
+
+      /* Code examples - inline */
+      .mv6bHd {
+        background-color: fade(@blue, 20%);
+        color: @text;
+      }
+
+      /* Source link button */
+      .niO4u {
+        background-color: @surface0 !important;
+        border-color: @surface1;
+      }
+      .BMebGe.btku5b.fCrZyc.LwdV0e.FR7ZSc.qVhvac.OJeuxf .niO4u:hover {
+        /* main button */
+        background-color: @surface1 !important;
+        border-color: @surface1;
+      }
+      /* Source text highlight */
+      .oXzekf > span:not([class]) {
+        background-color: fade(@blue, 15%);
+      }
+
+      /* Sources list - Right hand side */
+      .mv7LYc {
+        box-shadow: 0 4px 12px darken(@base, 10%);
+        .igcdNb {
+          background-color: fade(@blue, 15%);
+        }
+        .mNme1d.tNxQIb {
+          /* title */
+          color: @text !important;
+        }
+
+        .z1asCe.rzyADb:hover {
+          /* close sources list button */
+          color: @blue !important;
+        }
+      }
+
+      /* Rating buttons (thumb up/down) */
+      .cMkUmd[selected] {
+        background-color: fade(@blue, 30%);
+      }
+      .cMkUmd:hover {
+        background-color: fade(@blue, 15%);
+      }
+      .cMkUmd[selected],
+      .cMkUmd:hover {
+        .z1asCe {
+          color: @blue !important;
+        }
+      }
+    } /* AI Overview - END */
+
     /* AI search */
 
     .UxeQfc,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
Adds styling to the AI Overview section that provides site summary and code examples.

Closes #1528 

Example images with before and after both using Mocha as the darker themes have more of an issue with contrast with this section.

Before
<img height="400" alt="image" src="https://github.com/user-attachments/assets/92dda389-2c78-4446-8668-cf17b15da9fc" />

After
<img height="400" alt="image" src="https://github.com/user-attachments/assets/1303554c-72e3-4dbd-ad73-ff3f6b16a322" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
