### PR TITLE
fix(desmos): style bottom of share snapshot dialog

### DIFF
--- a/styles/desmos/catppuccin.user.less
+++ b/styles/desmos/catppuccin.user.less
@@ -488,7 +488,10 @@
       border-color: @base !important;
     }
 
-    .dcg-gray-link, .dcg-centered-top-link, .dcg-cancel-while-loading {
+    .dcg-gray-link,
+    .dcg-centered-top-link,
+    .dcg-cancel-while-loading,
+    .dcg-checkbox.dcg-hovered .dcg-checkbox__box.dcg-icon-check::before {
       color: @accent !important;
     }
 
@@ -551,7 +554,7 @@
     .dcg-row:nth-of-type(2) .dcg-cell,
     table th,
     table td,
-    .footer,
+    dcg-checkbox .footer,
     .dcg-add-inference-wizard--create-button-wrapper,
     .dcg-small-screen-menu__logout-container,
     .dcg-product-filter__clear-filter-container {
@@ -717,7 +720,8 @@
       border-bottom-color: @surface2 !important;
     }
 
-    .dcg-checkbox__box.dcg-icon-check.dcg-checked::before {
+    .dcg-checkbox__box.dcg-icon-check.dcg-checked::before,
+    .dcg-checkbox.dcg-hovered .dcg-checkbox__box.dcg-icon-check::before {
       text-shadow: none;
       paint-order: stroke fill;
       -webkit-text-stroke: 4px @text;

--- a/styles/desmos/catppuccin.user.less
+++ b/styles/desmos/catppuccin.user.less
@@ -202,6 +202,7 @@
     .dcg-add-inference-wizard__sample-type-selector.dcg-selected,
     .dcg-table--cell,
     .dcg-checkbox:not(.dcg-geometry-toolbar-view .dcg-checkbox),
+    .dcg-checkbox__box,
     .dcg-product-filter__button {
       border-color: @text !important;
     }
@@ -607,7 +608,8 @@
     }
 
     .dcg-axis-label,
-    .dcg-clickable-menu-row:has(.dcg-input-label) > .dcg-mathquill-wrapper {
+    .dcg-clickable-menu-row:has(.dcg-input-label) > .dcg-mathquill-wrapper,
+    .dcg-checkbox__box {
       --dcg-accent-color: @accent !important;
     }
 
@@ -713,6 +715,12 @@
 
     .dcg-shortcuts-table tr {
       border-bottom-color: @surface2 !important;
+    }
+
+    .dcg-checkbox__box.dcg-icon-check.dcg-checked::before {
+      text-shadow: none;
+      paint-order: stroke fill;
+      -webkit-text-stroke: 4px @text;
     }
 
     --dcg-custom-text-color: @text;

--- a/styles/desmos/catppuccin.user.less
+++ b/styles/desmos/catppuccin.user.less
@@ -384,7 +384,8 @@
     .dcg-my-graphs-modal__options,
     #dsm-panic-popover,
     .dcg-hotkeys-header,
-    .dcg-select-dropdown-list {
+    .dcg-select-dropdown-list,
+    .dcg-share-menu__footer {
       background: @base !important;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- Themes the bottom of the share dialog for snapshots
- Fixes the theming for checkboxes (there appear to have been some changes since they were originally themed)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
