### PR TITLE
fix(dev.to): Subforem support

### DIFF
--- a/styles/dev.to/catppuccin.user.less
+++ b/styles/dev.to/catppuccin.user.less
@@ -97,6 +97,8 @@
     --body-bg: @mantle;
     --black: if(@flavor = latte, @text, @crust);
     --body-color: @text;
+    --color-primary: @subtext0;
+    --color-secondary: @subtext1;
 
     --header-bg: @base;
     --header-shadow: @crust;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Add theming for newly introduced subforems. Specifically for the urls:
- [https://dev.to](https://dev.to/)
- [https://forem.com/](https://forem.com/)
- [https://core.forem.com/](https://core.forem.com/)
- [https://gg.forem.com/](https://gg.forem.com/)
- [https://future.forem.com/](https://future.forem.com/)
- [https://popcorn.forem.com/](https://popcorn.forem.com/)
- [https://vibe.forem.com/](https://vibe.forem.com/)
- [https://music.forem.com/](https://music.forem.com/)
- [https://dumb.dev.to/](https://dumb.dev.to/)
- [https://maker.forem.com/](https://maker.forem.com/)
- [https://design.forem.com/](https://design.forem.com/)

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
