### PR TITLE
fix(bsky): repost colour

### DIFF
--- a/styles/bsky/catppuccin.user.less
+++ b/styles/bsky/catppuccin.user.less
@@ -504,7 +504,7 @@
 
     /* repost */
     .r-5ld2xk,
-    [style*="color: rgb(69, 237, 159)"] {
+    [style*="color: rgb(92, 239, 170)"] {
       color: @green !important;
       > path {
         fill: @green !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The repost button on bluesky has the wrong colour because PBC changed the style and so the selector is incorrect.

Before:
<img width="118" height="140" alt="Screenshot 2025-08-11 at 10 12 17 PM" src="https://github.com/user-attachments/assets/85e6e47c-7782-4b4d-8dee-6427a907fc26" />

After (fixed):
<img width="176" height="134" alt="Screenshot 2025-08-11 at 10 11 54 PM" src="https://github.com/user-attachments/assets/c800edb5-8851-4871-bde0-489a32a9d2ee" />



## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
