### PR TITLE
fix(bsky): load new post button

### DIFF
--- a/styles/bsky/catppuccin.user.less
+++ b/styles/bsky/catppuccin.user.less
@@ -602,6 +602,12 @@
     circle[fill="hsl(211, 28%, 24.8%)"][r="1.5"] {
       fill: @surface1 !important;
     }
+
+    /* load new posts button */
+    button[style*="border-color: rgb(46, 64, 82); background-color: rgb(21, 52, 85)"] {
+      background-color: @surface0 !important;
+      border: @overlay0 !important;
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The load new posts button on bluesky is unstyled when there are new posts available.

Normal button (without new posts available, correct):
<img width="69" height="64" alt="Screenshot 2025-08-11 at 10 31 25 PM" src="https://github.com/user-attachments/assets/e0da61c6-91f8-4360-8f02-185986ee68d8" />

Unstyled button (with new posts, unstyled):
<img width="78" height="75" alt="Screenshot 2025-08-11 at 10 33 07 PM" src="https://github.com/user-attachments/assets/95c3debf-bc3e-4dfa-9aee-3505ee37be31" />

After (with new posts, fixed):
<img width="68" height="78" alt="Screenshot 2025-08-11 at 10 33 35 PM" src="https://github.com/user-attachments/assets/09ef86d5-a12e-4c1e-8d12-93a59786ca71" />

I followed (what I believe was) existing convention in the userstyle, but imo we should apply overlay2 to preserve the border around the button.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
