### PR TITLE
fix(bsky): border-color(s) on various lines

### DIFF
--- a/styles/bsky/catppuccin.user.less
+++ b/styles/bsky/catppuccin.user.less
@@ -383,6 +383,11 @@
       background-color: @red !important;
     }
 
+    /* Discard draft modal border */
+    [style*="border-color: rgb(54, 75, 97)"] {
+      border-color: @surface2 !important;
+    }
+
     /* the round gradient post button in the bottom right when the page is thinner than usual */
     [data-testid="composeFAB"] > div {
       background: unset !important;
@@ -555,6 +560,11 @@
     /* contrast fix for above */
     button[style*="background-color: rgb(0, 133, 255)"] > div > div {
       color: @base !important;
+    }
+
+    /* miscellaneous lines around the app */
+    [style*="border-color: rgb(46, 64, 82)"] {
+      border-color: @surface1 !important;
     }
 
     /* other button in notifications tab, inner text */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Various small lines around the app are unstyled.

### Discard draft modal

Before: 
<img width="629" height="366" alt="Screenshot 2025-08-11 at 10 45 39 PM" src="https://github.com/user-attachments/assets/acc29e6a-baab-46c1-aeea-48690640d818" />

After (fixed):
<img width="642" height="383" alt="Screenshot 2025-08-11 at 11 07 37 PM" src="https://github.com/user-attachments/assets/9707130e-3b79-446b-a5db-da590b93eea5" />

### On a feed:

Before:
<img width="637" height="1035" alt="Screenshot 2025-08-11 at 11 04 01 PM" src="https://github.com/user-attachments/assets/fd35b2e3-bfaf-4b2f-9682-818c9646759e" />

After (fixed):
<img width="633" height="1029" alt="Screenshot 2025-08-11 at 11 01 59 PM" src="https://github.com/user-attachments/assets/d8847815-689f-4a2e-8a5f-fd518486140e" />

I have intentionally set the discard draft modal to be bordered as `surface2` while the rest of the app uses `surface1` as they are set as different colours by Bluesky, and so I believe we should follow suit. Happy to keep it to a single colour if that is better by convention.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
