### PR TITLE
feat(bsky): theme the character limit progress circle

### DIFF
--- a/styles/bsky/catppuccin.user.less
+++ b/styles/bsky/catppuccin.user.less
@@ -582,6 +582,10 @@
       background-color: @overlay2 !important;
     }
 
+    path[stroke*="hsl(211, 99%, 56%)"] {
+      stroke: @accent !important;
+    }
+
     /* skeletons */
     .r-kdyh1x,
     .r-cpet4d {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The progression circle on the new post modal is unstyled.

Before:
<img width="99" height="75" alt="Screenshot 2025-08-11 at 11 27 31 PM" src="https://github.com/user-attachments/assets/82a72434-340e-4bc1-bc13-58c016228f42" />

After:
<img width="110" height="86" alt="Screenshot 2025-08-11 at 11 26 40 PM" src="https://github.com/user-attachments/assets/5ffa652b-fedb-43d6-9deb-23f60529f2d2" />

A bit hacky to style a path element directly but it works.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
