### PR TITLE
feat(tldraw): multiple styles

### DIFF
--- a/styles/tldraw/catppuccin.user.less
+++ b/styles/tldraw/catppuccin.user.less
@@ -23,6 +23,11 @@
     #catppuccin(@lightFlavor);
   }
 
+  /* for clerk components in modal */
+  .cl-modalContent {
+    #catppuccin(@lightFlavor);
+  }
+
   #catppuccin(@flavor) {
     @rosewater: @catppuccin[@@flavor][@rosewater];
     @flamingo: @catppuccin[@@flavor][@flamingo];
@@ -420,6 +425,17 @@
         background-color: var(--color-light-violet) !important;
       }
     }
+
+    /* sign in button */
+    .tla-primary-button::before {
+      background-color: var(--color-accent) !important;
+    }
+
+    /* text in sign-in button */
+    span.i18n-msg {
+      color: var(--color-selected-contrast) !important;
+    }
+
   }
 }
 

--- a/styles/tldraw/catppuccin.user.less
+++ b/styles/tldraw/catppuccin.user.less
@@ -437,6 +437,27 @@
       color: var(--color-selected-contrast) !important;
     }
 
+    /* export modal text */
+    [role*="tab"], tla-control > span.i18n-msg, label > span.i18n-msg {
+      color: var(--color-text-0) !important;
+    }
+
+    /* export modal button text */
+    button.tla-button > span > span.i18n-msg {
+      color: var(--color-selected-contrast) !important;
+    }
+
+    /* export modal button svg icon */
+    button.tla-button > span[role*="img"] {
+      color: var(--color-selected-contrast) !important;
+    }
+
+    /* export modal button background */
+    button.tla-button {
+      background-color: var(--color-accent) !important;
+    }
+
+
     /* clerk sign-in components */
 
     /* modal background */

--- a/styles/tldraw/catppuccin.user.less
+++ b/styles/tldraw/catppuccin.user.less
@@ -442,6 +442,11 @@
       color: var(--color-text-0) !important;
     }
 
+    /* export modal selected tab highlight */
+    [role*="tab"]::after {
+      background-color: var(--color-text-0) !important;;
+    }
+
     /* export modal button text */
     button.tla-button > span > span.i18n-msg {
       color: var(--color-selected-contrast) !important;
@@ -455,6 +460,37 @@
     /* export modal button background */
     button.tla-button {
       background-color: var(--color-accent) !important;
+    }
+
+    /* export modal pill toggle background when true */
+    div.tla-switch > div[data-checked*="true"] {
+      background-color: var(--color-accent) !important;
+    }
+
+    /* export modal pill toggle circle when true */
+    div.tla-switch > div[data-checked*="true"]::after {
+      background-color: var(--color-panel) !important;
+    }
+
+    /* export modal pill toggle background when false */
+    div.tla-switch > div[data-checked*="false"] {
+      background-color: @base !important;
+    }
+
+    /* export modal pill toggle circle when false */
+    div.tla-switch > div[data-checked*="false"]::after {
+      background-color: @surface2 !important;
+    }
+
+
+    /* export modal dropdown styles */
+    div.tla-control > div > button[role*="combobox"]::after {
+      background-color: var(--shadow-3-1) !important;
+    }
+    div.tla-control > div > button[role*="combobox"] > div {
+      color: var(--color-text-0) !important;
+      /* ensures that the text stays above the highlight fade */
+      z-index: 1;
     }
 
 

--- a/styles/tldraw/catppuccin.user.less
+++ b/styles/tldraw/catppuccin.user.less
@@ -427,34 +427,40 @@
       }
     }
 
-    /* sign in button */
+    /* sign in button background */
     .tla-primary-button::before {
       background-color: var(--color-accent) !important;
     }
 
-    /* text in sign-in button */
+    /* sign-in button text */
     .tla-primary-button > span.i18n-msg {
       color: var(--color-selected-contrast) !important;
     }
 
     /* clerk sign-in components */
+
+    /* modal background */
     .cl-card {
       background-color: @mantle !important;
     }
 
+    /* primary continue button */
     .cl-formButtonPrimary {
       background-color: var(--color-accent) !important;
       box-shadow: var(--shadow-1) !important;
     }
 
+    /* oauth continue with... buttons */
     .cl-socialButtonsBlockButton {
       box-shadow: var(--shadow-2) !important;
     }
 
+    /* modal text */
     h1.cl-headerTitle, .cl-formFieldLabel {
       color: var(--color-text-0) !important;
     }
 
+    /* input field background */
     .cl-input {
       background-color: @base !important;
     }

--- a/styles/tldraw/catppuccin.user.less
+++ b/styles/tldraw/catppuccin.user.less
@@ -24,6 +24,7 @@
   }
 
   /* for clerk components in modal */
+  /* do light mode because clerk on tldraw doesn't have dark mode set */
   .cl-modalContent {
     #catppuccin(@lightFlavor);
   }
@@ -436,6 +437,27 @@
       color: var(--color-selected-contrast) !important;
     }
 
+    /* clerk sign-in components */
+    .cl-card {
+      background-color: @mantle !important;
+    }
+
+    .cl-formButtonPrimary {
+      background-color: var(--color-accent) !important;
+      box-shadow: var(--shadow-1) !important;
+    }
+
+    .cl-socialButtonsBlockButton {
+      box-shadow: var(--shadow-2) !important;
+    }
+
+    h1.cl-headerTitle, .cl-formFieldLabel {
+      color: var(--color-text-0) !important;
+    }
+
+    .cl-input {
+      background-color: @base !important;
+    }
   }
 }
 

--- a/styles/tldraw/catppuccin.user.less
+++ b/styles/tldraw/catppuccin.user.less
@@ -433,7 +433,7 @@
     }
 
     /* text in sign-in button */
-    span.i18n-msg {
+    .tla-primary-button > span.i18n-msg {
       color: var(--color-selected-contrast) !important;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Closes #1788.

Styles the following:
- Sign in button on the top right.
- Clerk sign-in modal
- Export modal

For the components provided by Clerk, I opted to put them only in light mode because tldraw doesn't use the dark mode components from Clerk. I have attempted to style each of them to the best of my ability.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
