### PR TITLE
chore(bsky): lint

### DIFF
--- a/styles/bsky/catppuccin.user.less
+++ b/styles/bsky/catppuccin.user.less
@@ -621,7 +621,7 @@
     /* load new posts button */
     button[style*="border-color: rgb(46, 64, 82); background-color: rgb(21, 52, 85)"] {
       background-color: @surface0 !important;
-      border: @overlay0 !important;
+      border-color: @overlay0 !important;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Entirely my bad, and apologies for the extremely tiny PR.

My previous fix contained a style that used `border:` instead of `border-color:` and it's triggering ci lint failures on other userstyles. Not super high priority but will be annoying nontheless.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
