### PR TITLE
feat(tangled): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -66,6 +66,7 @@ collaborators:
   - &gradylink gradylink
   - &ashish0kumar ashish0kumar
   - &shnjd shnjd
+  - &NekoDrone NekoDrone
 
 userstyles:
   advent-of-code:
@@ -863,6 +864,12 @@ userstyles:
     categories: [discussion_forum, social_networking]
     color: text
     current-maintainers: [*Guaxinim5573]
+  tangled:
+    name: tangled.sh
+    link: https://tangled.sh/
+    categories: [development, productivity]
+    color: text
+    current-maintainers: [*NekoDrone]
   tldraw:
     name: tldraw
     link: https://www.tldraw.com

--- a/styles/tangled/catppuccin.user.less
+++ b/styles/tangled/catppuccin.user.less
@@ -1,0 +1,343 @@
+/* ==UserStyle==
+@name tangled.sh Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/tangled
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/tangled
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/tangled/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Atangled
+@description Soothing pastel theme for tangled
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@-moz-document domain("tangled.sh") {
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    @rosewater: @catppuccin[@@flavor][@rosewater];
+    @flamingo: @catppuccin[@@flavor][@flamingo];
+    @pink: @catppuccin[@@flavor][@pink];
+    @mauve: @catppuccin[@@flavor][@mauve];
+    @red: @catppuccin[@@flavor][@red];
+    @maroon: @catppuccin[@@flavor][@maroon];
+    @peach: @catppuccin[@@flavor][@peach];
+    @yellow: @catppuccin[@@flavor][@yellow];
+    @green: @catppuccin[@@flavor][@green];
+    @teal: @catppuccin[@@flavor][@teal];
+    @sky: @catppuccin[@@flavor][@sky];
+    @sapphire: @catppuccin[@@flavor][@sapphire];
+    @blue: @catppuccin[@@flavor][@blue];
+    @lavender: @catppuccin[@@flavor][@lavender];
+    @text: @catppuccin[@@flavor][@text];
+    @subtext1: @catppuccin[@@flavor][@subtext1];
+    @subtext0: @catppuccin[@@flavor][@subtext0];
+    @overlay2: @catppuccin[@@flavor][@overlay2];
+    @overlay1: @catppuccin[@@flavor][@overlay1];
+    @overlay0: @catppuccin[@@flavor][@overlay0];
+    @surface2: @catppuccin[@@flavor][@surface2];
+    @surface1: @catppuccin[@@flavor][@surface1];
+    @surface0: @catppuccin[@@flavor][@surface0];
+    @base: @catppuccin[@@flavor][@base];
+    @mantle: @catppuccin[@@flavor][@mantle];
+    @crust: @catppuccin[@@flavor][@crust];
+    @accent: @catppuccin[@@flavor][@@accentColor];
+
+    color-scheme: if(@flavor = latte, light, dark);
+
+    ::selection {
+      background-color: fade(@accent, 30%);
+    }
+
+    input,
+    textarea {
+      &::placeholder {
+        color: @subtext0 !important;
+      }
+    }
+
+    /* tangled.sh userstyle */
+
+    /* sitewide background */
+    body {
+      background-color: @base;
+    }
+
+    /* sitewide basic text */
+    a, p, .dark\:text-white {
+      color: @text;
+    }
+
+    /* sitewide subtexts */
+    .text-gray-600.dark\:text-gray-300 {
+      color: @subtext1;
+    }
+    .text-gray-700.dark\:text-gray-400 {
+      color: @subtext0;
+    }
+    .text-gray-400.font-mono {
+      color: @overlay2;
+    }
+
+    /* sitewide inputs */
+    input,
+    textarea {
+      background-color: @base;
+    }
+
+    /* sitewide markdown backtick code */
+    .bg-gray-100.dark\:bg-gray-700 {
+      background-color: @surface1;
+    }
+
+    /* top bar +new icon */
+    .btn-create::before {
+      background-color: @accent;
+      border-color: @accent;
+    }
+    .btn-create:hover::before {
+      background-color: fade(@accent, 60%);
+      border-color: fade(@accent, 20%);
+    }
+    .btn-create {
+      color: @crust;
+    }
+
+    /* top bar logout */
+    .text-red-400.dark\:text-red-400 {
+      color: @red;
+      &:hover {
+        color: lighten(@red, 5%);
+      }
+    }
+
+    /* footer segment headers */
+    .text-gray-900.dark\:text-gray-200 {
+      color: @subtext1;
+    }
+
+    /* footer copyright */
+    .text-gray-600.dark\:text-gray-400 {
+      color: @subtext0;
+    }
+
+    /* generic button */
+    .btn::before {
+      background-color: @surface1;
+      border-color: @overlay0;
+    }
+    .btn:hover::before {
+      background-color: @surface2;
+    }
+
+    /* timeline page list item */
+    .bg-white.dark\:bg-gray-800 {
+      background-color: @surface0;
+    }
+
+    /* profile punchcard component - reduce by 16.5% (ish) each step */
+    /* 100% */
+    .bg-green-500.dark\:bg-green-600 {
+      background-color: @accent;
+    }
+    /* 84% */
+    .bg-green-400.dark\:bg-green-700 {
+      background-color: fade(@accent, 84%);
+    }
+    /* 67% */
+    .bg-green-300.dark\:bg-green-800 {
+      background-color: fade(@accent, 67%);
+    }
+    /* 50% */
+    .bg-green-200.dark\:bg-green-900 {
+      background-color: fade(@accent, 50%);
+    }
+    /* none */
+    .bg-gray-200.dark\:bg-gray-700 {
+      background-color: @surface2;
+    }
+    /* future */
+    .border.border-gray-200.dark\:border-gray-700 {
+      border-color: @surface1;
+    }
+
+    /* profile activity list statuses (e.g. 3 open, 16 merged, 5 closed, etc.)
+    /* open PRs */
+    .bg-green-600.dark\:bg-green-700.text-white {
+      background-color: @green;
+      color: @crust;
+    }
+    .text-green-600.dark\:text-green-500 {
+      color: @green;
+    }
+    /* merged PRs */
+    .bg-purple-600.dark\:bg-purple-700.text-white {
+      background-color: @mauve;
+      color: @crust;
+    }
+    .text-purple-600.dark\:text-purple-500 {
+      color: @mauve;
+    }
+    /* closed PRs */
+    .bg-gray-800.dark\:bg-gray-700 {
+      background-color: @mantle;
+      color: @text;
+    }
+    /* "No activity for this month" text */
+    .text-gray-500.dark\:text-gray-400 {
+      color: @overlay1;
+    }
+
+    /* chroma syntax highlighting overrides */
+    /* the good news is that tangled by default already uses catppuccin macchiato so we can just edit those styles a little */
+    .chroma {
+      color: @text;
+    }
+    span.kd, span.kt {
+      color: @red;
+    }
+    span.o {
+      color: @sky;
+    }
+    span.k {
+      color: @mauve;
+    }
+    span.nf {
+      color: @blue;
+    }
+    span.s1 {
+      color: @green;
+    }
+    span.kc {
+      color: @peach;
+    }
+
+    /* email verification statuses */
+    /* verified */
+    span.bg-green-100.text-green-800.dark\:bg-green-900.dark\:text-green-200 {
+      background-color: @green;
+      color: @crust;
+    }
+    /* primary */
+    span.bg-blue-100.text-blue-800.dark\:bg-blue-900.dark\:text-blue-200 {
+      background-color: @blue;
+      color: @crust;
+    }
+    /* unverified */
+    span.bg-yellow-100.text-yellow-800.dark\:bg-yellow-900.dark\:text-yellow-200 {
+      background-color: @yellow;
+      color: @crust;
+    }
+
+    /* settings delete button */
+    button.text-red-500.dark\:text-red-400 {
+      color: @red;
+      &:hover {
+        color: lighten(@red, 5%);
+      }
+    }
+
+    /* repository issues and PRs */
+    /* commit */
+    .text-gray-700.dark\:text-gray-300.bg-gray-100.dark\:bg-gray-900 {
+      color: @text;
+      background-color: @base;
+    }
+
+    /* verified commit */
+    .bg-green-100.text-green-800.dark\:bg-green-900.dark\:text-green-200 {
+      color: @crust;
+      background-color: @green;
+    }
+
+    /* open issue or PR in repo */
+    .bg-green-600.dark\:bg-green-700 {
+      color: @crust;
+      background-color: @green;
+      > span.text-white.dark\:text-white,
+      svg.text-white.dark\:text-white,
+      span.text-white,
+      svg.text-white {
+        color: @crust;
+      }
+    }
+
+    /* closed issue or PR */
+    .bg-gray-800.dark\:bg-gray-700 {
+      background-color: @base;
+      > span.text-white, svg.text-white {
+        color: @text;
+      }
+    }
+
+    /* merged issue */
+    .bg-purple-600.dark\:bg-purple-700 {
+      background-color: @mauve;
+      > span.text-white, svg.text-white {
+        color: @crust;
+      }
+    }
+
+    /* ci run success checkmark */
+    .text-green-600 {
+      color: @green;
+    }
+
+    /* ci run failed cross */
+    .text-red-600 {
+      color: @red;
+    }
+
+    /* ci in progress or waiting */
+    .text-orange-400.dark\:text-orange-300 {
+      color: @peach;
+    }
+
+    /* ci progress circle */
+    /* this is super hacky and hella unmaintainable if tangled even changes the colour somewhat */
+    /* i'm wholly prepared to drop this. */
+    circle[stroke*="#ef4444"] {
+      stroke: @red; // failed
+    }
+    circle[stroke*="#fb923c"] {
+      stroke: @peach; // in progress or waiting
+    }
+    circle[stroke*="#10b981"] {
+      stroke: @green; // success
+    }
+
+    /* repository settings tab list selected */
+    .bg-white.dark\:bg-gray-700 {
+      background-color: @surface0;
+    }
+
+    /* repository setting tab list item */
+    .bg-gray-100.dark\:bg-gray-800 {
+      background-color: @base;
+    }
+
+    /* repository default branch dropdown */
+    select.bg-white.dark\:bg-gray-800 {
+      background-color: @base;
+    }
+  }
+}
+
+/* deno-fmt-ignore */
+@catppuccin: {
+  @latte:     { @rosewater: #dc8a78; @flamingo: #dd7878; @pink: #ea76cb; @mauve: #8839ef; @red: #d20f39; @maroon: #e64553; @peach: #fe640b; @yellow: #df8e1d; @green: #40a02b; @teal: #179299; @sky: #04a5e5; @sapphire: #209fb5; @blue: #1e66f5; @lavender: #7287fd; @text: #4c4f69; @subtext1: #5c5f77; @subtext0: #6c6f85; @overlay2: #7c7f93; @overlay1: #8c8fa1; @overlay0: #9ca0b0; @surface2: #acb0be; @surface1: #bcc0cc; @surface0: #ccd0da; @base: #eff1f5; @mantle: #e6e9ef; @crust: #dce0e8; };
+  @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
+  @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
+  @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+};


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for [tangled.sh](https://tangled.sh) 🎉

tangled.sh is a git collaboration platform (like GitHub) on the [ATProto](https://atproto.com/)!

## 💬 Additional Comments 💬

tangled uses Tailwind for styling, so a lot of the components that are styled in this userstyle are based off the application of certain Tailwind utility classes. This means that it is likely to break and be a rather large maintenance burden on me.

I am intending to write PRs to upstream to give components aria-labels, ids, roles, or other forms of identifiers to hopefully reduce said burden.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
