### PR TITLE
fix(chatgpt): accent messages and latte text

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -13,6 +13,8 @@
 @var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+
+@var checkbox accentb "Use accent for default user message bubble color" 1
 ==/UserStyle== */
 
 @-moz-document domain("chatgpt.com") {
@@ -124,6 +126,21 @@
 
     color: @text;
 
+    [data-state="closed"] .composer-submit-button-color {
+      background-color: fade(@accent, 50%);
+    }
+
+    .composer-submit-button-color,
+    .composer-secondary-button-color {
+      background-color: @accent;
+    }
+
+    & when (@accentb = 1) {
+      .user-message-bubble-color {
+        background-color: @accent;
+      }
+    }
+
     @white: if(@flavor = latte, @crust, @text);
     @black: if(@flavor = latte, @text, @crust);
     --white: @white;
@@ -157,6 +174,7 @@
       --sidebar-surface-tertiary: var(--gray-700);
       --bg-elevated-secondary: var(--gray-900);
       .popover,
+      .markdown,
       .dark,
       .dark .popover,
       .dark.popover,
@@ -167,6 +185,11 @@
         --text-primary: var(--white) !important;
         --text-secondary: var(--gray-200) !important;
         --text-tertiary: var(--gray-300) !important;
+      }
+      & when (@accentb = 1) {
+        .user-message-bubble-color .whitespace-pre-wrap {
+          color: var(--gray-800)
+        }
       }
     }
     & when (@flavor = latte) {
@@ -196,6 +219,7 @@
       --sidebar-surface-tertiary: var(--gray-300);
       --bg-elevated-secondary: var(--gray-100);
       .popover,
+      .markdown,
       .dark .popover,
       .dark.popover,
       .popover .dark {
@@ -206,6 +230,11 @@
         --text-secondary: var(--gray-600) !important;
         --text-tertiary: var(--gray-500) !important;
         --interactive-bg-secondary-hover: var(--gray-600) !important;
+      }
+      & when (@accentb = 1) {
+        .user-message-bubble-color .whitespace-pre-wrap {
+          color: var(--gray-200)
+        }
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
Adds accent color on both submit button and prompt introduced in GPT-5 update.
This fixes dark mode problem when using **Latte**.

Closes #1429.

<img width="673" height="665" alt="Screenshot_2025-08-13_10-50-09" src="https://github.com/user-attachments/assets/9b84aa82-d2c7-40b2-8a79-cde31a0dabc4" />
<img width="671" height="667" alt="Screenshot_2025-08-13_10-53-26" src="https://github.com/user-attachments/assets/abe5f497-3a84-4948-9f87-6830186386c5" />

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
