### PR TITLE
fix(claude): new chat icon color not applied correctly

### DIFF
--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -168,7 +168,7 @@
     }
 
     /* "New chat" plus icon */
-    svg.text-always-white {
+    .text-always-white svg {
       color: @base !important;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
(very small PR xD)

closes #1834 

The plus icon for a new chat was light, there was already a fix for that, but applied to `svg.className`, although the className in code is in the parent div of the svg, so it should be `className svg`.

## 🗒 Checklist 🗒

- [x ] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
