### PR TITLE
fix(claude): logo color

### DIFF
--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -163,8 +163,8 @@
     }
 
     /* Logo */
-    svg path[fill="#D97757"] {
-      fill: @accent !important;
+    .text-\[\#D97757\] {
+      color: @accent ;
     }
 
     /* "New chat" plus icon */


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The className styling the logo paths was moved a few parent divs up, so userstyle was showing the logo with original colors, fixed that to show with selected accent color

Looks like this now:
<img width="848" height="553" alt="image" src="https://github.com/user-attachments/assets/4435a2f4-93c9-4a9a-9d1d-128fa10affda" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
