### PR TITLE
Added overwrite rule for gray code

### DIFF
--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -146,6 +146,11 @@
         span.token[style="color: rgb(198, 120, 221);"] {
           color: @mauve !important;
         }
+
+        /* Gray */
+        span.token[style="color: rgb(171, 178, 191);"] {
+          color: @overlay2 !important;
+        }
       }
     }
 
@@ -163,12 +168,12 @@
     }
 
     /* Logo */
-    .text-\[\#D97757\] {
-      color: @accent;
+    div.text-\[\#D97757\] {
+      color: @accent !important;
     }
 
     /* "New chat" plus icon */
-    .text-always-white svg {
+    div.text-always-white svg {
       color: @base !important;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Claude added a gray color to its code blocks for symbols and punctuation. This new rule ensures the color gets matched to overlay2.
<img width="880" height="304" alt="image" src="https://github.com/user-attachments/assets/3a6d465d-770e-4e1c-9f27-2844f734e6ff" />

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
