### PR TITLE
feat(lichess): add theme to drawn annotations, local eval bar, and threat analysis button

### DIFF
--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -536,15 +536,14 @@
     .mchat__tab:hover {
       background: fade(@accent, 50%);
     }
-    .ceval .bar span{
-      background:@green;
+    .ceval .bar span {
+      background: @green;
     }
     .show-threat.active,
-    .show-threat:hover:not(.hidden),
-    {
+    .show-threat:hover:not(.hidden) {
       color: @red;
     }
-    .ceval .bar span.threat{
+    .ceval .bar span.threat {
       background: @red;
     }
     /* Openings */

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -536,6 +536,14 @@
     .mchat__tab:hover {
       background: fade(@accent, 50%);
     }
+    .show-threat.active,
+    .show-threat:hover:not(.hidden),
+    {
+      color: @red;
+    }
+    .ceval .bar span.threat{
+      background: @red;
+    }
     /* Openings */
     .opening__config,
     .opening__next {

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -411,6 +411,17 @@
       background: @accent;
     }
 
+    /* Analysis Arrows */
+    svg.cg-shapes g[cgHash$="green"] {
+      filter: @green-svg-filter;
+    }
+    svg.cg-shapes g[cgHash$="paleBlue"] {
+      filter: @sky-svg-filter;
+    }
+    svg.cg-shapes g[cgHash$="red"] {
+      filter: @red-svg-filter;
+    }
+
     /* Game Cards */
     .game__meta,
     .round__app__table {

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -536,6 +536,9 @@
     .mchat__tab:hover {
       background: fade(@accent, 50%);
     }
+    .ceval .bar span{
+      background:@green;
+    }
     .show-threat.active,
     .show-threat:hover:not(.hidden),
     {

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -61,6 +61,10 @@
     @crust: @catppuccin[@@flavor][@crust];
     @accent: @catppuccin[@@flavor][@@accentColor];
 
+    @green-svg-filter: @catppuccin-svg-filters[@@flavor][@green];
+    @sky-svg-filter: @catppuccin-svg-filters[@@flavor][@sky];
+    @red-svg-filter: @catppuccin-svg-filters[@@flavor][@red];
+
     color-scheme: if(@flavor = latte, light, dark);
 
     ::selection {
@@ -596,4 +600,111 @@
   @frappe:    { @rosewater: #f2d5cf; @flamingo: #eebebe; @pink: #f4b8e4; @mauve: #ca9ee6; @red: #e78284; @maroon: #ea999c; @peach: #ef9f76; @yellow: #e5c890; @green: #a6d189; @teal: #81c8be; @sky: #99d1db; @sapphire: #85c1dc; @blue: #8caaee; @lavender: #babbf1; @text: #c6d0f5; @subtext1: #b5bfe2; @subtext0: #a5adce; @overlay2: #949cbb; @overlay1: #838ba7; @overlay0: #737994; @surface2: #626880; @surface1: #51576d; @surface0: #414559; @base: #303446; @mantle: #292c3c; @crust: #232634; };
   @macchiato: { @rosewater: #f4dbd6; @flamingo: #f0c6c6; @pink: #f5bde6; @mauve: #c6a0f6; @red: #ed8796; @maroon: #ee99a0; @peach: #f5a97f; @yellow: #eed49f; @green: #a6da95; @teal: #8bd5ca; @sky: #91d7e3; @sapphire: #7dc4e4; @blue: #8aadf4; @lavender: #b7bdf8; @text: #cad3f5; @subtext1: #b8c0e0; @subtext0: #a5adcb; @overlay2: #939ab7; @overlay1: #8087a2; @overlay0: #6e738d; @surface2: #5b6078; @surface1: #494d64; @surface0: #363a4f; @base: #24273a; @mantle: #1e2030; @crust: #181926; };
   @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
+};
+
+@catppuccin-svg-filters: {
+  @latte: {
+    @green: brightness(0)
+      saturate(100%)
+      invert(48%)
+      sepia(82%)
+      saturate(443%)
+      hue-rotate(63deg)
+      brightness(93%)
+      contrast(87%);
+    @sky: brightness(0)
+      saturate(100%)
+      invert(50%)
+      sepia(95%)
+      saturate(2139%)
+      hue-rotate(163deg)
+      brightness(95%)
+      contrast(97%);
+    @red: brightness(0)
+      saturate(100%)
+      invert(13%)
+      sepia(72%)
+      saturate(4910%)
+      hue-rotate(338deg)
+      brightness(99%)
+      contrast(99%);
+  };
+  @frappe: {
+    @green: brightness(0)
+      saturate(100%)
+      invert(93%)
+      sepia(10%)
+      saturate(1334%)
+      hue-rotate(40deg)
+      brightness(86%)
+      contrast(89%);
+    @sky: brightness(0)
+      saturate(100%)
+      invert(87%)
+      sepia(24%)
+      saturate(479%)
+      hue-rotate(149deg)
+      brightness(90%)
+      contrast(90%);
+    @red: brightness(0)
+      saturate(100%)
+      invert(53%)
+      sepia(28%)
+      saturate(813%)
+      hue-rotate(308deg)
+      brightness(110%)
+      contrast(81%);
+  };
+  @macchiato: {
+    @green: brightness(0)
+      saturate(100%)
+      invert(93%)
+      sepia(11%)
+      saturate(1240%)
+      hue-rotate(47deg)
+      brightness(91%)
+      contrast(86%);
+    @sky: brightness(0)
+      saturate(100%)
+      invert(92%)
+      sepia(77%)
+      saturate(771%)
+      hue-rotate(163deg)
+      brightness(90%)
+      contrast(99%);
+    @red: brightness(0)
+      saturate(100%)
+      invert(59%)
+      sepia(56%)
+      saturate(354%)
+      hue-rotate(302deg)
+      brightness(95%)
+      contrast(95%);
+  };
+  @mocha: {
+    @green: brightness(0)
+      saturate(100%)
+      invert(92%)
+      sepia(11%)
+      saturate(1115%)
+      hue-rotate(57deg)
+      brightness(93%)
+      contrast(91%);
+    @sky: brightness(0)
+      saturate(100%)
+      invert(73%)
+      sepia(93%)
+      saturate(204%)
+      hue-rotate(149deg)
+      brightness(97%)
+      contrast(89%);
+    @red: brightness(0)
+      saturate(100%)
+      invert(69%)
+      sepia(16%)
+      saturate(1974%)
+      hue-rotate(301deg)
+      brightness(106%)
+      contrast(91%);
+  };
 };

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -61,9 +61,9 @@
     @crust: @catppuccin[@@flavor][@crust];
     @accent: @catppuccin[@@flavor][@@accentColor];
 
-    @green-svg-filter: @catppuccin-svg-filters[@@flavor][@green];
-    @sky-svg-filter: @catppuccin-svg-filters[@@flavor][@sky];
-    @red-svg-filter: @catppuccin-svg-filters[@@flavor][@red];
+    @green-filter: @catppuccin-filters[@@flavor][@green];
+    @sky-filter: @catppuccin-filters[@@flavor][@sky];
+    @red-filter: @catppuccin-filters[@@flavor][@red];
 
     color-scheme: if(@flavor = latte, light, dark);
 
@@ -412,14 +412,16 @@
     }
 
     /* Analysis Arrows */
-    svg.cg-shapes g[cgHash$="green"] {
-      filter: @green-svg-filter;
-    }
-    svg.cg-shapes g[cgHash$="paleBlue"] {
-      filter: @sky-svg-filter;
-    }
-    svg.cg-shapes g[cgHash$="red"] {
-      filter: @red-svg-filter;
+    svg.cg-shapes g {
+      &[cgHash$="green"] {
+        filter: @green-filter;
+      }
+      &[cgHash$="paleBlue"] {
+        filter: @sky-filter;
+      }
+      &[cgHash$="red"] {
+        filter: @red-filter;
+      }
     }
 
     /* Game Cards */
@@ -623,109 +625,10 @@
   @mocha:     { @rosewater: #f5e0dc; @flamingo: #f2cdcd; @pink: #f5c2e7; @mauve: #cba6f7; @red: #f38ba8; @maroon: #eba0ac; @peach: #fab387; @yellow: #f9e2af; @green: #a6e3a1; @teal: #94e2d5; @sky: #89dceb; @sapphire: #74c7ec; @blue: #89b4fa; @lavender: #b4befe; @text: #cdd6f4; @subtext1: #bac2de; @subtext0: #a6adc8; @overlay2: #9399b2; @overlay1: #7f849c; @overlay0: #6c7086; @surface2: #585b70; @surface1: #45475a; @surface0: #313244; @base: #1e1e2e; @mantle: #181825; @crust: #11111b; };
 };
 
-@catppuccin-svg-filters: {
-  @latte: {
-    @green: brightness(0)
-      saturate(100%)
-      invert(48%)
-      sepia(82%)
-      saturate(443%)
-      hue-rotate(63deg)
-      brightness(93%)
-      contrast(87%);
-    @sky: brightness(0)
-      saturate(100%)
-      invert(50%)
-      sepia(95%)
-      saturate(2139%)
-      hue-rotate(163deg)
-      brightness(95%)
-      contrast(97%);
-    @red: brightness(0)
-      saturate(100%)
-      invert(13%)
-      sepia(72%)
-      saturate(4910%)
-      hue-rotate(338deg)
-      brightness(99%)
-      contrast(99%);
-  };
-  @frappe: {
-    @green: brightness(0)
-      saturate(100%)
-      invert(93%)
-      sepia(10%)
-      saturate(1334%)
-      hue-rotate(40deg)
-      brightness(86%)
-      contrast(89%);
-    @sky: brightness(0)
-      saturate(100%)
-      invert(87%)
-      sepia(24%)
-      saturate(479%)
-      hue-rotate(149deg)
-      brightness(90%)
-      contrast(90%);
-    @red: brightness(0)
-      saturate(100%)
-      invert(53%)
-      sepia(28%)
-      saturate(813%)
-      hue-rotate(308deg)
-      brightness(110%)
-      contrast(81%);
-  };
-  @macchiato: {
-    @green: brightness(0)
-      saturate(100%)
-      invert(93%)
-      sepia(11%)
-      saturate(1240%)
-      hue-rotate(47deg)
-      brightness(91%)
-      contrast(86%);
-    @sky: brightness(0)
-      saturate(100%)
-      invert(92%)
-      sepia(77%)
-      saturate(771%)
-      hue-rotate(163deg)
-      brightness(90%)
-      contrast(99%);
-    @red: brightness(0)
-      saturate(100%)
-      invert(59%)
-      sepia(56%)
-      saturate(354%)
-      hue-rotate(302deg)
-      brightness(95%)
-      contrast(95%);
-  };
-  @mocha: {
-    @green: brightness(0)
-      saturate(100%)
-      invert(92%)
-      sepia(11%)
-      saturate(1115%)
-      hue-rotate(57deg)
-      brightness(93%)
-      contrast(91%);
-    @sky: brightness(0)
-      saturate(100%)
-      invert(73%)
-      sepia(93%)
-      saturate(204%)
-      hue-rotate(149deg)
-      brightness(97%)
-      contrast(89%);
-    @red: brightness(0)
-      saturate(100%)
-      invert(69%)
-      sepia(16%)
-      saturate(1974%)
-      hue-rotate(301deg)
-      brightness(106%)
-      contrast(91%);
-  };
-};
+/* deno-fmt-ignore */
+@catppuccin-filters: {
+  @latte: { @rosewater: brightness(0) saturate(100%) invert(65%) sepia(18%) saturate(1048%) hue-rotate(323deg) brightness(92%) contrast(86%); @flamingo: brightness(0) saturate(100%) invert(84%) sepia(44%) saturate(4533%) hue-rotate(310deg) brightness(98%) contrast(75%); @pink: brightness(0) saturate(100%) invert(60%) sepia(32%) saturate(775%) hue-rotate(266deg) brightness(93%) contrast(97%); @mauve: brightness(0) saturate(100%) invert(26%) sepia(59%) saturate(3315%) hue-rotate(255deg) brightness(94%) contrast(100%); @red: brightness(0) saturate(100%) invert(16%) sepia(78%) saturate(7275%) hue-rotate(342deg) brightness(84%) contrast(94%); @maroon: brightness(0) saturate(100%) invert(31%) sepia(56%) saturate(2395%) hue-rotate(331deg) brightness(99%) contrast(82%); @peach: brightness(0) saturate(100%) invert(38%) sepia(81%) saturate(1292%) hue-rotate(356deg) brightness(103%) contrast(99%); @yellow: brightness(0) saturate(100%) invert(74%) sepia(47%) saturate(4570%) hue-rotate(354deg) brightness(95%) contrast(83%); @green: brightness(0) saturate(100%) invert(51%) sepia(25%) saturate(4134%) hue-rotate(76deg) brightness(95%) contrast(66%); @teal: brightness(0) saturate(100%) invert(41%) sepia(45%) saturate(1101%) hue-rotate(139deg) brightness(100%) contrast(82%); @sky: brightness(0) saturate(100%) invert(47%) sepia(76%) saturate(2427%) hue-rotate(166deg) brightness(99%) contrast(97%); @sapphire: brightness(0) saturate(100%) invert(52%) sepia(41%) saturate(6982%) hue-rotate(160deg) brightness(102%) contrast(75%); @blue: brightness(0) saturate(100%) invert(30%) sepia(80%) saturate(1850%) hue-rotate(209deg) brightness(94%) contrast(105%); @lavender: brightness(0) saturate(100%) invert(48%) sepia(61%) saturate(538%) hue-rotate(194deg) brightness(102%) contrast(98%); @text: brightness(0) saturate(100%) invert(30%) sepia(10%) saturate(1259%) hue-rotate(196deg) brightness(97%) contrast(91%); @subtext1: brightness(0) saturate(100%) invert(36%) sepia(10%) saturate(890%) hue-rotate(196deg) brightness(98%) contrast(90%); @subtext0: brightness(0) saturate(100%) invert(47%) sepia(6%) saturate(1263%) hue-rotate(195deg) brightness(90%) contrast(81%); @overlay2: brightness(0) saturate(100%) invert(59%) sepia(7%) saturate(825%) hue-rotate(195deg) brightness(83%) contrast(91%); @overlay1: brightness(0) saturate(100%) invert(59%) sepia(14%) saturate(333%) hue-rotate(194deg) brightness(95%) contrast(89%); @overlay0: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(595%) hue-rotate(191deg) brightness(77%) contrast(81%); @surface2: brightness(0) saturate(100%) invert(86%) sepia(6%) saturate(482%) hue-rotate(189deg) brightness(82%) contrast(88%); @surface1: brightness(0) saturate(100%) invert(85%) sepia(8%) saturate(281%) hue-rotate(187deg) brightness(92%) contrast(88%); @surface0: brightness(0) saturate(100%) invert(96%) sepia(1%) saturate(5123%) hue-rotate(185deg) brightness(93%) contrast(83%); @base: brightness(0) saturate(100%) invert(89%) sepia(5%) saturate(140%) hue-rotate(182deg) brightness(109%) contrast(94%); @mantle: brightness(0) saturate(100%) invert(93%) sepia(19%) saturate(55%) hue-rotate(182deg) brightness(98%) contrast(92%); @crust: brightness(0) saturate(100%) invert(91%) sepia(1%) saturate(4489%) hue-rotate(196deg) brightness(106%) contrast(82%); };
+  @frappe: { @rosewater: brightness(0) saturate(100%) invert(90%) sepia(6%) saturate(734%) hue-rotate(321deg) brightness(95%) contrast(99%); @flamingo: brightness(0) saturate(100%) invert(88%) sepia(52%) saturate(817%) hue-rotate(293deg) brightness(113%) contrast(84%); @pink: brightness(0) saturate(100%) invert(76%) sepia(15%) saturate(844%) hue-rotate(280deg) brightness(107%) contrast(91%); @mauve: brightness(0) saturate(100%) invert(71%) sepia(25%) saturate(725%) hue-rotate(225deg) brightness(94%) contrast(91%); @red: brightness(0) saturate(100%) invert(67%) sepia(3%) saturate(7209%) hue-rotate(305deg) brightness(91%) contrast(99%); @maroon: brightness(0) saturate(100%) invert(61%) sepia(14%) saturate(957%) hue-rotate(307deg) brightness(109%) contrast(90%); @peach: brightness(0) saturate(100%) invert(68%) sepia(28%) saturate(662%) hue-rotate(335deg) brightness(96%) contrast(94%); @yellow: brightness(0) saturate(100%) invert(94%) sepia(88%) saturate(684%) hue-rotate(309deg) brightness(105%) contrast(80%); @green: brightness(0) saturate(100%) invert(89%) sepia(23%) saturate(582%) hue-rotate(42deg) brightness(87%) contrast(89%); @teal: brightness(0) saturate(100%) invert(91%) sepia(13%) saturate(986%) hue-rotate(110deg) brightness(85%) contrast(81%); @sky: brightness(0) saturate(100%) invert(75%) sepia(15%) saturate(623%) hue-rotate(141deg) brightness(109%) contrast(81%); @sapphire: brightness(0) saturate(100%) invert(77%) sepia(20%) saturate(730%) hue-rotate(157deg) brightness(97%) contrast(76%); @blue: brightness(0) saturate(100%) invert(68%) sepia(16%) saturate(1070%) hue-rotate(185deg) brightness(96%) contrast(95%); @lavender: brightness(0) saturate(100%) invert(75%) sepia(20%) saturate(626%) hue-rotate(201deg) brightness(101%) contrast(89%); @text: brightness(0) saturate(100%) invert(83%) sepia(12%) saturate(582%) hue-rotate(191deg) brightness(98%) contrast(96%); @subtext1: brightness(0) saturate(100%) invert(80%) sepia(18%) saturate(411%) hue-rotate(190deg) brightness(96%) contrast(84%); @subtext0: brightness(0) saturate(100%) invert(82%) sepia(6%) saturate(1287%) hue-rotate(192deg) brightness(86%) contrast(85%); @overlay2: brightness(0) saturate(100%) invert(65%) sepia(36%) saturate(230%) hue-rotate(190deg) brightness(92%) contrast(82%); @overlay1: brightness(0) saturate(100%) invert(55%) sepia(12%) saturate(638%) hue-rotate(189deg) brightness(98%) contrast(87%); @overlay0: brightness(0) saturate(100%) invert(49%) sepia(13%) saturate(662%) hue-rotate(192deg) brightness(94%) contrast(84%); @surface2: brightness(0) saturate(100%) invert(41%) sepia(20%) saturate(469%) hue-rotate(191deg) brightness(93%) contrast(86%); @surface1: brightness(0) saturate(100%) invert(34%) sepia(14%) saturate(771%) hue-rotate(190deg) brightness(89%) contrast(85%); @surface0: brightness(0) saturate(100%) invert(28%) sepia(7%) saturate(1468%) hue-rotate(193deg) brightness(92%) contrast(95%); @base: brightness(0) saturate(100%) invert(20%) sepia(17%) saturate(747%) hue-rotate(192deg) brightness(96%) contrast(97%); @mantle: brightness(0) saturate(100%) invert(8%) sepia(7%) saturate(7271%) hue-rotate(198deg) brightness(88%) contrast(75%); @crust: brightness(0) saturate(100%) invert(7%) sepia(7%) saturate(7415%) hue-rotate(197deg) brightness(86%) contrast(79%); };
+  @macchiato: { @rosewater: brightness(0) saturate(100%) invert(88%) sepia(13%) saturate(322%) hue-rotate(321deg) brightness(102%) contrast(91%); @flamingo: brightness(0) saturate(100%) invert(82%) sepia(3%) saturate(3070%) hue-rotate(314deg) brightness(107%) contrast(88%); @pink: brightness(0) saturate(100%) invert(80%) sepia(23%) saturate(509%) hue-rotate(280deg) brightness(102%) contrast(92%); @mauve: brightness(0) saturate(100%) invert(65%) sepia(18%) saturate(903%) hue-rotate(222deg) brightness(104%) contrast(93%); @red: brightness(0) saturate(100%) invert(61%) sepia(19%) saturate(1541%) hue-rotate(305deg) brightness(110%) contrast(86%); @maroon: brightness(0) saturate(100%) invert(71%) sepia(10%) saturate(1331%) hue-rotate(306deg) brightness(93%) contrast(101%); @peach: brightness(0) saturate(100%) invert(73%) sepia(13%) saturate(1676%) hue-rotate(330deg) brightness(103%) contrast(92%); @yellow: brightness(0) saturate(100%) invert(87%) sepia(89%) saturate(321%) hue-rotate(314deg) brightness(101%) contrast(87%); @green: brightness(0) saturate(100%) invert(93%) sepia(12%) saturate(1128%) hue-rotate(48deg) brightness(92%) contrast(85%); @teal: brightness(0) saturate(100%) invert(92%) sepia(10%) saturate(1176%) hue-rotate(110deg) brightness(87%) contrast(90%); @sky: brightness(0) saturate(100%) invert(78%) sepia(57%) saturate(230%) hue-rotate(142deg) brightness(96%) contrast(84%); @sapphire: brightness(0) saturate(100%) invert(74%) sepia(35%) saturate(438%) hue-rotate(156deg) brightness(92%) contrast(93%); @blue: brightness(0) saturate(100%) invert(67%) sepia(17%) saturate(1007%) hue-rotate(183deg) brightness(99%) contrast(94%); @lavender: brightness(0) saturate(100%) invert(74%) sepia(6%) saturate(2559%) hue-rotate(198deg) brightness(103%) contrast(94%); @text: brightness(0) saturate(100%) invert(81%) sepia(9%) saturate(726%) hue-rotate(192deg) brightness(104%) contrast(92%); @subtext1: brightness(0) saturate(100%) invert(84%) sepia(5%) saturate(1453%) hue-rotate(193deg) brightness(94%) contrast(86%); @subtext0: brightness(0) saturate(100%) invert(75%) sepia(18%) saturate(361%) hue-rotate(190deg) brightness(91%) contrast(86%); @overlay2: brightness(0) saturate(100%) invert(67%) sepia(9%) saturate(814%) hue-rotate(191deg) brightness(92%) contrast(88%); @overlay1: brightness(0) saturate(100%) invert(49%) sepia(38%) saturate(203%) hue-rotate(190deg) brightness(101%) contrast(93%); @overlay0: brightness(0) saturate(100%) invert(46%) sepia(16%) saturate(552%) hue-rotate(193deg) brightness(93%) contrast(84%); @surface2: brightness(0) saturate(100%) invert(34%) sepia(16%) saturate(611%) hue-rotate(192deg) brightness(101%) contrast(87%); @surface1: brightness(0) saturate(100%) invert(30%) sepia(11%) saturate(1085%) hue-rotate(194deg) brightness(92%) contrast(89%); @surface0: brightness(0) saturate(100%) invert(18%) sepia(21%) saturate(880%) hue-rotate(193deg) brightness(97%) contrast(84%); @base: brightness(0) saturate(100%) invert(12%) sepia(42%) saturate(570%) hue-rotate(194deg) brightness(90%) contrast(90%); @mantle: brightness(0) saturate(100%) invert(6%) sepia(6%) saturate(7499%) hue-rotate(200deg) brightness(93%) contrast(85%); @crust: brightness(0) saturate(100%) invert(5%) sepia(8%) saturate(5346%) hue-rotate(202deg) brightness(98%) contrast(88%); };
+  @mocha: { @rosewater: brightness(0) saturate(100%) invert(92%) sepia(5%) saturate(704%) hue-rotate(320deg) brightness(99%) contrast(93%); @flamingo: brightness(0) saturate(100%) invert(81%) sepia(5%) saturate(987%) hue-rotate(315deg) brightness(107%) contrast(90%); @pink: brightness(0) saturate(100%) invert(86%) sepia(11%) saturate(1177%) hue-rotate(283deg) brightness(101%) contrast(92%); @mauve: brightness(0) saturate(100%) invert(65%) sepia(58%) saturate(255%) hue-rotate(224deg) brightness(96%) contrast(102%); @red: brightness(0) saturate(100%) invert(61%) sepia(19%) saturate(997%) hue-rotate(294deg) brightness(104%) contrast(91%); @maroon: brightness(0) saturate(100%) invert(66%) sepia(16%) saturate(1301%) hue-rotate(306deg) brightness(116%) contrast(84%); @peach: brightness(0) saturate(100%) invert(68%) sepia(57%) saturate(278%) hue-rotate(338deg) brightness(98%) contrast(101%); @yellow: brightness(0) saturate(100%) invert(90%) sepia(70%) saturate(380%) hue-rotate(313deg) brightness(102%) contrast(95%); @green: brightness(0) saturate(100%) invert(88%) sepia(6%) saturate(2015%) hue-rotate(63deg) brightness(104%) contrast(78%); @teal: brightness(0) saturate(100%) invert(92%) sepia(12%) saturate(991%) hue-rotate(108deg) brightness(93%) contrast(90%); @sky: brightness(0) saturate(100%) invert(84%) sepia(21%) saturate(1302%) hue-rotate(164deg) brightness(106%) contrast(84%); @sapphire: brightness(0) saturate(100%) invert(74%) sepia(20%) saturate(876%) hue-rotate(156deg) brightness(96%) contrast(93%); @blue: brightness(0) saturate(100%) invert(68%) sepia(18%) saturate(951%) hue-rotate(180deg) brightness(98%) contrast(100%); @lavender: brightness(0) saturate(100%) invert(73%) sepia(7%) saturate(1670%) hue-rotate(195deg) brightness(102%) contrast(99%); @text: brightness(0) saturate(100%) invert(86%) sepia(6%) saturate(879%) hue-rotate(190deg) brightness(100%) contrast(93%); @subtext1: brightness(0) saturate(100%) invert(84%) sepia(19%) saturate(381%) hue-rotate(193deg) brightness(91%) contrast(89%); @subtext0: brightness(0) saturate(100%) invert(84%) sepia(9%) saturate(767%) hue-rotate(192deg) brightness(84%) contrast(84%); @overlay2: brightness(0) saturate(100%) invert(63%) sepia(15%) saturate(428%) hue-rotate(191deg) brightness(96%) contrast(84%); @overlay1: brightness(0) saturate(100%) invert(56%) sepia(15%) saturate(455%) hue-rotate(192deg) brightness(90%) contrast(88%); @overlay0: brightness(0) saturate(100%) invert(44%) sepia(6%) saturate(1275%) hue-rotate(194deg) brightness(97%) contrast(88%); @surface2: brightness(0) saturate(100%) invert(34%) sepia(8%) saturate(1015%) hue-rotate(195deg) brightness(99%) contrast(89%); @surface1: brightness(0) saturate(100%) invert(25%) sepia(6%) saturate(1950%) hue-rotate(197deg) brightness(99%) contrast(86%); @surface0: brightness(0) saturate(100%) invert(19%) sepia(5%) saturate(2844%) hue-rotate(199deg) brightness(91%) contrast(93%); @base: brightness(0) saturate(100%) invert(7%) sepia(4%) saturate(7496%) hue-rotate(202deg) brightness(93%) contrast(87%); @mantle: brightness(0) saturate(100%) invert(6%) sepia(4%) saturate(7465%) hue-rotate(202deg) brightness(95%) contrast(90%); @crust: brightness(0) saturate(100%) invert(3%) sepia(13%) saturate(6863%) hue-rotate(220deg) brightness(95%) contrast(91%); };
+}


### PR DESCRIPTION
## Add Theming to Miscellaneous Analysis Features

This PR fixes unthemed drawn annotations (piece circles, arrows), and fixes unthemed local eval bar and threat analysis button.

Due to the piece circles and arrows being SVGs (and my lack of CSS/LESS experience), I'm not sure if the approach I used is the most optimal, feel free to suggest alternatives.

Arrows and piece circles example:
<img width="769" height="764" alt="image" src="https://github.com/user-attachments/assets/45da702b-15f8-4c0a-a2a8-8bf35ff679f2" />

Themed local eval bar:
<img width="323" height="67" alt="image" src="https://github.com/user-attachments/assets/79096291-4b19-4923-ba22-0189b46ca7be" />

Threat eval bar and button:
<img width="327" height="74" alt="image" src="https://github.com/user-attachments/assets/200158c7-c1a4-45b8-803c-cfd71948c4dd" />

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
