### PR TITLE
fix(lichess): add capture indicator

### DIFF
--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -390,6 +390,13 @@
         rgba(0, 0, 0, 0) 20%
       );
     }
+    square.oc.move-dest {
+      background: radial-gradient(
+        transparent 0%,
+        transparent 79%,
+        fade(@accent, 50%) 80%
+      );
+    }
     square.selected {
       background: fade(@accent, 50%);
     }


### PR DESCRIPTION
## Add Capture Indicator

Added missing capture indicator for pieces that can be taken. Indicator also uses accent color.

Closes: #1362

Before: (Note Queen on g3 not highlighted)
<img width="881" height="886" alt="image" src="https://github.com/user-attachments/assets/7e4b8aaf-23e0-4423-af71-6e5747824995" />


After: (with examples of accent changes)
Mocha mauve
<img width="884" height="891" alt="image" src="https://github.com/user-attachments/assets/3f174376-83ab-4b13-9437-8f94e0f50fc4" />
Latte maroon
<img width="882" height="882" alt="image" src="https://github.com/user-attachments/assets/2acef1df-2aef-44fc-87b0-572d62564d20" />


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
