### PR TITLE
fix(whatsapp-web): hash rerolling resistant

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.less
+++ b/styles/whatsapp-web/catppuccin.user.less
@@ -27,8 +27,8 @@
   :root .color-refresh,
   .color-refresh,
   /* Layer under mount */
-  .x1bapj5e.x1bapj5e,
-  .x1bapj5e.x1bapj5e:root {
+  .app-wrapper-web.app-wrapper-web,
+  .app-wrapper-web.app-wrapper-web:root {
     #catppuccin(@lightFlavor);
   }
 
@@ -36,20 +36,9 @@
   .dark.color-refresh,
   .color-refresh.dark,
   /* Layer under mount */
-  .x1vmw6bp.x1vmw6bp,
-  .x1vmw6bp.x1vmw6bp:root {
+  .dark .app-wrapper-web.app-wrapper-web,
+  .dark .app-wrapper-web.app-wrapper-web:root {
     #catppuccin(@darkFlavor);
-  }
-
-  /* "System default" theme */
-  .xnw4er1.xnw4er1, .xnw4er1.xnw4er1:root {
-    #catppuccin(@lightFlavor);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .xnw4er1.xnw4er1, .xnw4er1.xnw4er1:root {
-      #catppuccin(@darkFlavor);
-    }
   }
 
   #initialLoad(@styles) {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Makes whatsapp-web userstyle resistant to hash rerolls on the base theme application.

## 🗒 Checklist 🗒

- [ ] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
