### PR TITLE
fix(cinny): color emojis and search results properly

### DIFF
--- a/styles/cinny/catppuccin.user.less
+++ b/styles/cinny/catppuccin.user.less
@@ -169,7 +169,7 @@
     --ic-danger-high: @maroon;
     --ic-danger-normal: @maroon;
 
-    /* Users */
+    /* Legacy user colors */
     --mx-uc-1: @blue;
     --mx-uc-2: @pink;
     --mx-uc-3: @teal;
@@ -264,7 +264,7 @@
     }
 
     /* Search results */
-    ._1m2qi7rn {
+    ._1m2qi7rq {
       background-color: @accent;
       color: @base;
     }

--- a/styles/cinny/catppuccin.user.less
+++ b/styles/cinny/catppuccin.user.less
@@ -100,75 +100,6 @@
       }
     }
 
-    /* Backgrounds */
-    --bg-surface: @base;
-    --bg-surface-transparent: fade(@base, 0%);
-    --bg-surface-low: @mantle;
-    --bg-surface-low-transparent: fade(@mantle, 0%);
-    --bg-surface-extra-low: @crust;
-    --bg-surface-extra-low-transparent: fade(@crust, 0%);
-    --bg-surface-border: fade(@crust, 20%);
-    --bg-surface-hover: @surface0;
-    --bg-surface-active: @surface1;
-    --bg-overlay: fade(@crust, 60%);
-    --bg-overlay-low: fade(@crust, 80%);
-    --bg-primary: @accent;
-    --bg-primary-hover: fade(@accent, 80%);
-    --bg-primary-active: fade(@accent, 70%);
-    --bg-primary-border: fade(@accent, 38%);
-    --bg-tooltip: @surface0;
-    --bg-badge: @lavender;
-    --bg-positive: @green;
-    --bg-positive-hover: fade(@green, 8%);
-    --bg-positive-active: fade(@green, 15%);
-    --bg-positive-border: fade(@green, 40%);
-    --bg-caution: @peach;
-    --bg-caution-hover: fade(@peach, 8%);
-    --bg-caution-active: fade(@peach, 15%);
-    --bg-caution-border: fade(@peach, 40%);
-    --bg-danger: @maroon;
-    --bg-danger-hover: fade(@maroon, 5%);
-    --bg-danger-active: fade(@maroon, 10%);
-    --bg-danger-border: fade(@maroon, 20%);
-    --bg-ping: fade(@green, 40%);
-    --bg-ping-hover: fade(@green, 50%);
-
-    /* Texts */
-    --tc-surface-high: @text;
-    --tc-surface-normal: @text;
-    --tc-surface-normal-low: @subtext1;
-    --tc-surface-low: @subtext0;
-    --tc-primary-high: @crust;
-    --tc-primary-normal: @text;
-    --tc-primary-low: @subtext1;
-    --tc-tooltip: @subtext0;
-    --tc-code: @mauve;
-    --tc-link: @blue;
-    --tc-badge: @crust;
-    --tc-positive-high: @green;
-    --tc-positive-normal: @green;
-    --tc-positive-low: @green;
-    --tc-caution-high: @peach;
-    --tc-caution-normal: @peach;
-    --tc-caution-low: @peach;
-    --tc-danger-high: @maroon;
-    --tc-danger-normal: @maroon;
-    --tc-danger-low: @maroon;
-
-    /* Icons */
-    --ic-surface-high: @text;
-    --ic-surface-normal: @text;
-    --ic-surface-low: @subtext1;
-    --ic-primary-high: @crust;
-    --ic-primary-normal: @crust;
-    --ic-primary-low: @crust;
-    --ic-positive-high: @green;
-    --ic-positive-normal: @maroon;
-    --ic-caution-high: @peach;
-    --ic-caution-normal: @peach;
-    --ic-danger-high: @maroon;
-    --ic-danger-normal: @maroon;
-
     /* Legacy user colors */
     --mx-uc-1: @blue;
     --mx-uc-2: @pink;
@@ -284,6 +215,78 @@
 
       background-color: @base;
     }
+
+    /* I don't think these actually do anything anymore, but they are
+    still defined in the app. They _might_ be removed in a future release. */
+
+    /* Backgrounds */
+    --bg-surface: @base;
+    --bg-surface-transparent: fade(@base, 0%);
+    --bg-surface-low: @mantle;
+    --bg-surface-low-transparent: fade(@mantle, 0%);
+    --bg-surface-extra-low: @crust;
+    --bg-surface-extra-low-transparent: fade(@crust, 0%);
+    --bg-surface-border: fade(@crust, 20%);
+    --bg-surface-hover: @surface0;
+    --bg-surface-active: @surface1;
+    --bg-overlay: fade(@crust, 60%);
+    --bg-overlay-low: fade(@crust, 80%);
+    --bg-primary: @accent;
+    --bg-primary-hover: fade(@accent, 80%);
+    --bg-primary-active: fade(@accent, 70%);
+    --bg-primary-border: fade(@accent, 38%);
+    --bg-tooltip: @surface0;
+    --bg-badge: @lavender;
+    --bg-positive: @green;
+    --bg-positive-hover: fade(@green, 8%);
+    --bg-positive-active: fade(@green, 15%);
+    --bg-positive-border: fade(@green, 40%);
+    --bg-caution: @peach;
+    --bg-caution-hover: fade(@peach, 8%);
+    --bg-caution-active: fade(@peach, 15%);
+    --bg-caution-border: fade(@peach, 40%);
+    --bg-danger: @maroon;
+    --bg-danger-hover: fade(@maroon, 5%);
+    --bg-danger-active: fade(@maroon, 10%);
+    --bg-danger-border: fade(@maroon, 20%);
+    --bg-ping: fade(@green, 40%);
+    --bg-ping-hover: fade(@green, 50%);
+
+    /* Texts */
+    --tc-surface-high: @text;
+    --tc-surface-normal: @text;
+    --tc-surface-normal-low: @subtext1;
+    --tc-surface-low: @subtext0;
+    --tc-primary-high: @crust;
+    --tc-primary-normal: @text;
+    --tc-primary-low: @subtext1;
+    --tc-tooltip: @subtext0;
+    --tc-code: @mauve;
+    --tc-link: @blue;
+    --tc-badge: @crust;
+    --tc-positive-high: @green;
+    --tc-positive-normal: @green;
+    --tc-positive-low: @green;
+    --tc-caution-high: @peach;
+    --tc-caution-normal: @peach;
+    --tc-caution-low: @peach;
+    --tc-danger-high: @maroon;
+    --tc-danger-normal: @maroon;
+    --tc-danger-low: @maroon;
+
+    /* Icons */
+    --ic-surface-high: @text;
+    --ic-surface-normal: @text;
+    --ic-surface-low: @subtext1;
+    --ic-primary-high: @crust;
+    --ic-primary-normal: @crust;
+    --ic-primary-low: @crust;
+    --ic-positive-high: @green;
+    --ic-positive-normal: @maroon;
+    --ic-caution-high: @peach;
+    --ic-caution-normal: @peach;
+    --ic-danger-high: @maroon;
+    --ic-danger-normal: @maroon;
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

- removed the background color in emojis
- made the background colors of message search results work

| old | now |
| --- | --- |
| <img width="153" height="67" alt="image" src="https://github.com/user-attachments/assets/b44dbd62-99f9-41e7-92f9-9dd3b527e976" /> | <img width="153" height="67" alt="image" src="https://github.com/user-attachments/assets/6ccbc7ed-ec31-484d-9e0f-4df2ef90a1bd" /> |
| <img width="315" height="72" alt="image" src="https://github.com/user-attachments/assets/b739483a-f938-4404-bbf8-d0449c368d80" /> | <img width="315" height="72" alt="image" src="https://github.com/user-attachments/assets/a2aef615-3850-4a17-a324-c79ece3e0757" /> |

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
