### PR TITLE
chore(lib): mark staff as codeowners

### DIFF
--- a/scripts/generate/main.ts
+++ b/scripts/generate/main.ts
@@ -58,6 +58,8 @@ async function userstylesStaffCodeOwners() {
   const paths = ["/.github/", "/scripts/", "/template/", "/lib/"];
 
   const octokit = getAuthenticatedOctokit();
+  // Set codeowners to include each member of the userstyles-staff team specifically instead of the team as a whole,
+  // to require individual reviews from each member instead of just one on behalf of the team.
   const staffMembers = await getUserstylesTeamMembers(
     octokit,
     "userstyles-staff",

--- a/scripts/generate/main.ts
+++ b/scripts/generate/main.ts
@@ -55,7 +55,7 @@ function maintainersCodeOwners() {
     .join("\n");
 }
 async function userstylesStaffCodeOwners() {
-  const paths = ["/.github/", "/scripts/", "/template/"];
+  const paths = ["/.github/", "/scripts/", "/template/", "/lib/"];
 
   const octokit = getAuthenticatedOctokit();
   const staffMembers = await getUserstylesTeamMembers(


### PR DESCRIPTION
Marks the whole `lib/` folder as owned by staff, since library modules are intended to be used by more than one userstyle they have larger ranging consequences than just a single userstyle would.