### PR TITLE
fix(google-photos): root target selector

### DIFF
--- a/styles/google-photos/catppuccin.user.less
+++ b/styles/google-photos/catppuccin.user.less
@@ -16,7 +16,7 @@
 ==/UserStyle== */
 
 @-moz-document domain("photos.google.com") {
-  :root {
+  body {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Fixes the root target selector for Google Photos.

## 🗒 Checklist 🗒

- [ ] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
