### PR TITLE
chore(google-gemini): add `WalkQuackBack` as maintainer

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -359,7 +359,7 @@ userstyles:
     categories: [artificial_intelligence]
     icon: googlegemini
     color: mauve
-    current-maintainers: [*Dandraghas]
+    current-maintainers: [*Dandraghas, *WalkQuackBack]
   hackage:
     name: Hackage
     link: https://hackage.haskell.org


### PR DESCRIPTION
Add WalkQuackBack as maintainer for google-gemini
In preperation for library PRs