### PR TITLE
fix(npm): use accent over red for dependency links

### DIFF
--- a/styles/npm/catppuccin.user.less
+++ b/styles/npm/catppuccin.user.less
@@ -632,7 +632,7 @@
     #tabpanel-dependencies,
     #tabpanel-dependents {
       ul a {
-        color: @red;
+        color: @accent;
 
         &:hover {
           color: @text;


### PR DESCRIPTION
Used `red` mistakenly originally to match the site, red is npm's accent so it should really be `accent`.