### PR TITLE
fix(tuta): retheme calendar and small elements

### DIFF
--- a/styles/tuta/catppuccin.user.less
+++ b/styles/tuta/catppuccin.user.less
@@ -74,6 +74,62 @@
       color: @text;
     }
 
+    /* calendar */
+    .mlr-l.rel, .pt-s.pb-m {
+      background: @mantle !important;
+    }
+
+    .calendar-day {
+      background: @mantle;
+      border-color: @surface0;
+    }
+
+    .calendar-day:hover {
+      background: @base;
+    }
+
+    .calendar-current-day-circle {
+      background: @subtext1;
+    }
+
+    /* search fix */
+    .search-bar {
+      background-color: @surface0;
+    }
+
+    .search-bar:hover {
+      background-color: lighten(@surface0, 5%);
+    }
+
+    .counter-badge {
+      background-color: @surface1 !important;
+    }
+
+    /* small fixes */
+    .mlr-l {
+      color: @text;
+    }
+
+    .text-bubble.button-content, .input {
+      color: @text !important;
+    }
+
+    .fill-absolute.content-bg, .tutaui-card-container {
+      background-color: @mantle !important;
+    }
+
+    .flex, .selectable, .editor-border, .dialog-header {
+      border-color: @surface0 !important;
+    }
+
+    .toggle-button .icon.icon-large.center-h > .ionicon {
+      color: @text !important;
+    }
+
+    .checkbox {
+      border-color: @text;
+    }
+
     .list-row {
       background-color: @base;
     }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed elements on the calendar page and small elements such as the "online" message and settings menu backgrounds
This PR 

Closes #1785 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md).
