### PR TITLE
docs(contributing): clarify lint command, automated versioning

### DIFF
--- a/docs/src/content/docs/contributing/index.md
+++ b/docs/src/content/docs/contributing/index.md
@@ -9,7 +9,11 @@ If it is your first time contributing to a project on GitHub, please see the pop
 
 ## Development environment
 
-This repositories uses [Deno](https://deno.com/) extensively for linting, formatting, and automation. We highly recommend setting up Deno locally to improve your workflow — see ["Installation" - Deno Docs](https://docs.deno.com/runtime/manual/getting_started/installation). With Deno installed locally, you can run the lint script using `deno task lint` (and `deno task lint:fix` to automatically apply fixes) and the formatting script using `deno fmt`.
+This repository uses [Deno](https://deno.com/) extensively for linting, formatting, and automation. It is highly recommended to set up Deno locally to improve your workflow — see ["Installation" - Deno Docs](https://docs.deno.com/runtime/manual/getting_started/installation).
+
+With Deno installed locally, you can lint all userstyles with `deno task lint`, and if any issues are found, `deno task lint:fix` to automatically apply fixes in some cases. For quicker linting, specify the userstyle to lint with `deno task lint my-userstyle` (or equivalently using the relative path/autocomplete, `deno task lint styles/my-userstyle`).
+
+It's helpful to maintainers to run formatting with `deno fmt` before opening a pull request, though not strictly necessary.
 
 > [!IMPORTANT]
 > `deno task lint` is not to be confused with Deno's built-in linter, `deno lint`. `deno lint` only checks our TypeScript files in `scripts/`, whereas `deno task lint` is the custom Deno task for linting userstyles that you should be using.

--- a/docs/src/content/docs/contributing/index.md
+++ b/docs/src/content/docs/contributing/index.md
@@ -9,19 +9,28 @@ If it is your first time contributing to a project on GitHub, please see the pop
 
 ## Development environment
 
-This repositories uses [Deno](https://deno.com/) extensively for linting, formatting, and automation. We recommend setting up Deno locally to improve your workflow — see ["Installation" - Deno Docs](https://docs.deno.com/runtime/manual/getting_started/installation). With Deno installed locally, you can run the lint script using `deno task lint` (and `deno task lint:fix` to automatically apply fixes) and the formatting script using `deno fmt`.
+This repositories uses [Deno](https://deno.com/) extensively for linting, formatting, and automation. We highly recommend setting up Deno locally to improve your workflow — see ["Installation" - Deno Docs](https://docs.deno.com/runtime/manual/getting_started/installation). With Deno installed locally, you can run the lint script using `deno task lint` (and `deno task lint:fix` to automatically apply fixes) and the formatting script using `deno fmt`.
 
-When editing a userstyle, we suggest setting up live reloading so that local changes (from your IDE) can be automatically reloaded through Stylus. See ["Using hot reloading in Stylus"](/contributing/tips-and-tricks/hot-reloading/).
+> [!IMPORTANT]
+> `deno task lint` is not to be confused with Deno's built-in linter, `deno lint`. `deno lint` only checks our TypeScript files in `scripts/`, whereas `deno task lint` is the custom Deno task for linting userstyles that you should be using.
 
-## Recommendations
+To edit and/or create userstyles, [set up live reloading](/contributing/tips-and-tricks/hot-reloading/) so that local changes (edits made from your editor of choice) can be automatically reloaded through Stylus.
+
+## Versioning
+
+You may notice that userstyles contain a line in the format of `@version 2000.01.01` in the UserCSS metadata section at the top. **This line should not be edited by hand**. We use an automated versioning system that updates the version value (based on [Calendar Versioning](https://calver.org/)) when a change is made to a userstyle, after merging the pull request.
+
+## Authoring userstyles
 
 ### Assessing websites
 
-Some websites are unfortunately not ideal for userstyles. Websites with auto-generated classes - think `aeN WR beA nH oy8Mbf`, `cfb2a888`, etc. - lead to unreadable and unmaintainable userstyles that break quickly and are difficult to update/maintain. Such userstyles, if created, will also take longer to review and merge.
+Some websites are, unfortunately, not ideal for userstyles. Websites with auto-generated classes — think `aeN WR beA nH oy8Mbf`, `cfb2a888`, and so on — lead to unreadable and unmaintainable userstyles that break quickly and are difficult to update/maintain. Such userstyles, if created, will also take longer to review and merge.
+
+On the other hand, if a website uses CSS variables — see below — it is a great candidate for userstyling.
 
 ### CSS variables
 
-While writing a userstyle, you may have come across [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) (or "custom properties"). We prefer that these variables are used if present, rather than theming individual elements. As the website typically uses these variables itself, it saves a lot of work in theming and maintaining the userstyle.
+While writing a userstyle, you may come across [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) (or "custom properties"). We prefer that these variables are used if present, rather than theming individual elements. As the website typically uses these variables itself, it saves a lot of work in theming and maintaining the userstyle.
 
 ### Opinionated changes
 


### PR DESCRIPTION
The (already existing) `## Authoring userstyles` section is messy. I can't figure out how to structure it in a way where it is meaningfully located. The assessing websites part should probably be on userstyles creation page?