### PR TITLE
docs(guides/images-and-svgs): monochrome images, inlined svg data urls

### DIFF
--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -58,7 +58,7 @@ Once you have obtained the SVG contents, paste them in between the single quotes
 ```
 
 > [!NOTE]
-> Make sure the quotes in `escape('')` are single quotes, not double quotes (`escape("")`), before pasting the SVG contents. Using double quotes will not work as double quotes are also used in the contents of SVGs.
+> Ensure `escape()` uses single quotes, not double quotes, before pasting the SVG contents — `escape('')`, not `escape("")`.
 
 > [!WARNING]
 > The error `Invalid % without number` appears until an interpolated color is added in the SVG contents. This is covered in the following section.

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -43,7 +43,11 @@ Below is an example of what a rule for an inlined SVG data URL could look like.
 }
 ```
 
-The contents past `data:image/svg+xml,` are almost gibberish. This is because they are URL encoded. To get the actual SVG contents, you'll need to URL decode the string. This can be done with the JavaScript builtin function `decodeURIComponent`; run `node -e 'console.log(decodeURIComponent("..."))'`, inserting your URL encoded SVG contents in between the double quotes in place of the `...`. Alternatively, use an online tool such as https://www.urldecoder.io/.
+The text after `data:image/svg+xml,` is URL encoded. To get the contents of the SVG, the string needs to be URL decoded.
+
+There are two ways to do this:
+- Using the JavaScript built-in function `decodeURIComponent`. You can run `node -e 'console.log(decodeURIComponent("..."))'`, with the URL encoded SVG contents placed between the double quotes in place of `...`.
+- Use an online tool such as [https://www.urldecoder.io/](URLDecoder).
 
 ---
 

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -7,7 +7,7 @@ sidebar:
 
 ## Monochrome `<img>` elements
 
-If you encounter an `<img>` element with bitonal contents, the easiest way to theme it is to apply a CSS color filter. The `@<color>-filter` filters can be used to theme Catppuccin colours.
+If you encounter an `<img>` element with single colored contents, the easiest way to theme it is to apply a CSS color filter. The `@<color>-filter` filters can be used to theme Catppuccin colours.
 
 For example:
 

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -61,7 +61,7 @@ Once you have obtained the SVG contents, paste them in between the single quotes
 > Make sure the quotes in `escape('')` are single quotes, not double quotes (`escape("")`), before pasting the SVG contents. Using double quotes will not work as double quotes are also used in the contents of SVGs.
 
 > [!WARNING]
-> The `Invalid % without number` error may appear until an interpolated color is added in the SVG contents (as is detailed below).
+> The error `Invalid % without number` appears until an interpolated color is added in the SVG contents. This is covered in the following section.
 
 Now, replace any colors in the SVG with their respective Catppuccin variants. For example, take the following SVG icon for Twitter:
 

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -31,7 +31,7 @@ Below is an example of what a rule for an external SVG URL could look like.
 }
 ```
 
-The easiest way to theme external SVGs is to visit the URL of the SVG and paste its contents.
+To obtain the contents of this remote SVG resource, you can either: visit the URL of the SVG, right click and select **View Page Source**, and copy its contents from the resulting page; or, run `curl "https://example.org/assets/xyz.svg"` and copy the contents from the terminal output (copy the contents automatically with `curl "https://example.org/assets/xyz.svg" | pbcopy` on macOS).
 
 ### Inlined SVG data URL
 

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -31,7 +31,12 @@ Below is an example of what a rule for an external SVG URL could look like.
 }
 ```
 
-To obtain the contents of this remote SVG resource, you can either: visit the URL of the SVG, right click and select **View Page Source**, and copy its contents from the resulting page; or, run `curl "https://example.org/assets/xyz.svg"` and copy the contents from the terminal output (copy the contents automatically with `curl "https://example.org/assets/xyz.svg" | pbcopy` on macOS).
+To obtain the contents of this remote SVG resource, you can either:
+- Visit the URL of the SVG, right click and select **View Page Source**, and copy its contents from the resulting page.
+- Run `curl "https://example.org/assets/xyz.svg"` and copy the contents from the terminal output.
+
+> [!TIP]
+> On macOS, copy the SVG contents after `curl`-ing automatically with `| pbcopy`: `curl "https://example.org/assets/xyz.svg" | pbcopy`.
 
 ### Inlined SVG data URL
 

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -86,7 +86,9 @@ There is only one color used, `fill="#1D9BF0"`. That hex code is a shade of blue
 
 ## External SVGs through `<img>` elements
 
-Theming an external SVG in an `<img>>` element is similar, but the `content` property is used instead of `background-image` to cover up the original image with our new one. As with the previous tip for `background-image`, you only need to update the SVG inside of the `escape('')` (see above for details).
+Theming an external SVG referenced from an `<img>` element is similar. However, the `content` property is used instead of `background-image` to replace the image.
+
+As with the previous tip for `background-image`, only the SVG inside of the `escape('')` needs to be updated.
 
 ```less
 img.xyz {

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -7,7 +7,7 @@ sidebar:
 
 ## Monochrome `<img>` elements
 
-If you encounter an `<img>` element with monochrome contents, the easiest approach is to apply a CSS color filter. You can use the `@<color>-filter` variables provided out of the box.
+If you encounter an `<img>` element with bitonal contents, the easiest way to theme it is to apply a CSS color filter. The `@<color>-filter` filters can be used to theme Catppuccin colours.
 
 For example:
 

--- a/docs/src/content/docs/contributing/guides/images-and-svgs.md
+++ b/docs/src/content/docs/contributing/guides/images-and-svgs.md
@@ -5,9 +5,25 @@ sidebar:
   order: 2
 ---
 
+## Monochrome `<img>` elements
+
+If you encounter an `<img>` element with monochrome contents, the easiest approach is to apply a CSS color filter. You can use the `@<color>-filter` variables provided out of the box.
+
+For example:
+
+```css
+img.twitter-icon {
+  filter: @blue-filter;
+}
+```
+
 ## SVGs as `background-image`s
 
-Websites will sometimes use the `background-image` CSS property to apply an SVG, often for icons. We will refer to these as "external SVGs" throughout the rest of this guide, as the SVGs are usually at a different URL and linked to with [`url()`](https://developer.mozilla.org/en-US/docs/Web/CSS/url). Below is an example of what a rule for an external SVG could look like.
+Websites will sometimes use the `background-image` CSS property to apply an SVG, often for icons. The value of the `background-image` is usually either a URL to an external SVG resource, such as `url("https://example.org/assets/xyz.svg")`, or an inlined SVG [data URL](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data), like `url("data:image/svg+xml,%3Csvg%3E...%3C/svg%3E");`.
+
+### External SVG URL
+
+Below is an example of what a rule for an external SVG URL could look like.
 
 ```css
 .xyz {
@@ -15,17 +31,37 @@ Websites will sometimes use the `background-image` CSS property to apply an SVG,
 }
 ```
 
-The easiest way to theme external SVGs is to visit the URL of the SVG and paste its contents in between the single quotes of the `escape('')` section of the following template:
+The easiest way to theme external SVGs is to visit the URL of the SVG and paste its contents.
 
+### Inlined SVG data URL
+
+Below is an example of what a rule for an inlined SVG data URL could look like.
+
+```css
+.xyz {
+  background-image: url("data:image/svg+xml,%3Csvg%20viewBox%3D%220%200%2024%2024%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20fill%3D%22red%22%20d%3D%22%22/%3E%3C/svg%3E");
+}
+```
+
+The contents past `data:image/svg+xml,` are almost gibberish. This is because they are URL encoded. To get the actual SVG contents, you'll need to URL decode the string. This can be done with the JavaScript builtin function `decodeURIComponent`; run `node -e 'console.log(decodeURIComponent("..."))'`, inserting your URL encoded SVG contents in between the double quotes in place of the `...`. Alternatively, use an online tool such as https://www.urldecoder.io/.
+
+---
+
+Once you have obtained the SVG contents, paste them in between the single quotes of `escape('')` in the following template:
+
+<!-- deno-fmt-ignore -->
 ```less
 .xyz {
-  @svg: escape("<svg>...</svg>");
+  @svg: escape('');
   background-image: url("data:image/svg+xml,@{svg}");
 }
 ```
 
 > [!NOTE]
-> The `Invalid % without number` error may appear if you have not done the following step. Make sure to add/replace an interpolated color in the SVG contents (as is detailed below) for this error to go away.
+> Make sure the quotes in `escape('')` are single quotes, not double quotes (`escape("")`), before pasting the SVG contents. Using double quotes will not work as double quotes are also used in the contents of SVGs.
+
+> [!WARNING]
+> The `Invalid % without number` error may appear until an interpolated color is added in the SVG contents (as is detailed below).
 
 Now, replace any colors in the SVG with their respective Catppuccin variants. For example, take the following SVG icon for Twitter:
 
@@ -44,9 +80,9 @@ There is only one color used, `fill="#1D9BF0"`. That hex code is a shade of blue
 }
 ```
 
-## `<img>` elements
+## External SVGs through `<img>` elements
 
-Theming an inline image is similar, but `content` is used instead of `background-image` to cover up the original image with our new one. As with the previous tip for `background-image`, you only need to update the SVG inside of the `escape('')` (see above for details).
+Theming an external SVG in an `<img>>` element is similar, but the `content` property is used instead of `background-image` to cover up the original image with our new one. As with the previous tip for `background-image`, you only need to update the SVG inside of the `escape('')` (see above for details).
 
 ```less
 img.xyz {
@@ -63,17 +99,5 @@ img.twitter-icon {
     '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="@{blue}" d="M21.543 7.104c.015.211.015.423.015.636 0 6.507-4.954 14.01-14.01 14.01v-.003A13.94 13.94 0 0 1 0 19.539a9.88 9.88 0 0 0 7.287-2.041 4.93 4.93 0 0 1-4.6-3.42 4.916 4.916 0 0 0 2.223-.084A4.926 4.926 0 0 1 .96 9.167v-.062a4.887 4.887 0 0 0 2.235.616A4.928 4.928 0 0 1 1.67 3.148 13.98 13.98 0 0 0 11.82 8.292a4.929 4.929 0 0 1 8.39-4.49 9.868 9.868 0 0 0 3.128-1.196 4.941 4.941 0 0 1-2.165 2.724A9.828 9.828 0 0 0 24 4.555a10.019 10.019 0 0 1-2.457 2.549z"/></svg>'
   );
   content: url("data:image/svg+xml,@{svg}");
-}
-```
-
-## Non-SVG images or many `<img>` elements with external SVGs
-
-If you encounter non-SVG images, or many `<img>` elements that are single-colored, the best approach is to apply a CSS color filter to the images. You can use the `@<color>-filter` variables provided out of the box.
-
-For example:
-
-```css
-img.twitter-icon {
-  filter: @blue-filter;
 }
 ```


### PR DESCRIPTION
Moves the formerly titled "Non-SVG images or many `<img>` elements with external SVGs" section to the top, now titled "Monochrome `<img>` elements". Since the filter palette and variables are included by default with the standard library, this is now by far the easiest and simplest way for many usecases.

In the "SVGs as `background-image`s" section, I've split the obtaining of the SVG contents into two subsections depending on the original format. This includes a new subsection on "Inlined SVG data URL"s.

An additional note about single quotes when pasting SVG contents, some wording changes.