### PR TITLE
feat(lichess): unthemed UI elements

### DIFF
--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -109,6 +109,13 @@
       background: @crust;
     }
 
+    /* Hamburger menu */
+    .hbg__in {
+      &, &::before, &::after {
+        background-color: @overlay1;
+      }
+    }
+
     /* Popup skining */
     dialog {
       background: @crust;

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -115,6 +115,18 @@
         background-color: @overlay1;
       }
     }
+    .topnav-toggle:checked ~ .hbg {
+      background: @base;
+    }
+    @media (max-width: 1019.29px) {
+    #topnav {
+      background: @crust;
+
+      & .community-patron::after  {
+        color: @peach;
+      }
+    }
+  }
 
     /* Popup skining */
     dialog {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This pull request aims to theme the following from #1891:

- [X] Hamburger menu icon
- [X] Hamburger menu headers/sections
- [ ] Settings menu item hovers
- [ ] Stockfish configuration buttons
- [ ] Sign in, register page (input borders, sign in button)

Screenshots:

<img width="433" height="930" alt="image" src="https://github.com/user-attachments/assets/3da6c6b3-ec89-49ff-b9f5-47b54812498f" />


## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
