### PR TITLE
feat(scripts/lint): provide lint fix tip with failed lint run

### DIFF
--- a/scripts/lint/main.ts
+++ b/scripts/lint/main.ts
@@ -73,7 +73,7 @@ if (didLintFail || log.failed) {
     console.log(
       `\n  ${
         color.bold(color.inverse(color.green(`${THIN_SPACE}TIP${THIN_SPACE}`)))
-      }: Run ${color.bold("deno task lint:fix")} to fix autofixable issues.`,
+      } Run ${color.bold("deno task lint:fix")} to fix autofixable issues.`,
     );
   }
   Deno.exit(1);


### PR DESCRIPTION
Prints a tip instructing users to run `deno task lint:fix` when the lint run fails and they aren't already passing the fix argument.

<img width="1544" height="1160" alt="CleanShot 2025-09-08 at 17 10 24" src="https://github.com/user-attachments/assets/d7f188c9-1e04-446c-8160-6d7f1cd57958" />
