### PR TITLE
fix(porkbun): unthemed utilitarian view

### DIFF
--- a/styles/porkbun/catppuccin.user.less
+++ b/styles/porkbun/catppuccin.user.less
@@ -139,6 +139,13 @@
       }
     }
 
+    /* fix button background with utilitarian table view */
+    .utilitarianTableRow {
+      .btn-default {
+        background-color: @base;
+      }
+    }
+
     .btn-primary {
       background-color: @accent;
       border-color: @accent;
@@ -240,6 +247,11 @@
 
       [style*="border-top:2px solid gray;"] {
         border-top-color: @surface2 !important;
+      }
+
+      /* utilitarian view */
+      tbody > tr {
+        background-color: @base;
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

fixes the utilitarian view being unthemed:
<img width="1262" height="504" alt="image" src="https://github.com/user-attachments/assets/6ff9135b-084e-4d8a-8077-91cac1bffb4b" />
with fix

<img width="1295" height="446" alt="image" src="https://github.com/user-attachments/assets/8f16bf4f-22ab-409f-a66b-dc6be692b80f" />
without fix

(you can enable this view under "domain management settings")

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
