### PR TITLE
fix(lichess): fix invisible top clock

### DIFF
--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -422,6 +422,9 @@
     .rclock .bar {
       background: @accent;
     }
+    .rclock-top {
+      z-index: 0;
+    }
 
     /* Game Cards */
     .game__meta,


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This PR fixes the invisible top clock. It does not change the color of the unthemed running clock which will be done in #1897.

Before:
<img width="1279" height="874" alt="Screenshot 2025-09-12 at 14 38 24" src="https://github.com/user-attachments/assets/c7dab66d-deb0-4cf7-898c-c8d35b36e05e" />


After:
<img width="1294" height="866" alt="Screenshot 2025-09-12 at 14 39 29" src="https://github.com/user-attachments/assets/c2859267-9e49-4b96-9d75-b919ee712fcb" />



## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
