### PR TITLE
fix(whatsapp-web): contrast rebalancing

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.less
+++ b/styles/whatsapp-web/catppuccin.user.less
@@ -77,6 +77,7 @@
 
     @emphasize: 10%;
     @deemphasize: if(@flavor = latte, 15%, 30%);
+    @bubble-surface-deemp: 20%;
 
     @scrim: 30%;
     @pressed: 20%;
@@ -134,16 +135,16 @@
       if(@lighterMessages = 1, @surface1, @base),
     );
 
-    #WDS(systems-bubble-surface-outgoing, mix(@accent, @base, @deemphasize));
+    #WDS(systems-bubble-surface-outgoing, mix(@accent, @base, @bubble-surface-deemp));
     #WDS(systems-bubble-content-deemphasized, fade(@text, 50%));
 
     #WDS(systems-bubble-surface-overlay, @mantle);
     #WDS(systems-bubble-surface-system, @mantle);
 
-    #WDS(systems-bubble-surface-e2e, mix(@yellow, @mantle, 5%));
+    #WDS(systems-bubble-surface-e2e, mix(@yellow, @mantle, @bubble-surface-deemp));
     #WDS(systems-bubble-content-e2e, @yellow);
 
-    #WDS(systems-bubble-surface-business, mix(@teal, @mantle, 5%));
+    #WDS(systems-bubble-surface-business, mix(@teal, @mantle, @bubble-surface-deemp));
 
     #WDS(systems-chat-surface-composer, @base);
     #WDS(systems-chat-background-wallpaper, @crust);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Increases the contrast for WhatsApp web chat outgoing, encryption and buisness bubbles.

<img width="1008" height="136" alt="image" src="https://github.com/user-attachments/assets/c365caaa-0fee-4d01-9eca-8f35d650a8b4" />


## 🗒 Checklist 🗒

- [ ] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
