### PR TITLE
fix(lichess): inverted piece colors and black queen piece

### DIFF
--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -362,7 +362,7 @@
       .is2d .knight {
         #piece(@f, @s) {
           @svg: escape(
-            '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="none" fill-rule="evenodd" stroke="@{s}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10c10.5 1 16.5 8 16 29H15c0-9 10-6.5 8-21" fill="@{f}"/><path d="M24 18c.38 2.91-5.55 7.37-8 9-3 2-2.82 4.34-5 4-1.042-.94 1.41-3.04 0-3-1 0 .19 1.23-1 2-1 0-4.003 1-4-4 0-2 6-12 6-12s1.89-1.9 2-3.5c-.73-.994-.5-2-.5-3 1-1 3 2.5 3 2.5h2s.78-1.992 2.5-3c1 0 1 3 1 3" fill="@{f}"/><path d="M9.5 25.5a.5.5 0 1 1-1 0 .5.5 0 1 1 1 0m5.433-9.75a.5 1.5 30 1 1-.866-.5.5 1.5 30 1 1 .866.5" fill="@{f}" stroke="@{s}"/><path d="m24.55 10.4-.45 1.45.5.15c3.15 1 5.65 2.49 7.9 6.75S35.75 29.06 35.25 39l-.05.5h2.25l.05-.5c.5-10.06-.88-16.85-3.25-21.34s-5.79-6.64-9.19-7.16z" fill="@{s}" stroke="none"/></g></svg>'
+            '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="none" fill-rule="evenodd" stroke="@{s}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10c10.5 1 16.5 8 16 29H15c0-9 10-6.5 8-21" fill="@{f}"/><path d="M24 18c.38 2.91-5.55 7.37-8 9-3 2-2.82 4.34-5 4-1.042-.94 1.41-3.04 0-3-1 0 .19 1.23-1 2-1 0-4.003 1-4-4 0-2 6-12 6-12s1.89-1.9 2-3.5c-.73-.994-.5-2-.5-3 1-1 3 2.5 3 2.5h2s.78-1.992 2.5-3c1 0 1 3 1 3" fill="@{f}"/><path d="M9.5 25.5a.5.5 0 1 1-1 0 .5.5 0 1 1 1 0m5.433-9.75a.5 1.5 30 1 1-.866-.5.5 1.5 30 1 1 .866.5" fill="@{f}" stroke="@{s}"/></g></svg>'
           );
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
@@ -390,7 +390,7 @@
       .is2d .king {
         #piece(@f, @s) {
           @svg: escape(
-            '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="@{f}" fill-rule="evenodd" stroke="@{s}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22.5 11.63V6" stroke-linejoin="miter"/><path d="M22.5 25s4.5-7.5 3-10.5c0 0-1-2.5-3-2.5s-3 2.5-3 2.5c-1.5 3 3 10.5 3 10.5" fill="@{f}" stroke-linecap="butt" stroke-linejoin="miter"/><path d="M11.5 37c5.5 3.5 15.5 3.5 21 0v-7s9-4.5 6-10.5c-4-6.5-13.5-3.5-16 4V27v-3.5c-3.5-7.5-13-10.5-16-4-3 6 5 10 5 10z" fill="@{f}"/><path d="M20 8h5" stroke-linejoin="miter"/><path d="M32 29.5s8.5-4 6.03-9.65C34.15 14 25 18 22.5 24.5l.01 2.1-.01-2.1C20 18 9.906 14 6.997 19.85c-2.497 5.65 4.853 9 4.853 9" stroke="@{s}"/><path d="M11.5 30c5.5-3 15.5-3 21 0m-21 3.5c5.5-3 15.5-3 21 0m-21 3.5c5.5-3 15.5-3 21 0" stroke="@{s}"/></g></svg>'
+            '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="@{f}" fill-rule="evenodd" stroke="@{s}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22.5 11.63V6" stroke-linejoin="miter"/><path d="M22.5 25s4.5-7.5 3-10.5c0 0-1-2.5-3-2.5s-3 2.5-3 2.5c-1.5 3 3 10.5 3 10.5" fill="@{f}" stroke-linecap="butt" stroke-linejoin="miter"/><path d="M11.5 37c5.5 3.5 15.5 3.5 21 0v-7s9-4.5 6-10.5c-4-6.5-13.5-3.5-16 4V27v-3.5c-3.5-7.5-13-10.5-16-4-3 6 5 10 5 10z" fill="@{f}"/><path d="M20 8h5" stroke-linejoin="miter"/><path d="M11.5 30c5.5-3 15.5-3 21 0m-21 3.5c5.5-3 15.5-3 21 0m-21 3.5c5.5-3 15.5-3 21 0" stroke="@{s}"/></g></svg>'
           );
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -397,17 +397,17 @@
         }
       }
       .is2d .queen {
-        &.black {
+        #piece(@f, @s){
           @svg: escape(
-            '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill-rule="evenodd" fill="@{base}" stroke="@{text}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><g stroke="@{text}"><circle fill="@{text}" cx="6" cy="12" r="2.75"/><circle fill="@{text}" cx="14" cy="9" r="2.75"/><circle fill="@{text}" cx="22.5" cy="8" r="2.75"/><circle fill="@{text}" cx="31" cy="9" r="2.75"/><circle fill="@{text}" cx="39" cy="12" r="2.75"/></g><path fill="@{text}" d="M9 26c8.5-1.5 21-1.5 27 0l2.5-12.5L31 25l-.3-14.1-5.2 13.6-3-14.5-3 14.5-5.2-13.6L14 25 6.5 13.5z" stroke-linecap="butt"/><path d="M9 26c0 2 1.5 2 2.5 4 1 1.5 1 1 .5 3.5-1.5 1-1.5 2.5-1.5 2.5-1.5 1.5.5 2.5.5 2.5 6.5 1 16.5 1 23 0 0 0 1.5-1 0-2.5 0 0 .5-1.5-1-2.5-.5-2.5-.5-2 .5-3.5 1-2 2.5-2 2.5-4-8.5-1.5-18.5-1.5-27 0z" stroke-linecap="butt"/><path d="M11 38.5a35 35 1 0 0 23 0" fill="none" stroke-linecap="butt"/><path d="M11 29a35 35 1 0 1 23 0m-21.5 2.5h20m-21 3a35 35 1 0 0 22 0m-23 3a35 35 1 0 0 24 0" fill="none" stroke="@{text}"/></g></svg>'
+          '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="@{f}" fill-rule="evenodd" stroke="@{s}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0m16.5-4.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M41 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0M16 8.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M33 9a2 2 0 1 1-4 0 2 2 0 1 1 4 0"/><path d="M9 26c8.5-1.5 21-1.5 27 0l2-12-7 11V11l-5.5 13.5-3-15-3 15-5.5-14V25L7 14z" stroke-linecap="butt"/><path d="M9 26c0 2 1.5 2 2.5 4 1 1.5 1 1 .5 3.5-1.5 1-1.5 2.5-1.5 2.5-1.5 1.5.5 2.5.5 2.5 6.5 1 16.5 1 23 0 0 0 1.5-1 0-2.5 0 0 .5-1.5-1-2.5-.5-2.5-.5-2 .5-3.5 1-2 2.5-2 2.5-4-8.5-1.5-18.5-1.5-27 0z" stroke-linecap="butt"/><path d="M11.5 30c3.5-1 18.5-1 22 0M12 33.5c6-1 15-1 21 0" fill="none"/></g></svg>'
           );
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
+        &.black {
+          #piece(@base, @text);
+        }
         &.white {
-          @svg: escape(
-            '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="@{text}" fill-rule="evenodd" stroke="@{base}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0m16.5-4.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M41 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0M16 8.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M33 9a2 2 0 1 1-4 0 2 2 0 1 1 4 0"/><path d="M9 26c8.5-1.5 21-1.5 27 0l2-12-7 11V11l-5.5 13.5-3-15-3 15-5.5-14V25L7 14z" stroke-linecap="butt"/><path d="M9 26c0 2 1.5 2 2.5 4 1 1.5 1 1 .5 3.5-1.5 1-1.5 2.5-1.5 2.5-1.5 1.5.5 2.5.5 2.5 6.5 1 16.5 1 23 0 0 0 1.5-1 0-2.5 0 0 .5-1.5-1-2.5-.5-2.5-.5-2 .5-3.5 1-2 2.5-2 2.5-4-8.5-1.5-18.5-1.5-27 0z" stroke-linecap="butt"/><path d="M11.5 30c3.5-1 18.5-1 22 0M12 33.5c6-1 15-1 21 0" fill="none"/></g></svg>'
-          );
-          background-image: url("data:image/svg+xml,@{svg}") !important;
+          #piece(@text, @base);
         }
       }
     }

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -326,10 +326,10 @@
       }
     }
     & when (@stylePieces = 1) {
-    @w-piece-fill: if(@flavor = latte, @base, @text);
-    @b-piece-fill: if(@flavor = latte, @text, @base);
-    @w-piece-stroke: if(@flavor = latte, @text, @base);
-    @b-piece-stroke: if(@flavor = latte, @base, @text);
+    @w-piece-fill: if(@flavor = latte, @mantle, @text);
+    @b-piece-fill: if(@flavor = latte, @text, @mantle);
+    @w-piece-stroke: if(@flavor = latte, @text, @mantle);
+    @b-piece-stroke: if(@flavor = latte, @mantle, @text);
 
       .is2d .pawn {
         #piece(@f, @s) {

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -326,6 +326,11 @@
       }
     }
     & when (@stylePieces = 1) {
+    @w-piece-fill: if(@flavor = latte, @base, @text);
+    @b-piece-fill: if(@flavor = latte, @text, @base);
+    @w-piece-stroke: if(@flavor = latte, @text, @base);
+    @b-piece-stroke: if(@flavor = latte, @base, @text);
+
       .is2d .pawn {
         #piece(@f, @s) {
           @svg: escape(
@@ -334,10 +339,10 @@
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
         &.black {
-          #piece(@base, @text);
+          #piece(@b-piece-fill, @b-piece-stroke);
         }
         &.white {
-          #piece(@text, @base);
+          #piece(@w-piece-fill, @w-piece-stroke);
         }
       }
       .is2d .bishop {
@@ -348,10 +353,10 @@
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
         &.black {
-          #piece(@base, @text);
+          #piece(@b-piece-fill, @b-piece-stroke);
         }
         &.white {
-          #piece(@text, @base);
+          #piece(@w-piece-fill, @w-piece-stroke);
         }
       }
       .is2d .knight {
@@ -362,10 +367,10 @@
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
         &.black {
-          #piece(@base, @text);
+          #piece(@b-piece-fill, @b-piece-stroke);
         }
         &.white {
-          #piece(@text, @base);
+          #piece(@w-piece-fill, @w-piece-stroke);
         }
       }
       .is2d .rook {
@@ -376,10 +381,10 @@
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
         &.black {
-          #piece(@base, @text);
+          #piece(@b-piece-fill, @b-piece-stroke);
         }
         &.white {
-          #piece(@text, @base);
+          #piece(@w-piece-fill, @w-piece-stroke);
         }
       }
       .is2d .king {
@@ -390,10 +395,10 @@
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
         &.black {
-          #piece(@base, @text);
+          #piece(@b-piece-fill, @b-piece-stroke);
         }
         &.white {
-          #piece(@text, @base);
+          #piece(@w-piece-fill, @w-piece-stroke);
         }
       }
       .is2d .queen {
@@ -404,10 +409,10 @@
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }
         &.black {
-          #piece(@base, @text);
+          #piece(@b-piece-fill, @b-piece-stroke);
         }
         &.white {
-          #piece(@text, @base);
+          #piece(@w-piece-fill, @w-piece-stroke);
         }
       }
     }

--- a/styles/lichess/catppuccin.user.less
+++ b/styles/lichess/catppuccin.user.less
@@ -326,10 +326,10 @@
       }
     }
     & when (@stylePieces = 1) {
-    @w-piece-fill: if(@flavor = latte, @mantle, @text);
-    @b-piece-fill: if(@flavor = latte, @text, @mantle);
-    @w-piece-stroke: if(@flavor = latte, @text, @mantle);
-    @b-piece-stroke: if(@flavor = latte, @mantle, @text);
+      @w-piece-fill: if(@flavor = latte, @mantle, @text);
+      @b-piece-fill: if(@flavor = latte, @text, @mantle);
+      @w-piece-stroke: if(@flavor = latte, @text, @mantle);
+      @b-piece-stroke: if(@flavor = latte, @mantle, @text);
 
       .is2d .pawn {
         #piece(@f, @s) {
@@ -402,9 +402,9 @@
         }
       }
       .is2d .queen {
-        #piece(@f, @s){
+        #piece(@f, @s) {
           @svg: escape(
-          '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="@{f}" fill-rule="evenodd" stroke="@{s}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0m16.5-4.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M41 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0M16 8.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M33 9a2 2 0 1 1-4 0 2 2 0 1 1 4 0"/><path d="M9 26c8.5-1.5 21-1.5 27 0l2-12-7 11V11l-5.5 13.5-3-15-3 15-5.5-14V25L7 14z" stroke-linecap="butt"/><path d="M9 26c0 2 1.5 2 2.5 4 1 1.5 1 1 .5 3.5-1.5 1-1.5 2.5-1.5 2.5-1.5 1.5.5 2.5.5 2.5 6.5 1 16.5 1 23 0 0 0 1.5-1 0-2.5 0 0 .5-1.5-1-2.5-.5-2.5-.5-2 .5-3.5 1-2 2.5-2 2.5-4-8.5-1.5-18.5-1.5-27 0z" stroke-linecap="butt"/><path d="M11.5 30c3.5-1 18.5-1 22 0M12 33.5c6-1 15-1 21 0" fill="none"/></g></svg>'
+            '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45"><g fill="@{f}" fill-rule="evenodd" stroke="@{s}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0m16.5-4.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M41 12a2 2 0 1 1-4 0 2 2 0 1 1 4 0M16 8.5a2 2 0 1 1-4 0 2 2 0 1 1 4 0M33 9a2 2 0 1 1-4 0 2 2 0 1 1 4 0"/><path d="M9 26c8.5-1.5 21-1.5 27 0l2-12-7 11V11l-5.5 13.5-3-15-3 15-5.5-14V25L7 14z" stroke-linecap="butt"/><path d="M9 26c0 2 1.5 2 2.5 4 1 1.5 1 1 .5 3.5-1.5 1-1.5 2.5-1.5 2.5-1.5 1.5.5 2.5.5 2.5 6.5 1 16.5 1 23 0 0 0 1.5-1 0-2.5 0 0 .5-1.5-1-2.5-.5-2.5-.5-2 .5-3.5 1-2 2.5-2 2.5-4-8.5-1.5-18.5-1.5-27 0z" stroke-linecap="butt"/><path d="M11.5 30c3.5-1 18.5-1 22 0M12 33.5c6-1 15-1 21 0" fill="none"/></g></svg>'
           );
           background-image: url("data:image/svg+xml,@{svg}") !important;
         }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

This PR fixes the inverted colors for the pieces on latte and also fixes the queen piece svg.
It also makes some smaller minor changes (slight changes to piece colors and removing weird thick lines on knight and king).

Closes: #1890

<img width="629" height="628" alt="image" src="https://github.com/user-attachments/assets/c4007c51-82f1-4eb5-ab31-2658df0d7c8b" />
<img width="641" height="629" alt="image" src="https://github.com/user-attachments/assets/b8eaf85a-108b-47f4-86f1-60fb38f3e1ef" />




## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
