### PR TITLE
fix(youtube): vertical ellipsis menu

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -1224,6 +1224,15 @@
       background-color: @accent !important;
       color: @crust !important;
     }
+
+    /* Vertical ellipsis menu on main page*/
+    .ytListViewModelHost {
+      background-color: @mantle !important;
+      color: @text !important;
+      .yt-icon-shape {
+        color: @text !important;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Vertical ellipsis menus on main page(right of video titles) are unthemed.
|Before|After|
|-|-|
|<img width="683" height="851" src="https://github.com/user-attachments/assets/822ff317-6d0e-473b-8c9d-8e9a6980f78a" />|<img width="683" height="851" src="https://github.com/user-attachments/assets/b8fcefd5-790a-4e0e-aa2a-724c43a9b302" />|

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
