### PR TITLE
fix(github): dark theme header

### DIFF
--- a/styles/github/catppuccin.user.less
+++ b/styles/github/catppuccin.user.less
@@ -40,6 +40,9 @@ regexp(
       }
       &[data-dark-theme="dark"] {
         #catppuccin(@darkFlavor);
+        header[data-color-mode] {
+          #catppuccin(@darkFlavor);
+        }
       }
     }
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Re-applies dark flavor styles to the header element in the specific case where the system is in dark mode with dark flavor is used. Other theme combinations continue to inherit styles normally.

Closes #1849 

| Stage | Screenshot |
|--------|-------|
| Before | ![Before Dark Mode Header](https://github.com/user-attachments/assets/ca26df6c-377b-49f6-8d50-e50c9065bd1a) |  
| After | ![After Dark Mode Header](https://github.com/user-attachments/assets/cf7a68d0-cb6f-40cc-9f77-0cbb64612742) |

Verified the following combinations work as expected:

|  | Latte | Macchiato | Mocha |
|----------------------------|-------|-----------|-------|
| Light Flavor / Light Theme  | ✅    | ✅        | ✅    |
| Dark Flavor / Light Theme   | ✅    | ✅        | ✅    |
| Light Flavor / Dark Theme   | ✅    | ✅        | ✅    |
| Dark Flavor / Dark Theme    | ✅    | ✅        | ✅    |



## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
