### PR TITLE
fix(wikipedia): recolor {{text diff}} template

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -2,7 +2,7 @@
 @name Wikipedia Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/wikipedia
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wikipedia
-@version 2025.06.04
+@version 2025.10.07
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wikipedia/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awikipedia
 @description Soothing pastel theme for Wikipedia
@@ -235,8 +235,8 @@
     --background-color-warning-subtle: fade(@yellow, 20%);
     --background-color-success-subtle: fade(@green, 20%);
     --background-color-notice-subtle: @surface0;
-    --background-color-content-added: #2a4b8d;
-    --background-color-content-removed: #a66200;
+    --background-color-content-added: @blue;
+    --background-color-content-removed: @yellow;
     --background-color-backdrop-light: rgba(0, 0, 0, 0.65);
     --background-color-backdrop-dark: rgba(255, 255, 255, 0.65);
     --background-color-base: @base;
@@ -408,6 +408,12 @@
     /* View history */
     .flaggedrevs-color-1 {
       background-color: fade(@blue, 10%);
+    }
+
+    /* {{text diff}} */
+    .diffchange {
+      /* Color is styled inline on the page */
+      color: var(--color-inverted) !important;
     }
 
     /* Language search and settings */


### PR DESCRIPTION
* Change --background-color-content-removed and --background-color-content-added vars to use Catppuccin colors
* Add rule recoloring .diffchange color to --color-inverted for visibility on colored background; uses !important because every .diffchange element is individually styled inline

## 🔧 What does this fix? 🔧

Closes #1951 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
