### PR TITLE
fix(proton): softer border colors

### DIFF
--- a/styles/proton/catppuccin.user.less
+++ b/styles/proton/catppuccin.user.less
@@ -173,7 +173,7 @@
       --focus-outline: @accent;
       --focus-ring: fade(@accent, 40%);
       --border-norm: @overlay0;
-      --border-weak: @overlay1;
+      --border-weak: @surface1;
       --background-norm: @base;
       --background-weak: @mantle;
       --background-strong: @crust;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The "weak" border color of the Proton theme (which is used for most borders) doesn't match other userstyles (e.g. GitHub). This PR fixes that.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
