### PR TITLE
feat(lib/mediawiki): use codex style guide

### DIFF
--- a/lib/mediawiki.less
+++ b/lib/mediawiki.less
@@ -164,8 +164,8 @@
 
     --background-color-input-binary--checked: @accent;
 
-    --background-color-tab-list-item-framed--hover: rgba(255, 255, 255, 0.3);
-    --background-color-tab-list-item-framed--active: rgba(255, 255, 255, 0.65);
+    --background-color-tab-list-item-framed--hover: fade(@catppuccin[@latte][@base], 30%);
+    --background-color-tab-list-item-framed--active: fade(@catppuccin[@latte][@base], 65%);
 
     --border-base: 1px solid var(--border-color-base);
     --border-subtle: 1px solid var(--border-color-subtle);


### PR DESCRIPTION
Use the [Wikimedia Codex color design tokens](https://doc.wikimedia.org/codex/latest/design-tokens/color.html) to base the colour bindings. 

This makes the appearance of the style more consistent with base Wikipedia.