### PR TITLE
fix(bsky): a few selectors; wip

### DIFF
--- a/styles/bsky/catppuccin.user.less
+++ b/styles/bsky/catppuccin.user.less
@@ -436,7 +436,6 @@
     [style*="color: rgb(111, 131, 159)"], // dark
     [style*="color: rgb(111, 131, 159)"] // dim
     {
-      fill: @subtext1;
       color: @subtext1 !important;
       fill: @subtext1 !important;
     }


### PR DESCRIPTION
the bluesky devs changed the color palette, here we go again

## 🔧 What does this fix? 🔧
- a few color selectors.
- bookmark icon support

**feel free to help fix this**

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
