### PR TITLE
feat(wanderlog): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -928,6 +928,12 @@ userstyles:
     icon: vikunja
     color: blue
     current-maintainers: [*Guaxinim5573]
+  wanderlog:
+    name: Wanderlog
+    link: https://wanderlog.com
+    categories: [productivity, note_taking]
+    color: peach
+    current-maintainers: [*zenoix]
   web.dev:
     name: web.dev
     link: https://web.dev

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -243,6 +243,12 @@
       &.Button__disabled:hover {
         color: @subtext0;
       }
+
+      &:not(.Button__disabled).Button__focused .Button__icon,
+      &:not(.Button__disabled):active .Button__icon,
+      &:not(.Button__disabled):hover .Button__icon {
+        color: @base;
+      }
     }
     .brand-button {
       color: @base !important;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1639,7 +1639,7 @@
 
     .PlanPageLoaded {
       &__grayBackground {
-        background-color: @base;
+        background-color: fade(@accent, 10%);
       }
       &__footer {
         background-color: @mantle;
@@ -1648,6 +1648,14 @@
 
     .PlanBoard__spacer {
       background-color: @mantle;
+    }
+
+    // Explore section
+    .PlanInspirationsInner__title {
+      color: @text;
+    }
+    .InsertSectionSpacer__dividerInner {
+      border-top-color: @subtext0;
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -101,6 +101,7 @@
       color: @text !important;
     }
     .color-gray-600,
+    .color-gray-900,
     .text-muted {
       color: @subtext1 !important;
     }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -666,6 +666,10 @@
     // Dropdowns
     .DropdownMenu {
       border-color: @accent;
+
+      .DropdownItem.bg-gray-200 {
+        background-color: @surface1;
+      }
     }
     .dropdown {
       &-menu {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -498,6 +498,7 @@
       }
 
       &-link,
+      &-link:hover,
       .contact-us-button:hover,
       .Footer__link a,
       .Footer__contact {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -852,6 +852,9 @@
     .SaveToDocTooltip__body {
       color: @base;
     }
+    .FeatureTooltipInternal__dismiss {
+      color: @base;
+    }
 
     // Inputs
     .Input__input {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1746,5 +1746,15 @@
         }
       }
     }
+
+    // Notes text box
+    .SectionComponent__box {
+      background-color: @surface0;
+    }
+    .SectionComponent__textOnly .ql-editor {
+      li::before {
+        color: @accent;
+      }
+    }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -989,5 +989,37 @@
         color: @text;
       }
     }
+
+    /* History page */
+
+    // Tables
+    .table {
+      color: @text;
+
+      td, th {
+        border-top-color: @accent;
+      }
+
+      thead th {
+        color: @text;
+      }
+
+      &-hover tbody tr:hover {
+        background-color: @surface0;
+      }
+    }
+    // Table row element
+    .PlansList__inner td, .PlansList__inner td:hover {
+      color: @subtext1;
+
+      a {
+        color: @text;
+      }
+
+      .Badge__light {
+        background-color: @surface0;
+        color: @subtext1;
+      }
+    }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -540,7 +540,10 @@
 
       &:not(.Button__disabled):hover,
       &:not(.Button__disabled):active,
-      &:not(.Button__disabled).Button__focused {
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):hover .Button__icon,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled):active .Button__icon {
         border-color: var(--accent-darker);
         color: @subtext0;
       }
@@ -555,7 +558,8 @@
 
       &:not(.Button__disabled):hover,
       &:not(.Button__disabled):active,
-      &:not(.Button__disabled).Button__focused {
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):hover .Button__icon {
         border-color: var(--accent-darker);
         color: var(--accent-darker);
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1069,7 +1069,8 @@
 
       &SectionHeading,
       &SectionSubheading,
-      &FeatureTile__subheader {
+      &FeatureTile__subheader,
+      &CallToAction__lead {
         color: @text;
       }
 
@@ -1077,7 +1078,7 @@
         border-top-color: @accent;
       }
 
-      &__sublead {
+      &Lead__sublead, &__sublead {
         color: @subtext1;
       }
     }
@@ -1244,6 +1245,11 @@
           color: @text;
         }
       }
+    }
+
+    /* Embed map in blog page https://wanderlog.com/embed-travel-map-on-blog */
+    .MapEmbedLandingPageInner__hero {
+      background-color: fade(@accent, 10%);
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -147,14 +147,29 @@
         background-color: var(--accent-darker);
       }
     }
-    .Button__flat, .flat-button {
+    .Button__flat,
+    .flat-button,
+    .Button__flat-primary,
+    .Button__flat-primary .Button__icon,
+    .Button__flat-primary:hover {
       color: @accent;
 
       &:hover, &:active {
         color: var(--accent-darker);
       }
     }
-    .Button__default {
+    .Button__flat-secondary {
+      &, .Button__icon {
+        color: @text;
+
+        &:hover,
+        &:not(.Button__disabled):active,
+        &:not(.Button__disabled):active .Button__icon {
+          color: @subtext1;
+        }
+      }
+    }
+    .Button__default, .Button__primary {
       background-color: transparent;
       border-color: @accent;
 
@@ -175,6 +190,12 @@
       &:not(.Button__disabled):active {
         background-color: @surface0;
         border-color: var(--accent-darker);
+      }
+
+      .Button__icon {
+        img {
+          filter: @text-filter;
+        }
       }
     }
     .outline-icon-button {
@@ -454,6 +475,29 @@
 
       .links-list-rich-text-block a {
         color: var(--gray--600);
+      }
+    }
+
+    /* Login Page */
+    .LoginFormBody {
+      &__hr {
+        border-top-color: @accent;
+      }
+
+      &__subtitle {
+        color: @subtext1;
+      }
+
+      > button .Button__labelText {
+        color: @text;
+
+        strong {
+          color: @accent;
+        }
+
+        &:hover strong {
+          color: var(--accent-darker);
+        }
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -91,9 +91,16 @@
     }
 
     // Text
+    .text-brand {
+      color: @accent;
+    }
+    a.text-brand:active, a.text-brand:focus, a.text-brand:hover {
+      color: var(--accent-darker);
+    }
     .text-white {
       color: @text !important;
     }
+    .color-gray-600,
     .text-muted {
       color: @subtext1 !important;
     }
@@ -103,6 +110,14 @@
     .text-secondary {
       color: @subtext0 !important;
     }
+    .link-unstyled,
+    .link-unstyled:active,
+    .link-unstyled:active:hover,
+    .link-unstyled:focus,
+    .link-unstyled:hover,
+    .link-unstyled:visited {
+      color: inherit !important;
+    }
 
     // Backgrounds
     .bg-white {
@@ -110,6 +125,9 @@
     }
     .bg-gray-100 {
       background-color: @mantle;
+    }
+    .bg-light {
+      background-color: @surface0 !important;
     }
 
     // Navbar
@@ -159,16 +177,25 @@
       background-color: @accent;
     }
 
+    // Notifications popup
+    .popover {
+      background-color: @surface0;
+    }
+    .NotificationButtonLoaded__popover .popover {
+      border-color: @accent;
+    }
+
     // Buttons
-    .Button__brand {
+    .Button__brand, .Button__dark {
       background-color: @accent;
       border-color: @accent;
 
-      &, &:hover {
+      &, &:hover, &:active {
         color: @base;
       }
 
-      &:not(.Button__disabled):hover {
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active {
         background-color: var(--accent-darker);
         border-color: var(--accent-darker);
       }
@@ -184,6 +211,8 @@
     .flat-button,
     .Button__flat-primary,
     .Button__flat-primary .Button__icon,
+    .Button__flat .Button__icon,
+    .Button__flat:hover,
     .Button__flat-primary:hover {
       color: @accent;
 
@@ -193,6 +222,12 @@
       &:not(.Button__disabled):active .Button__icon {
         color: var(--accent-darker);
       }
+    }
+    .Button__brand,
+    .Button__brand .Button__icon,
+    .Button__brand:hover,
+    .Button__brand:not(.Button__disabled):hover .Button__icon {
+      color: @base;
     }
     .Button__flat-secondary, .btn {
       &, .Button__icon {
@@ -263,17 +298,6 @@
         }
       }
     }
-    .Button__dark {
-      background-color: @text;
-      border-color: @text;
-      color: @base;
-
-      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
-        background-color: @subtext1;
-        border-color: @subtext1;
-        color: @base;
-      }
-    }
     .Button__light-gray {
       background-color: @surface0;
       border-color: @accent;
@@ -293,7 +317,7 @@
       border-color: @surface1;
 
       &, .Button__icon, &:hover {
-        color: @subtext1;
+        color: @text;
       }
 
       &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
@@ -333,19 +357,106 @@
         background-color: fade(@base, 80%);
       }
     }
+    .Button__translucent-black {
+      background-color: transparent;
+      &, .Button__icon, &:hover, &:active {
+        color: @text;
+      }
+
+      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+        background-color: transparent;
+        border-color: transparent;
+        .Button__icon {
+          color: @text;
+        }
+      }
+    }
+    .Button__transparent-black-outline {
+      border-color: @accent;
+
+      &, .Button__icon {
+        color: @text;
+      }
+      &:hover, &:active {
+        color: @subtext1;
+      }
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active {
+        border-color: var(--accent-darker);
+      }
+    }
 
     // Badges
     .Badge__light,
-    .Badge__lightGray {
+    .Badge__lightGray,
+    .Badge__brand {
       background-color: @accent;
       color: @base;
     }
+    .Badge__yellowWithWhiteText {
+      background-color: @yellow;
+      color: @base;
+    }
+    .Badge__redWithWhiteText {
+      background-color: @red;
+      color: @base;
+    }
+    .VisitGeosBadgeIcon__gold {
+      color: @peach;
+    }
+
     .VerifiedBadge {
       background-color: @accent;
 
       svg {
         color: @base;
       }
+    }
+
+    // Bubbles
+    .UserBubblesList__bubble {
+      border-color: @accent;
+    }
+    .EditorBubble__container {
+      background-color: @accent;
+    }
+    .TextBubble__colorTheme {
+      &__white {
+        background-color: @mantle;
+        color: @text;
+      }
+      &__gray200 {
+        background-color: @surface1;
+        color: @text;
+      }
+    }
+
+    // Tooltips
+    .tooltip.show {
+      opacity: 1;
+    }
+    .ChildrenTargetedTooltip__tooltipInner__error {
+      background-color: @red;
+      color: @base;
+
+      .Button__icon {
+        color: @surface0;
+      }
+      .Button:hover .Button__icon, .Button:active .Button__icon {
+        color: @base;
+      }
+    }
+    .bs-tooltip-auto[x-placement^="bottom"]
+      .ChildrenTargetedTooltip__arrow__error::before,
+    .bs-tooltip-bottom .ChildrenTargetedTooltip__arrow__error::before {
+      // Error tooltip arrow (pointing up)
+      border-bottom-color: @red !important;
+    }
+    .bs-tooltip-auto[x-placement^="top"]
+      .ChildrenTargetedTooltip__arrow__error::before,
+    .bs-tooltip-top .ChildrenTargetedTooltip__arrow__error::before {
+      border-top-color: @red !important;
     }
 
     // Inputs
@@ -455,7 +566,7 @@
       }
 
       &-item {
-        color: @text;
+        color: @text !important;
         &:hover, &:active, &:focus {
           background-color: @surface1;
         }
@@ -488,6 +599,41 @@
       svg[color="#de703c"] {
         color: var(--warning);
       }
+    }
+
+    // Text radio buttons
+    .TextRadioButtons {
+      &__tabs {
+        background-color: @surface0;
+      }
+      &__tab:hover {
+        background-color: @surface1;
+      }
+      &__tabSelected {
+        background-color: @accent;
+        color: @base;
+
+        &:hover {
+          background-color: var(--accent-darker) !important;
+        }
+      }
+    }
+
+    // Toggle switches
+    .react-switch-bg {
+      background-color: @surface0 !important;
+
+      &[style*="background: rgb(63, 82, 227)"] {
+        background-color: var(--accent-darker) !important;
+      }
+    }
+    .react-switch-handle {
+      background-color: @text !important;
+    }
+
+    // Share menu
+    .LinkSharing {
+      border-color: @accent;
     }
 
     // Footer
@@ -712,6 +858,43 @@
       .links-list-rich-text-block a {
         color: var(--gray--600);
       }
+    }
+
+    /* Homepage (logged in) */
+
+    // Promos
+    // NOTE: Not sure how consistent these selectors will be as they are for promos
+    .HeaderPromoWithButtons__container {
+      background-color: @surface0;
+    }
+    img.HeaderPromoWithButtons__background {
+      filter: @accent-filter;
+    }
+    .HeaderPromoWithButtons__body {
+      color: @subtext0;
+    }
+    @media (max-width: 768px) {
+      .HeaderPromoWithButtons__closeButton {
+        .Button__icon {
+          color: @text;
+        }
+        &:hover .Button__icon, &:active .Button__icon {
+          color: @subtext0 !important;
+        }
+      }
+    }
+    .HeaderPromoWithButtons__closeButton {
+      .Button__icon {
+        color: @base;
+      }
+      &:hover .Button__icon, &:active .Button__icon {
+        color: @crust !important;
+      }
+    }
+
+    // Your trips
+    .YourTripsAndGuidesColumn__horizontalLine {
+      border-color: @subtext0;
     }
 
     /* Login Page */

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -147,7 +147,7 @@
     .bg-gray-100 {
       background-color: @mantle;
     }
-    .bg-yellow-lightest, .bg-purple-lightest {
+    .bg-yellow-lightest, .bg-purple-lightest, .bg-indigo-lightest {
       background-color: @surface1;
     }
     .bg-light {
@@ -377,6 +377,21 @@
         color: @subtext1;
       }
     }
+    .Button__flat-purple,
+    .Button__flat-purple .Button__icon,
+    .Button__flat-purple:hover {
+      background-color: transparent;
+      border-color: transparent;
+      color: @mauve;
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):active {
+        background-color: transparent;
+        border-color: transparent;
+        color: darken(@accent, 5%);
+      }
+    }
     .Button__icon-lightest-gray {
       background-color: @surface0;
       border-color: @surface0;
@@ -533,7 +548,7 @@
         border-color: @accent;
       }
     }
-    .Button__indigo {
+    .Button__indigo, .Button__purple {
       background-color: @accent;
       border-color: @accent;
 
@@ -628,11 +643,19 @@
         background-color: @text;
         color: @surface1;
       }
-      &__whiteOnGreen {
+      &__blueBase {
+        background-color: @blue;
+        color: @base;
+      }
+      &__purpleBase, &__whiteOnPurple {
+        background-color: @mauve;
+        color: @base;
+      }
+      &__green, &__whiteOnGreen {
         background-color: @green;
         color: @base;
       }
-      &__whiteOnYellow {
+      &__yellow, &__whiteOnYellow {
         background-color: @yellow;
         color: @base;
       }
@@ -882,6 +905,10 @@
 
       &-header {
         color: @accent;
+      }
+
+      &-divider {
+        border-top-color: @surface0;
       }
     }
     .StyledDropdownMenu {
@@ -2194,7 +2221,7 @@
       border-top-color: @text;
     }
 
-    // List items
+    // List items and itinerary section
     .ChecklistSectionItem__container {
       background-color: @surface0;
 
@@ -2257,6 +2284,15 @@
         background-color: @base;
       }
 
+      &__dot {
+        // Dot at the start and end of an itinerary "journey"
+        border-color: @accent;
+      }
+
+      &__verticalLine line {
+        stroke: @accent !important;
+      }
+
       &__horizontalLine {
         .DashedLine line {
           stroke: @text !important;
@@ -2269,10 +2305,36 @@
       &__addBlockIcon {
         color: @accent;
       }
+
+      &__travelModeToggle {
+        // Time and distance between itinerary items
+        background-color: @base !important;
+
+        .fa-caret-down {
+          color: @subtext1;
+        }
+      }
     }
     .NoteSectionItem__noteIcon {
       background-color: @accent;
       color: @base;
+    }
+    .TotalRouteInfo__infoText {
+      color: @subtext1;
+    }
+    .BlockWithIcon {
+      &__gray {
+        background-color: @surface1;
+      }
+
+      &__purple-lightest {
+        // Looks like you don't have lodging ...
+        background-color: fade(@mauve, 20%);
+      }
+    }
+    .FlightUpdatesPromo__heading {
+      // Itinerary "Live flight updates"
+      color: @text;
     }
 
     // Budgeting section

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -139,6 +139,9 @@
     .color-teal {
       color: @teal;
     }
+    .RatingWithLogo__yellowRating {
+      color: @yellow;
+    }
 
     // Backgrounds
     .bg-white {
@@ -577,6 +580,9 @@
         border-color: @accent;
       }
     }
+    .LargeIconButton:focus, .LargeIconButton:hover {
+      background-color: @surface0;
+    }
     .Button__indigo, .Button__purple {
       background-color: @accent;
       border-color: @accent;
@@ -616,7 +622,7 @@
     .CircleButton__imageBackground {
       background-color: @surface2;
 
-      svg[color="#000000"] {
+      svg[color="#000000"], svg[color="#6c757d"] {
         color: @text;
       }
       svg[color="#1877f2"] {
@@ -643,6 +649,10 @@
     .VisitGeosBadgeIcon__gold {
       color: @peach;
     }
+    .Badge__info {
+      background-color: var(--info);
+      color: @base;
+    }
     .Badge__warning {
       background-color: var(--warning);
       color: @base;
@@ -655,12 +665,19 @@
         background-color: transparent;
       }
     }
+    .Badge__danger {
+      background-color: @red;
+      color: @base;
+    }
     .Badge__whiteWithIndigoTextAndOutline {
       background-color: @surface0;
       border-color: @blue;
       color: @blue;
     }
-
+    .Badge__whiteDangerous {
+      background-color: fade(@base, 80%);
+      color: @text;
+    }
     .VerifiedBadge {
       background-color: @accent;
 
@@ -798,6 +815,9 @@
       .ChildrenTargetedTooltip__arrow__primary::before,
     .bs-tooltip-top .ChildrenTargetedTooltip__arrow__primary::before {
       border-top-color: @accent !important;
+    }
+    .SaveToDocTooltip__body {
+      color: @base;
     }
 
     // Inputs
@@ -2280,9 +2300,14 @@
       background-color: @surface1;
       color: @text;
     }
-    .BoardBlockSeparator__horizontalLine {
-      // Cruise itinerary separator
-      border-top-color: @text;
+    .BoardBlockSeparator {
+      &__horizontalLine {
+        // Cruise itinerary separator
+        border-top-color: @text;
+      }
+      &__selected {
+        border-top-color: @accent;
+      }
     }
 
     // List items and itinerary section
@@ -2771,6 +2796,212 @@
       &__user {
         border-bottom-color: @text;
       }
+    }
+
+    /* Guides */
+
+    .PlacesListPageLoaded__title, .HeaderImageOverlay__header {
+      color: @text;
+    }
+
+    // Guide contents button
+    .ContentsButtonInner {
+      border-color: @accent;
+      &:not(.ContentsButtonInner__expanded):focus,
+      &:not(.ContentsButtonInner__expanded):hover {
+        border-color: var(--accent-darker);
+        background-color: @surface0;
+      }
+
+      &__expanded {
+        background-color: @surface0 !important;
+      }
+
+      &__subtitle, &__title {
+        color: @text;
+      }
+
+      &__section:focus, &__section:hover {
+        background-color: @surface1;
+      }
+    }
+    .ExpandingButton {
+      background-color: @surface0;
+
+      .Button__icon .fa-bars-staggered {
+        color: @accent;
+      }
+    }
+
+    // Guide items
+    .PlaceView__selectable {
+      &:hover,
+      &:hover .PlaceView__snippetQuote {
+        background-color: @base;
+      }
+
+      .Badge__light {
+        .text-muted {
+          color: @base !important;
+        }
+
+        .color-gray-400 {
+          color: @surface2;
+        }
+      }
+
+      .SplitDropdownToggle__divider {
+        &_light-gray {
+          // When added to list
+          background-color: @surface0;
+        }
+
+        &_gray {
+          background-color: @surface1;
+        }
+
+        &_dark {
+          // When not added to list
+          background-color: @accent;
+        }
+      }
+      .SplitDropdownToggle__line {
+        &_light-gray {
+          // When added to list
+          background-color: @surface1;
+        }
+
+        &_gray {
+          background-color: @surface2;
+        }
+
+        &_dark {
+          // When not added to list
+          background-color: var(--accent-darker);
+        }
+      }
+
+      .Button__light-gray {
+        // We don't want the accent border when the place is added to a list
+        border-color: @surface0;
+        &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+          border-color: @surface1;
+        }
+        // Place list selection dropdown symbol
+
+        svg {
+          // Dropdown chevron when added to list
+          color: @text;
+        }
+      }
+
+      .Button__gray svg {
+        color: @text;
+      }
+
+      .Button__dark svg {
+        //Dropdown chevron when not added to list
+        color: @base;
+      }
+    }
+    .PlaceView__selected, .PlaceView__selected:hover {
+      background-color: @surface0;
+
+      // Need to increase the surface level by 1 as selected bg is not base
+      .SplitDropdownToggle__divider {
+        &_light-gray {
+          // When added to list
+          background-color: @surface1;
+        }
+      }
+      .SplitDropdownToggle__line {
+        &_light-gray {
+          // When added to list
+          background-color: @surface2;
+        }
+      }
+      .Button__light-gray {
+        background-color: @surface1;
+        border-color: @surface1;
+        &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+          border-color: @surface2;
+        }
+      }
+    }
+    .PlacesListPageLoaded {
+      &__floatingBottomButton {
+        // Back to top button
+        .Button__default {
+          background-color: @surface0;
+        }
+      }
+    }
+
+    // Photo gallery
+    .lg-counter {
+      color: @subtext0;
+    }
+    .lg-toolbar .lg-icon {
+      color: @text;
+
+      &:hover {
+        color: @subtext0;
+      }
+    }
+    .lg-sub-html {
+      color: @text;
+    }
+    .lg-outer .lg-thumb-item {
+      border-color: @overlay0;
+
+      &.active, &:hover {
+        border-color: @accent;
+      }
+    }
+    .lg-next, .lg-prev {
+      background-color: @surface0;
+      color: @text;
+
+      &:not(.disabled):hover {
+        background-color: @surface1;
+      }
+    }
+
+    // Comments
+    .CommentFormInner {
+      &__textbox {
+        border-color: @accent;
+        background-color: @surface1;
+      }
+
+      &__button {
+        background-color: @accent !important;
+        color: @base;
+
+        &:hover {
+          background-color: var(--accent-darker) !important;
+          color: @base !important;
+        }
+
+        &.Button__disabled {
+          background-color: fade(@accent, 40%) !important;
+          border-color: fade(@accent, 40%);
+          color: @subtext0 !important;
+        }
+      }
+    }
+    .CommentItemInner__button {
+      // Reply button
+      color: @subtext0 !important;
+
+      // Thumbs up button
+      .fa-thumbs-up {
+        color: @subtext0;
+      }
+    }
+
+    .RelatedGuidesSection__relatedGuidesContainer {
+      background-color: @mantle;
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -132,7 +132,7 @@
     .bg-gray-100 {
       background-color: @mantle;
     }
-    .bg-yellow-lightest {
+    .bg-yellow-lightest, .bg-purple-lightest {
       background-color: @surface1;
     }
     .bg-light {
@@ -1067,12 +1067,18 @@
         color: @accent !important;
       }
 
-      &SectionSubheading, &FeatureTile__subheader {
+      &SectionHeading,
+      &SectionSubheading,
+      &FeatureTile__subheader {
         color: @text;
       }
 
       &SectionWithDivider {
         border-top-color: @accent;
+      }
+
+      &__sublead {
+        color: @subtext1;
       }
     }
 
@@ -1194,6 +1200,49 @@
       }
       .nav-link {
         color: @text;
+      }
+    }
+
+    /* Extension page https://wanderlog.com/extension*/
+    .ExtensionLandingPageHero__background {
+      background-color: fade(@accent, 10%);
+    }
+
+    /* Travel budgeting & cost tracking page https://wanderlog.com/travel-budget-expense-splitting-app */
+    .BudgetLandingPageHero__background {
+      background-color: fade(@accent, 10%);
+    }
+    .BudgetLandingPageAnimation {
+      &__section {
+        background-color: @surface0;
+        svg {
+          color: @text !important;
+        }
+      }
+
+      &__background {
+        background-color: @accent;
+        color: @base;
+      }
+
+      &__progressBar {
+        background-color: @text;
+
+        .progress-bar {
+          background-color: @base;
+        }
+      }
+    }
+    .BudgetLandingPageGetAppPromo__appText {
+      svg[data-icon="star"] {
+        color: @yellow !important;
+      }
+
+      .GetAppPromoLeftSide {
+        &__largeAppCaption,
+        &__ratingMessage {
+          color: @text;
+        }
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -136,6 +136,9 @@
     .small-uppercase-title {
       color: @subtext1;
     }
+    .color-teal {
+      color: @teal;
+    }
 
     // Backgrounds
     .bg-white {
@@ -204,8 +207,16 @@
       background-color: fade(@accent, 20%);
     }
 
+    // Borders
+    .border-top {
+      border-top-color: @text !important;
+    }
+
     // Fake progress bar between SPA pages
     .FakeTopProgressBar {
+      background-color: @accent;
+    }
+    .progress-bar {
       background-color: @accent;
     }
 
@@ -550,6 +561,10 @@
     }
     .ProBadgeCircular {
       border-color: @text;
+
+      & svg[color="#ffffff"] {
+        color: @surface0;
+      }
     }
 
     // Bubbles
@@ -567,6 +582,10 @@
       &__gray200 {
         background-color: @surface1;
         color: @text;
+
+        svg[color="#6c757d"] {
+          color: @text;
+        }
       }
       &__gray300 {
         background-color: @text;
@@ -663,6 +682,10 @@
 
       &__withLeftContent {
         border-color: @accent;
+        background-color: @surface2;
+        svg[color="#212529"] {
+          color: @subtext1;
+        }
       }
       &__iconButton {
         svg[color="#6c757d"] {
@@ -1646,10 +1669,6 @@
       svg[data-icon="user-plus"] {
         color: @text;
       }
-
-      .ProBadgeCircular svg[color="#ffffff"] {
-        color: @surface0;
-      }
     }
 
     // Editable text titles and subtitles
@@ -1807,6 +1826,10 @@
     .SectionItemControls {
       &__control {
         color: @accent;
+
+        &:hover {
+          color: var(--accent-darker) !important;
+        }
       }
 
       &__selectedBar {
@@ -1970,5 +1993,52 @@
       // Cruise itinerary separator
       border-top-color: @text;
     }
+
+    // Budgeting section
+    .BudgetOverview__container {
+      background-color: @surface0;
+    }
+    .BudgetBreakdownModal__graph {
+      .recharts-rectangle {
+        fill: @overlay2;
+
+        &[fill="#3f52e3"] {
+          fill: @accent;
+        }
+      }
+
+      .ExpenseTotalBarGraph__customTooltip {
+        background-color: @surface0;
+      }
+    }
+    .ExpenseSettingsModal__dropdownButton {
+      border-color: @accent;
+      box-shadow: inset 0 -1px 0 @accent;
+    }
+    .BudgetOverview__progressBar {
+      background-color: @surface1;
+    }
+    .CostSplitOptions__toggle {
+      border-color: @accent;
+      background-color: @surface1;
+    }
+    .ExpenseCategoryButton {
+      background-color: @surface0;
+      svg {
+        color: @text;
+      }
+
+      &:hover {
+        background-color: @surface1;
+      }
+    }
+    .AddOrEditExpenseScreen__dateButton:hover {
+      background-color: @surface0;
+    }
+    .SplitWithDropdown__separator {
+      border-top-color: @text;
+    }
+
+    // .TipToast__container
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1,0 +1,126 @@
+/* ==UserStyle==
+@name Wanderlog Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/wanderlog
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/wanderlog
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/wanderlog/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Awanderlog
+@description Soothing pastel theme for Wanderlog
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@import "https://userstyles.catppuccin.com/lib/lib.less";
+
+@-moz-document domain("wanderlog.com") {
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+    #lib.defaults();
+
+    --blue: @blue;
+    --brand: @accent;
+    --brand-2: @accent;
+    --cyan: @sky;
+    --danger: @red;
+    --green: @green;
+    --indigo: @mauve;
+    --info: @sapphire;
+    --orange: @peach;
+    --pink: @pink;
+    --primary: @accent;
+    --purple: @accent;
+    --red: @red;
+    --success: @green;
+    --swiper-theme-color: @accent;
+    --teal: @teal;
+    --warning: @peach;
+    --yellow: @yellow;
+
+    --accent-darker: darken(@accent, 5%);
+
+    /* General */
+    body {
+      background-color: @base;
+      color: @text;
+    }
+
+    // Text
+    .text-muted {
+      color: @subtext1 !important;
+    }
+
+    // Backgrounds
+    .bg-white {
+      background-color: @base !important;
+    }
+
+    // Navbar
+    .NavbarContainer.bg-white {
+      background-color: @mantle !important;
+      border-bottom-color: @accent;
+    }
+    .navbar-light .navbar-nav .nav-link {
+      color: @text;
+
+      &:hover, &:focus {
+        color: @subtext0;
+      }
+    }
+    .NavbarNavLink {
+      border-bottom-color: transparent;
+
+      &:hover, &:active, &:focus {
+        background-color: @base;
+        background-color: @mantle;
+      }
+
+      &__white:hover,
+      &__white:active,
+      &__white:focus {
+        border-color: @accent;
+        background-color: @mantle !important;
+      }
+    }
+    .Logo__logoMd {
+      filter: @accent-filter;
+    }
+
+    // Buttons
+    .Button__brand {
+      background-color: @accent;
+      border-color: @accent;
+
+      &, &:hover {
+        color: @base;
+      }
+
+      &:not(.Button__disabled):hover {
+        background-color: var(--accent-darker);
+        border-color: var(--accent-darker);
+      }
+    }
+
+    // Inputs
+    .Input__input {
+      border-color: @accent;
+    }
+    .form-control {
+      color: @text;
+      background-color: @surface0;
+    }
+  }
+}

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -2207,6 +2207,9 @@
       border-top-color: @text;
     }
 
-    // .TipToast__container
+    // Planner tip
+    .TipToast__container {
+      background-color: fade(@base, 90%);
+    }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -114,7 +114,7 @@
     .text-secondary {
       color: @subtext0 !important;
     }
-    .text-dark {
+    .text-body, .text-dark {
       color: @text !important;
     }
     .link-unstyled,
@@ -127,6 +127,9 @@
     }
     .color-primary-darkest {
       color: @text;
+    }
+    .small-uppercase-title {
+      color: @subtext0;
     }
 
     // Backgrounds
@@ -835,6 +838,15 @@
       }
     }
 
+    // Cards
+    .IconAndTextRowButton__div {
+      background-color: @surface0;
+
+      &:hover {
+        background-color: @surface1;
+      }
+    }
+
     // Quotes
     .IndentedQuote {
       border-left-color: @accent;
@@ -859,12 +871,40 @@
         fill: @text !important;
       }
 
+      // Gradients
+      #colortemperature stop, #colorhours stop, #colorspeed stop {
+        stop-color: @accent !important;
+      }
+
       // Splines and legend icons
       path[stroke="#e23e57"] {
         stroke: @red;
       }
       path[stroke="#3498db"] {
         stroke: @blue;
+      }
+      path[stroke="#f75940"], path[stroke="#ec9b3b"] {
+        stroke: @accent;
+      }
+
+      // Bar graphs
+      .recharts-rectangle {
+        &[fill="#46cdcf"],
+        &[fill="#3498db"],
+        &[fill="#7045af"] {
+          fill: @overlay1;
+        }
+        &[fill="#215b63"],
+        &[fill="#17b978"],
+        &[fill="#2a7aaf"],
+        &[fill="#4a266a"] {
+          fill: @accent;
+        }
+
+        // Background behind bars on hover
+        &.recharts-tooltip-cursor {
+          fill: @surface0;
+        }
       }
 
       // Legend text
@@ -882,10 +922,34 @@
 
         div[style="color: rgb(226, 62, 87);"] {
           color: @red !important;
+
+          & + div[style="color: rgb(52, 152, 219);"] {
+            // Set blue tooltip text if it directly follows red tooltip text
+            // Used for setting high low temp tool tip color as typically blue text is set to accent
+            color: @blue !important;
+          }
         }
 
-        div[style="color: rgb(52, 152, 219);"] {
-          color: @blue !important;
+        div[style="color: rgb(247, 89, 64);"],
+        div[style="color: rgb(70, 205, 207);"],
+        div[style="color: rgb(23, 185, 120);"],
+        div[style="color: rgb(52, 152, 219);"],
+        div[style="color: rgb(112, 69, 175);"],
+        div[style="color: rgb(236, 155, 59);"] {
+          color: @accent !important;
+        }
+      }
+      circle.recharts-dot {
+        stroke: @text;
+
+        &[fill="#e23e57"] {
+          fill: @red;
+        }
+        &[fill="#3498db"] {
+          fill: @blue;
+        }
+        &[fill="#f75940"], &[fill="#ec9b3b"] {
+          fill: @accent;
         }
       }
     }
@@ -1377,6 +1441,31 @@
       &__footer {
         background-color: @mantle !important;
       }
+    }
+
+    /* Weather pages https://wanderlog.com/weather/countries */
+    .TemperatureSummary {
+      background-color: @surface0;
+      color: @text;
+
+      .btn-light {
+        background-color: @surface0;
+        border-color: @accent;
+
+        svg {
+          color: @subtext1;
+        }
+
+        &:hover, &:active {
+          background-color: @surface1;
+          border-color: @accent;
+        }
+      }
+    }
+
+    // General weather stats
+    .StatIcon svg {
+      color: @accent;
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -697,7 +697,7 @@
       }
       &__optionSelected {
         background-color: @accent !important;
-        color: @base;
+        color: @base !important;
       }
     }
     .react-autosuggest {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -213,9 +213,12 @@
       filter: @accent-filter;
     }
 
-    // Heading underline block for some pages
+    // Underline block for some pages
     .Heading__underline {
       background-color: fade(@accent, 20%);
+    }
+    .UnderlinedText__yellowLight {
+      background-color: fade(@yellow, 20%);
     }
 
     // Borders

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1538,6 +1538,20 @@
         color: @text;
       }
 
+      // Subtle overlay over header background
+      &__scrim {
+        background: linear-gradient(
+          180deg,
+          fade(@accent, 20%) 0,
+          transparent 100%
+        );
+      }
+
+      // When there is no header bg image
+      &__placeholder {
+        background-color: @base;
+      }
+
       svg[data-icon="user-plus"] {
         color: @text;
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -844,6 +844,48 @@
       );
     }
 
+    // Charts and graphs
+    .recharts-wrapper {
+      // Axis
+      .recharts-cartesian-axis-line,
+      .recharts-cartesian-axis-tick-line {
+        stroke: @text !important;
+      }
+      .recharts-cartesian-axis-tick-value {
+        fill: @text !important;
+      }
+
+      // Splines and legend icons
+      path[stroke="#e23e57"] {
+        stroke: @red;
+      }
+      path[stroke="#3498db"] {
+        stroke: @blue;
+      }
+
+      // Legend text
+      span[style="color: rgb(226, 62, 87);"] {
+        color: @red !important;
+      }
+      span[style="color: rgb(52, 152, 219);"] {
+        color: @blue !important;
+      }
+
+      // Tooltip on hover
+      .Graph__customTooltip {
+        background-color: @surface1;
+        border-color: @accent;
+
+        div[style="color: rgb(226, 62, 87);"] {
+          color: @red !important;
+        }
+
+        div[style="color: rgb(52, 152, 219);"] {
+          color: @blue !important;
+        }
+      }
+    }
+
     // Footer
     .footer, #react-main > .footer {
       background-color: @mantle;
@@ -1330,46 +1372,6 @@
       }
       &__footer {
         background-color: @mantle !important;
-      }
-    }
-    .recharts-wrapper {
-      // Axis
-      .recharts-cartesian-axis-line,
-      .recharts-cartesian-axis-tick-line {
-        stroke: @text !important;
-      }
-      .recharts-cartesian-axis-tick-value {
-        fill: @text !important;
-      }
-
-      // Splines and legend icons
-      path[stroke="#e23e57"] {
-        stroke: @red;
-      }
-      path[stroke="#3498db"] {
-        stroke: @blue;
-      }
-
-      // Legend text
-      span[style="color: rgb(226, 62, 87);"] {
-        color: @red !important;
-      }
-      span[style="color: rgb(52, 152, 219);"] {
-        color: @blue !important;
-      }
-
-      // Tooltip on hover
-      .Graph__customTooltip {
-        background-color: @surface1;
-        border-color: @accent;
-
-        div[style="color: rgb(226, 62, 87);"] {
-          color: @red !important;
-        }
-
-        div[style="color: rgb(52, 152, 219);"] {
-          color: @blue !important;
-        }
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -70,6 +70,14 @@
 
     a {
       color: @blue;
+
+      &:hover, &:active {
+        color: darken(@blue, 5%);
+      }
+    }
+
+    svg[color="#212529"] {
+      color: @text;
     }
 
     // Wanderlog animated loading logo
@@ -78,16 +86,25 @@
     }
 
     // Text
+    .text-white {
+      color: @text !important;
+    }
     .text-muted {
       color: @subtext1 !important;
     }
     .text-danger {
       color: @red !important;
     }
+    .text-secondary {
+      color: @subtext0 !important;
+    }
 
     // Backgrounds
     .bg-white {
       background-color: @base !important;
+    }
+    .bg-gray-100 {
+      background-color: @mantle;
     }
 
     // Navbar
@@ -99,7 +116,7 @@
       color: @text;
 
       &:hover, &:focus {
-        color: @subtext0;
+        color: @subtext1;
       }
     }
     .NavbarNavLink {
@@ -115,6 +132,17 @@
       &__white:focus {
         border-color: @accent;
         background-color: @mantle !important;
+      }
+    }
+
+    .navbar-dark .navbar-brand,
+    .navbar-dark .navbar-nav .nav-link {
+      color: @text;
+    }
+    .NavbarContainer__darkBackground .btn-secondary,
+    .NavbarContainer__darkBackground .nav-link {
+      &:hover, &:active, &:focus {
+        background-color: fade(@base, 25%);
       }
     }
     .Logo__logoMd {
@@ -158,7 +186,7 @@
         color: var(--accent-darker);
       }
     }
-    .Button__flat-secondary {
+    .Button__flat-secondary, .btn {
       &, .Button__icon {
         color: @text;
 
@@ -198,6 +226,51 @@
         }
       }
     }
+    .Button__flat-white,
+    .Button__flat-white .Button__icon {
+      color: @text;
+
+      &:hover, &:active {
+        color: @subtext1;
+      }
+    }
+    .Button__dark {
+      background-color: @text;
+      border-color: @text;
+      color: @base;
+
+      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+        background-color: @subtext1;
+        border-color: @subtext1;
+        color: @base;
+      }
+    }
+    .Button__gray {
+      background-color: @surface1;
+      border-color: @surface1;
+
+      &, & .Button__icon, &:hover {
+        color: @subtext1;
+      }
+
+      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+        background-color: @surface2;
+        border-color: @surface2;
+        color: @text;
+
+        & .Button__icon {
+          color: @text;
+        }
+      }
+
+      &.Button__disabled {
+        background-color: @surface0;
+
+        &, & .Button__icon, &:hover {
+          color: @subtext0 !important;
+        }
+      }
+    }
     .outline-icon-button {
       border-color: @accent;
       color: @text;
@@ -213,7 +286,9 @@
     .Input__input {
       border-color: @accent;
     }
-    .form-control {
+    .form-control,
+    .form-control-gray,
+    .form-control-gray:focus {
       color: @text;
       background-color: @surface1;
     }
@@ -226,6 +301,79 @@
       }
     }
     .InputButton__button {
+      border-color: @accent;
+    }
+    .IconLabelCounterRow__counter {
+      border-color: @accent;
+    }
+    // Date inputs
+    .InputDateRangePicker {
+      &__date {
+        color: @subtext0;
+      }
+      &__dateSet {
+        color: @text;
+      }
+      &__divider {
+        background-color: @accent;
+      }
+      &__focusedDate {
+        color: @accent;
+      }
+    }
+    .DateRangePicker_picker,
+    .DayPicker,
+    .DayPicker__horizontal,
+    .CalendarMonth,
+    .CalendarMonthGrid {
+      background-color: @surface0;
+    }
+    .CalendarMonth_caption {
+      color: @text;
+    }
+    .CalendarDay {
+      &__default {
+        background-color: @surface1;
+        border-color: @overlay0;
+        color: @text;
+
+        &:hover {
+          background-color: @surface2;
+        }
+      }
+
+      &__hovered_span, &__hovered_span:hover {
+        background-color: fade(@accent, 20%) !important;
+      }
+
+      &__selected, &__selected_span {
+        background-color: @accent !important;
+        border-color: @overlay0 !important;
+        color: @base;
+
+        &:hover, &:active {
+          background-color: var(--accent-darker) !important;
+        }
+      }
+    }
+    .DayPickerNavigation {
+      &_button__default {
+        background-color: @accent;
+        border-color: @accent;
+        color: @base;
+
+        &:hover, &:active {
+          background-color: var(--accent-darker);
+        }
+      }
+      &_svg__horizontal {
+        fill: @base;
+      }
+    }
+    .DayPicker_weekHeader {
+      color: @text;
+    }
+    .DateRangePickerInput__withBorder {
       border-color: @accent;
     }
 
@@ -258,19 +406,21 @@
     }
 
     // Footer
-    .footer {
-      background-color: @crust;
+    .footer, #react-main > .footer {
+      background-color: @mantle;
 
       &-container {
-        background-color: @crust;
+        background-color: @mantle;
       }
 
       &-link,
-      .contact-us-button:hover {
+      .contact-us-button:hover,
+      .Footer__link a,
+      .Footer__contact {
         color: var(--gray--900);
       }
 
-      &-heart-wrapper svg {
+      &-heart-wrapper svg, .Footer__noEmoji {
         color: @accent;
       }
     }
@@ -498,6 +648,22 @@
         &:hover strong {
           color: var(--accent-darker);
         }
+      }
+    }
+
+    /* Hotels page */
+
+    .LandingPage {
+      &Heading__color {
+        color: @accent !important;
+      }
+
+      &SectionSubheading, &FeatureTile__subheader {
+        color: @text;
+      }
+
+      &SectionWithDivider {
+        border-top-color: @accent;
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -155,7 +155,7 @@
       }
     }
     .Button__default {
-      background-color: @accent;
+      background-color: transparent;
       border-color: @accent;
 
       &,
@@ -167,13 +167,13 @@
       &:not(.Button__disabled).Button__focused .Button__icon,
       &:not(.Button__disabled):hover .Button__icon,
       &:not(.Button__disabled):active .Button__icon {
-        color: @base;
+        color: @text;
       }
 
       &:not(.Button__disabled).Button__focused,
       &:not(.Button__disabled):hover,
       &:not(.Button__disabled):active {
-        background-color: var(--accent-darker);
+        background-color: @surface0;
         border-color: var(--accent-darker);
       }
     }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -334,7 +334,9 @@
         color: @text;
       }
 
-      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused {
         background-color: @surface2;
         border-color: @surface2;
         color: @text;
@@ -396,7 +398,8 @@
       }
 
       &:not(.Button__disabled):hover,
-      &:not(.Button__disabled):active {
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused {
         border-color: var(--accent-darker);
       }
     }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -603,16 +603,16 @@
       opacity: 1;
     }
     .tooltip-inner {
-      background-color: @mantle;
+      background-color: @crust;
       color: @text;
     }
     .bs-tooltip-auto[x-placement^="top"] .arrow::before,
     .bs-tooltip-top .arrow::before {
-      border-top-color: @mantle;
+      border-top-color: @crust;
     }
     .bs-tooltip-auto[x-placement^="bottom"] .arrow::before,
     .bs-tooltip-bottom .arrow::before {
-      border-bottom-color: @mantle;
+      border-bottom-color: @crust;
     }
     .ChildrenTargetedTooltip__tooltipInner__error {
       background-color: @red;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -134,7 +134,7 @@
       color: @text;
     }
     .small-uppercase-title {
-      color: @subtext0;
+      color: @subtext1;
     }
 
     // Backgrounds
@@ -280,7 +280,10 @@
     .Button__flat-primary .Button__icon,
     .Button__flat .Button__icon,
     .Button__flat:hover,
-    .Button__flat-primary:hover {
+    .Button__flat-primary:hover,
+    .Button__flat-brand,
+    .Button__flat-brand .Button__icon,
+    .Button__flat-brand:hover {
       color: @accent;
 
       &:hover,
@@ -502,6 +505,20 @@
       &:not(:disabled):not(.disabled):hover {
         color: @subtext0;
         opacity: 1;
+      }
+    }
+    .btn-light {
+      background-color: @surface0;
+      border-color: @accent;
+      color: @subtext1;
+
+      svg {
+        color: @subtext1;
+      }
+
+      &:hover, &:active {
+        background-color: @surface1;
+        border-color: @accent;
       }
     }
 
@@ -1541,20 +1558,6 @@
     .TemperatureSummary {
       background-color: @surface0;
       color: @text;
-
-      .btn-light {
-        background-color: @surface0;
-        border-color: @accent;
-
-        svg {
-          color: @subtext1;
-        }
-
-        &:hover, &:active {
-          background-color: @surface1;
-          border-color: @accent;
-        }
-      }
     }
 
     // General weather stats
@@ -1766,8 +1769,14 @@
         }
       }
     }
-    .SectionItemControls__control {
-      color: @accent;
+    .SectionItemControls {
+      &__control {
+        color: @accent;
+      }
+
+      &__selectedBar {
+        background-color: @accent;
+      }
     }
 
     // Notes text box
@@ -1849,6 +1858,82 @@
         background-color: @surface1;
         color: @text;
       }
+    }
+    // Hotels
+    .HotelsSectionItemEdit {
+      &__inputLabel {
+        color: @subtext1;
+      }
+      &__input, &__input:focus {
+        background-color: @surface1;
+        color: @text;
+      }
+      &__date {
+        background-color: @surface1;
+        color: @text;
+      }
+    }
+    // General attachments (pro feature)
+    .AttachmentsSectionItem {
+      background-color: @surface0;
+      &__titleInput {
+        background-color: @surface0;
+        color: @text;
+
+        &:focus {
+          background-color: @surface1;
+        }
+      }
+    }
+    .ViewFileAttachmentModal__body {
+      background-color: @crust;
+      border-top-color: @accent;
+      border-bottom-color: @accent;
+    }
+    .ql-editor.ql-blank::before {
+      color: @subtext0;
+    }
+    // Rental car, train, bus, ferry, cruise reservations
+    .RentalCarsTerminusView {
+      &__mutedText {
+        color: @subtext1;
+      }
+
+      &__address {
+        color: @subtext0;
+      }
+    }
+    .RentalCarsSectionItemEdit {
+      &__inputLabel {
+        color: @subtext1;
+      }
+    }
+    .RentalCarsTerminusEdit__inputButton {
+      background-color: @surface1;
+      color: @text;
+    }
+    .TerminusEdit {
+      &__date, &__timeInput {
+        background-color: @surface1;
+        color: @text;
+      }
+    }
+    .TransitSectionItemEdit {
+      &__inputLabel {
+        color: @subtext1;
+      }
+      &__input, &__input:focus {
+        background-color: @surface1;
+        color: @text;
+      }
+    }
+    .CruiseSectionItemEdit__input, .CruiseSectionItemEdit__input:focus {
+      background-color: @surface1;
+      color: @text;
+    }
+    .BoardBlockSeparator__horizontalLine {
+      // Cruise itinerary separator
+      border-top-color: @text;
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -124,6 +124,9 @@
     .link-unstyled:visited {
       color: inherit !important;
     }
+    .color-primary-darkest {
+      color: @text;
+    }
 
     // Backgrounds
     .bg-white {
@@ -179,6 +182,11 @@
     }
     .Logo__logoMd {
       filter: @accent-filter;
+    }
+
+    // Heading underline block for some pages
+    .Heading__underline {
+      background-color: fade(@accent, 20%);
     }
 
     // Fake progress bar between SPA pages
@@ -495,6 +503,22 @@
       }
     }
 
+    // Star icons
+    svg[data-icon="star"] {
+      &[color="#ec9b3b"], &[color="#2c365d"] {
+        color: @yellow !important;
+      }
+      &[color="#adb5bd"] {
+        color: @surface1;
+      }
+      &[color="#6c757d"] {
+        color: @subtext1;
+      }
+    }
+    svg[data-icon="star-half"] {
+      color: @yellow !important;
+    }
+
     // Tooltips
     .tooltip.show {
       opacity: 1;
@@ -778,6 +802,30 @@
       &__radioCircleSelected {
         border-color: @accent;
       }
+    }
+
+    // Get app promos
+    .LandingPageGetAppPromo__container {
+      background-color: @surface0;
+    }
+    .GetAppPromoLeftSide {
+      &__largeAppCaption,
+      &__ratingMessage {
+        color: @text;
+      }
+    }
+
+    // Quotes
+    .IndentedQuote {
+      border-left-color: @accent;
+    }
+    .ExpandableText__inlineButton {
+      background: linear-gradient(
+        90deg,
+        hsla(0, 0%, 100%, 0),
+        fade(@base, 80%) 16px,
+        @base 32px
+      );
     }
 
     // Footer
@@ -1208,7 +1256,7 @@
       }
     }
 
-    /* Extension page https://wanderlog.com/extension*/
+    /* Extension page https://wanderlog.com/extension */
     .ExtensionLandingPageHero__background {
       background-color: fade(@accent, 10%);
     }
@@ -1238,22 +1286,75 @@
         }
       }
     }
-    .BudgetLandingPageGetAppPromo__appText {
-      svg[data-icon="star"] {
-        color: @yellow !important;
-      }
-
-      .GetAppPromoLeftSide {
-        &__largeAppCaption,
-        &__ratingMessage {
-          color: @text;
-        }
-      }
-    }
 
     /* Embed map in blog page https://wanderlog.com/embed-travel-map-on-blog */
     .MapEmbedLandingPageInner__hero {
       background-color: fade(@accent, 10%);
+    }
+
+    /* Trip Planners by Destination page and subpages https://wanderlog.com/tp */
+    a.TripPlannerGeosListPage__geo {
+      color: @subtext1;
+    }
+    .LandingPageCreateTripPlanHero {
+      &__translucentColor {
+        color: @text;
+      }
+      &__createTripPlanBox {
+        background-color: @accent;
+        border-color: @accent;
+      }
+    }
+    .TripPlannerLandingPageInner {
+      &__sectionHeading {
+        color: @text;
+      }
+      &__sectionWithDivider {
+        border-top-color: @accent;
+      }
+      &__footer {
+        background-color: @mantle !important;
+      }
+    }
+    .recharts-wrapper {
+      // Axis
+      .recharts-cartesian-axis-line,
+      .recharts-cartesian-axis-tick-line {
+        stroke: @text !important;
+      }
+      .recharts-cartesian-axis-tick-value {
+        fill: @text !important;
+      }
+
+      // Splines and legend icons
+      path[stroke="#e23e57"] {
+        stroke: @red;
+      }
+      path[stroke="#3498db"] {
+        stroke: @blue;
+      }
+
+      // Legend text
+      span[style="color: rgb(226, 62, 87);"] {
+        color: @red !important;
+      }
+      span[style="color: rgb(52, 152, 219);"] {
+        color: @blue !important;
+      }
+
+      // Tooltip on hover
+      .Graph__customTooltip {
+        background-color: @surface1;
+        border-color: @accent;
+
+        div[style="color: rgb(226, 62, 87);"] {
+          color: @red !important;
+        }
+
+        div[style="color: rgb(52, 152, 219);"] {
+          color: @blue !important;
+        }
+      }
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -49,6 +49,16 @@
     --teal: @teal;
     --warning: @peach;
     --yellow: @yellow;
+    --white: @base;
+    --gray--100: @subtext1;
+    --gray--200: @subtext1;
+    --gray--300: @subtext1;
+    --gray--600: @subtext1;
+    --gray--600-2: @subtext1;
+    --gray700: @subtext0;
+    --gray700-2: @subtext0;
+    --gray--900: @text;
+    --gray--900-2: @text;
 
     --accent-darker: darken(@accent, 5%);
 
@@ -56,6 +66,10 @@
     body {
       background-color: @base;
       color: @text;
+    }
+
+    a {
+      color: @blue;
     }
 
     // Text
@@ -113,6 +127,53 @@
         border-color: var(--accent-darker);
       }
     }
+    .brand-button {
+      color: @base !important;
+
+      &:hover, &:active {
+        background-color: var(--accent-darker);
+      }
+    }
+    .Button__flat, .flat-button {
+      color: @accent;
+
+      &:hover, &:active {
+        color: var(--accent-darker);
+      }
+    }
+    .Button__default {
+      background-color: @accent;
+      border-color: @accent;
+
+      &,
+      &:hover,
+      &:active,
+      & .Button__icon,
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused .Button__icon,
+      &:not(.Button__disabled):hover .Button__icon,
+      &:not(.Button__disabled):active .Button__icon {
+        color: @base;
+      }
+
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active {
+        background-color: var(--accent-darker);
+        border-color: var(--accent-darker);
+      }
+    }
+    .outline-icon-button {
+      border-color: @accent;
+      color: @text;
+    }
+
+    // Badges
+    .Badge__light {
+      background-color: @accent;
+      color: @base;
+    }
 
     // Inputs
     .Input__input {
@@ -121,6 +182,250 @@
     .form-control {
       color: @text;
       background-color: @surface0;
+    }
+
+    // Dropdowns
+    .DropdownMenu {
+      border-color: @accent;
+    }
+    .dropdown {
+      &-menu {
+        background-color: @surface0;
+        color: @text;
+      }
+
+      &-item {
+        color: @text;
+        &:hover, &:active, &:focus {
+          background-color: @surface1;
+        }
+      }
+    }
+    .react-autosuggest {
+      &__suggestions-container {
+        background-color: @surface0;
+        border-color: @accent;
+      }
+
+      &__suggestion--highlighted {
+        background-color: @surface1;
+      }
+    }
+
+    // Footer
+    .footer {
+      background-color: @crust;
+
+      &-container {
+        background-color: @crust;
+      }
+
+      &-link,
+      .contact-us-button:hover {
+        color: var(--gray--900);
+      }
+
+      &-heart-wrapper svg {
+        color: @accent;
+      }
+    }
+
+    /* Homepage (not logged in) */
+
+    // Main page hero text
+    .page-title-heading.text_align_center.font_weight_bold.font_color_gray_900.font_size_48.font_size_xs_36 {
+      color: @accent;
+    }
+    // Main page hero subtext
+    .body-text.font_size_18.font_color_gray_600 {
+      color: @subtext1;
+    }
+
+    // Hero video
+    .demo-video-328,
+    .demo-video-1280,
+    #hero-section-video-mobile,
+    #hero-section-video-web {
+      border-color: @accent;
+    }
+
+    // Reviews section
+    .reviews-section---desktop, .reviews-section---mobile {
+      background-color: @base;
+    }
+    .reviews-overlay---see-more {
+      background-image: linear-gradient(#0000, @base);
+    }
+    .card-review {
+      background-color: @surface0;
+      border-color: @accent;
+
+      .stars-small img {
+        filter: @yellow-filter;
+      }
+    }
+
+    // Spotlight section
+    .spotlight-on-wanderlog---home {
+      background-color: fade(@accent, 10%);
+    }
+    .spotlight-card {
+      border-color: fade(@accent, 20%);
+    }
+    .spotlight-card-author-text {
+      &-author {
+        color: @subtext0;
+      }
+      &-username {
+        color: @blue;
+      }
+    }
+
+    // Infographics section
+    .infographics---home {
+      background-color: fade(@accent, 10%);
+    }
+    .infographics-card {
+      &-header {
+        color: @accent;
+      }
+      &-star {
+        filter: @accent-filter;
+      }
+    }
+
+    // Android only section
+    .branch_left_vector, .branch_right_vector {
+      filter: @green-filter;
+    }
+
+    // Features section
+    .home__feature_tab_overlay {
+      &_left {
+        background-image: linear-gradient(
+          90deg,
+          @base 0%,
+          rgba(0, 0, 0, 0) 100%
+        );
+        mix-blend-mode: normal;
+      }
+      &_right {
+        background-image: linear-gradient(
+          270deg,
+          @base 0%,
+          rgba(0, 0, 0, 0) 100%
+        );
+        mix-blend-mode: normal;
+      }
+    }
+    .home__feature_tab_icon {
+      filter: @text-filter;
+      &_container {
+        border-color: @accent;
+
+        &[style="background-color: rgb(255, 255, 255);"] {
+          background-color: @base !important;
+        }
+
+        &[style="background-color: rgb(0, 0, 0);"] {
+          background-color: @accent !important;
+
+          svg {
+            filter: @base-filter;
+          }
+        }
+      }
+    }
+    .swiper-slide-active .home__feature_tab_icon_container {
+      background-color: @accent;
+      svg {
+        filter: @base-filter;
+      }
+    }
+    .swiper-slide-active .home__feature_tab_title {
+      color: @text;
+    }
+
+    // Regular features section
+    .regular-feature-section {
+      background-color: @base;
+    }
+
+    // Pro features section
+    .pro-features-card {
+      background-color: @surface0;
+
+      svg {
+        color: @accent;
+      }
+    }
+
+    // Explore places section
+    .explore-places-card {
+      .text_color_white {
+        color: @text;
+      }
+
+      &-overlay {
+        background-image: linear-gradient(
+          fade(@crust, 0%),
+          fade(@crust, 60%) 50%
+        );
+      }
+    }
+
+    // Travel guides section
+    .travel-guides-section {
+      background-color: @base;
+    }
+    .avatar-name-views-likes-icon {
+      filter: @accent-filter;
+    }
+
+    // Market badges section
+    .market-badges {
+      &-section {
+        background-color: @base;
+      }
+
+      &-container {
+        background-image: none;
+        background-color: @accent;
+
+        .section-heading {
+          color: @base;
+        }
+
+        .rating {
+          background-color: @base;
+          border: @base;
+        }
+
+        .star-filled {
+          filter: @yellow-filter;
+        }
+      }
+      &-text {
+        ._4-9-on-app-store-4-7-on-google-play-0 {
+          color: @text;
+        }
+
+        span {
+          color: @subtext0;
+        }
+      }
+    }
+
+    // Links section
+    .links-section {
+      background-color: @base;
+      .links-list-title {
+        color: @text;
+      }
+
+      .links-list-rich-text-block a {
+        color: var(--gray--600);
+      }
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -80,6 +80,10 @@
       color: @text;
     }
 
+    hr {
+      border-top-color: @accent;
+    }
+
     // Wanderlog animated loading logo
     .Loading__logo {
       filter: @accent-filter;
@@ -264,6 +268,20 @@
         color: @base;
       }
     }
+    .Button__light-gray {
+      background-color: @surface0;
+      border-color: @accent;
+
+      &, .Button__icon, &:hover {
+        color: @text;
+      }
+
+      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+        background-color: @surface1;
+        border-color: @accent;
+        color: @text;
+      }
+    }
     .Button__gray {
       background-color: @surface1;
       border-color: @surface1;
@@ -294,11 +312,34 @@
       border-color: @accent;
       color: @text;
     }
+    .Button__translucent-white {
+      background-color: fade(@base, 70%);
+
+      &,
+      .Button__icon,
+      &:hover,
+      &:not(.Button__disabled):active {
+        color: @text;
+      }
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active {
+        background-color: fade(@base, 80%);
+      }
+    }
 
     // Badges
-    .Badge__light {
+    .Badge__light,
+    .Badge__lightGray {
       background-color: @accent;
       color: @base;
+    }
+    .VerifiedBadge {
+      background-color: @accent;
+
+      svg {
+        color: @base;
+      }
     }
 
     // Inputs
@@ -683,6 +724,34 @@
 
       &SectionWithDivider {
         border-top-color: @accent;
+      }
+    }
+
+    /* Travel guides */
+    // Travel guide cards
+    .Card {
+      svg[data-icon="heart"], svg[data-icon="eye"] {
+        color: @accent;
+      }
+    }
+    .Card__title,
+    .ProfilePageNameLink {
+      color: @text;
+
+      &:focus, &:hover, &:active {
+        color: @subtext1;
+      }
+    }
+    // Page breadcrumbs
+    .Breadcrumbs svg[data-icon="chevron-right"] {
+      color: @accent;
+    }
+    // Links to guide categories (e.g. Madrid guides within Spain page)
+    a[href^="/guides/"]:not(.Button) {
+      color: @accent;
+
+      &:hover, &:active {
+        color: var(--accent-darker);
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -186,7 +186,10 @@
     .Button__flat-primary:hover {
       color: @accent;
 
-      &:hover, &:active {
+      &:hover,
+      &:active,
+      &:not(.Button__disabled):hover .Button__icon,
+      &:not(.Button__disabled):active .Button__icon {
         color: var(--accent-darker);
       }
     }
@@ -195,6 +198,8 @@
         color: @text;
 
         &:hover,
+        &:not(.Button__disabled):hover,
+        &:not(.Button__disabled):hover .Button__icon,
         &:not(.Button__disabled):active,
         &:not(.Button__disabled):active .Button__icon {
           color: @subtext1;
@@ -356,7 +361,8 @@
       &__labelContainer {
         color: @subtext1;
       }
-      &__labelFocused {
+      &__labelFocused,
+      &__boldUnfocusedLabel {
         color: @text;
       }
     }
@@ -371,7 +377,7 @@
       &__date {
         color: @subtext0;
       }
-      &__dateSet {
+      &__dateSet, &__icon {
         color: @text;
       }
       &__divider {
@@ -454,6 +460,15 @@
         }
       }
     }
+    .StyledDropdownMenu {
+      &__toggle:focus {
+        background-color: @surface0;
+      }
+      &__optionSelected {
+        background-color: @accent !important;
+        color: @base;
+      }
+    }
     .react-autosuggest {
       &__suggestions-container {
         background-color: @surface0;
@@ -462,6 +477,15 @@
 
       &__suggestion--highlighted {
         background-color: @surface1;
+      }
+    }
+    // When autocomplete location dropdown don't get a good match
+    .LowMatchStaticGeoAutosuggestSuggestion__suggestion {
+      background-color: fade(@peach, 30%);
+
+      // Warning symbol
+      svg[color="#de703c"] {
+        color: var(--warning);
       }
     }
 
@@ -752,6 +776,32 @@
 
       &:hover, &:active {
         color: var(--accent-darker);
+      }
+    }
+
+    /* Plan a new trip and write a new guide pages */
+    .TripmatesButton__inviteButton,
+    .TripmatesButton__inviteButton .Button__icon {
+      color: @text;
+    }
+    .TripOrGuideForm__addMoreButton {
+      background-color: @accent !important;
+      border-color: @accent !important;
+
+      &:hover, &:active {
+        background-color: var(--accent-darker) !important;
+        border-color: var(--accent-darker) !important;
+      }
+
+      .Button__icon, &:hover .Button__icon, &:active .Button__icon {
+        color: @base !important;
+      }
+    }
+    .Chip {
+      border-color: @accent;
+
+      &__default {
+        color: @text;
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -300,6 +300,10 @@
       &:hover,
       &:active,
       &:not(.Button__disabled):hover .Button__icon,
+      &:not(.Button__disabled):active .Button__icon,
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused .Button__icon,
       &:not(.Button__disabled):active .Button__icon {
         color: var(--accent-darker);
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -190,7 +190,9 @@
         background-color: @mantle !important;
       }
     }
-
+    .NavbarContainer__darkTranslucent {
+      background-color: @mantle !important;
+    }
     .navbar-dark .navbar-brand,
     .navbar-dark .navbar-nav .nav-link {
       color: @text;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -568,7 +568,22 @@
         }
       }
     }
+    .Button__danger {
+      background-color: @red;
+      border-color: @red;
 
+      &, .Button__icon, &:hover {
+        color: @base;
+      }
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):active {
+        background-color: darken(@red, 5%);
+        border-color: darken(@red, 5%);
+        color: @base;
+      }
+    }
     // Badges
     .Badge__light,
     .Badge__lightGray,
@@ -979,6 +994,9 @@
       }
     }
     .FormButton {
+      .FormButton__icon {
+        color: @text;
+      }
       &:active .FormButton__icon,
       &:active .FormButton__label,
       &:hover .FormButton__icon,
@@ -2385,6 +2403,17 @@
     // Planner tip
     .TipToast__container {
       background-color: fade(@base, 95%);
+    }
+
+    // Trip Settings
+    .TripPlanSettings {
+      &__heading {
+        color: @text;
+      }
+
+      &__divider {
+        background-color: @accent;
+      }
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -219,13 +219,20 @@
     .border-top {
       border-top-color: @text !important;
     }
+    .border-bottom {
+      border-bottom-color: @text !important;
+    }
 
-    // Fake progress bar between SPA pages
+    // Progress bars
     .FakeTopProgressBar {
       background-color: @accent;
     }
     .progress-bar {
       background-color: @accent;
+    }
+    .progress {
+      // Progress bar backgrounds
+      background-color: @overlay0;
     }
 
     // Notifications popup
@@ -606,6 +613,18 @@
         color: @base;
       }
     }
+    .CircleButton__imageBackground {
+      background-color: @surface2;
+
+      svg[color="#000000"] {
+        color: @text;
+      }
+      svg[color="#1877f2"] {
+        // Facebook logo
+        color: @blue;
+      }
+    }
+
     // Badges
     .Badge__light,
     .Badge__lightGray,
@@ -2625,11 +2644,6 @@
         color: @base !important;
       }
 
-      .progress {
-        // Reviews tab progress bar background
-        background-color: @overlay0;
-      }
-
       .Badge__light {
         .text-muted {
           color: @base !important;
@@ -2685,6 +2699,78 @@
     // Arrangement and color modal
     .RearrangeSectionRow__section {
       background-color: @surface0;
+    }
+
+    /* Profile Page */
+    .ProfilePageUserDetails {
+      &__container {
+        border-color: @accent;
+      }
+    }
+    .NumberAndTitle__number, .NumberAndTitle__title {
+      color: @text;
+    }
+    .VisitGeosSummary {
+      background-color: fade(@base, 90%);
+
+      &:active, &:focus, &:hover {
+        background-color: @base;
+      }
+    }
+    .ProfilePageMapOverlayGroup {
+      // Make invisible buttons on profile page maps visible
+
+      &__leftTop,
+      &__rightTop {
+        .Button__default {
+          background-color: fade(@base, 80%);
+          color: @text;
+
+          &:not(.Button__disabled):hover,
+          &:not(.Button__disabled):active,
+          &:not(.Button__disabled).Button__focused {
+            background-color: fade(@base, 90%);
+            border-color: transparent;
+            .Button__icon {
+              color: @text;
+            }
+          }
+        }
+        .Button__translucent-black {
+          background-color: fade(@base, 80%);
+          color: @text;
+
+          &:not(.Button__disabled):hover,
+          &:not(.Button__disabled):active,
+          &:not(.Button__disabled).Button__focused {
+            background-color: fade(@base, 90%);
+            border-color: transparent;
+            .Button__icon {
+              color: @text;
+            }
+          }
+        }
+      }
+    }
+    .ProfilePageMapContainer__userDisplay {
+      background-color: @base;
+    }
+    .TravelLeaderboard {
+      &__container {
+        background-color: @surface0;
+      }
+
+      &__heading {
+        color: @text;
+      }
+    }
+    .LeaderboardList {
+      &__index {
+        color: @accent;
+      }
+      &__user {
+        border-bottom-color: @text;
+      }
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -923,7 +923,7 @@
         div[style="color: rgb(226, 62, 87);"] {
           color: @red !important;
 
-          & + div[style="color: rgb(52, 152, 219);"] {
+          + div[style="color: rgb(52, 152, 219);"] {
             // Set blue tooltip text if it directly follows red tooltip text
             // Used for setting high low temp tool tip color as typically blue text is set to accent
             color: @blue !important;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -199,7 +199,7 @@
       background-color: @accent;
       border-color: @accent;
 
-      &, &:hover, &:active {
+      &, &:hover, &:active, .Button__icon {
         color: @base;
       }
 
@@ -348,7 +348,11 @@
       background-color: @surface0;
       border-color: @accent;
 
-      &, .Button__icon, &:hover {
+      &,
+      .Button__icon,
+      &:hover,
+      &:not(.Button__disabled):hover .Button__icon,
+      &:not(.Button__disabled):active .Button__icon {
         color: @text;
       }
 

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1819,6 +1819,122 @@
       }
     }
 
+    // Sidebar
+    .PlanNavSidebar {
+      &__fixed {
+        background-color: @mantle;
+        border-right-color: @accent;
+      }
+    }
+    .NavSidebarItem {
+      &:active, &:focus, &:hover {
+        color: @subtext0 !important;
+      }
+    }
+    .PlanWideNavSidebar {
+      &Heading__activeHeadingContainer {
+        background-color: @accent;
+      }
+
+      &Heading__chevron, &Heading__heading {
+        color: @text;
+
+        &:active, &:focus, &:hover {
+          color: @subtext1 !important;
+        }
+      }
+
+      &Heading__activeChevron,
+      &Heading__activeHeading {
+        &, &:active, &:focus, &:hover {
+          color: @base !important;
+        }
+      }
+
+      &Item__label {
+        color: @text;
+      }
+      &Item__sublabel {
+        color: @subtext1;
+      }
+
+      &__hideSidebar {
+        background-color: @mantle;
+        color: @accent;
+
+        &:active, &:focus, &:hover {
+          color: var(--accent-darker) !important;
+        }
+      }
+    }
+    .PlanNarrowNavSidebar {
+      &Heading__headingContainer {
+        background-color: @surface0;
+        color: @text;
+
+        &:active, &:focus, &:hover {
+          background-color: @surface0 !important;
+          color: @accent !important;
+        }
+      }
+
+      &Heading__activeHeadingContainer {
+        background-color: @accent;
+        color: @base;
+
+        &:active, &:focus, &:hover {
+          background-color: @accent !important;
+          color: @base !important;
+        }
+      }
+
+      &Item__dot {
+        background-color: @text;
+      }
+
+      &Item__dotContainer:active .PlanNarrowNavSidebarItem__dot,
+      &Item__dotContainer:focus .PlanNarrowNavSidebarItem__dot,
+      &Item__dotContainer:hover .PlanNarrowNavSidebarItem__dot {
+        background-color: var(--accent-darker) !important;
+      }
+
+      &Item__activeDot,
+      &Item__dotContainer:active .PlanNarrowNavSidebarItem__activeDot,
+      &Item__dotContainer:focus .PlanNarrowNavSidebarItem__activeDot,
+      &Item__dotContainer:hover .PlanNarrowNavSidebarItem__activeDot {
+        background-color: @accent;
+      }
+
+      &Item__text:active, &Item__text:focus, &Item__text:hover {
+        color: var(--accent-darker) !important;
+      }
+
+      &Item__activeText {
+        color: @accent;
+      }
+
+      &__hideSidebar {
+        background-color: @mantle;
+        color: @accent;
+
+        &:active, &:focus, &:hover {
+          color: var(--accent-darker) !important;
+        }
+      }
+    }
+    .TripPlanAssistantButton {
+      background: @accent;
+
+      .fa-wand-magic-sparkles,
+      .Button__labelText {
+        color: @base;
+      }
+
+      &:hover {
+        background-color: var(--accent-darker);
+      }
+    }
+
     // Spacers
     .PlanBoard__spacer {
       background-color: @mantle;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -230,6 +230,21 @@
         background-color: var(--accent-darker);
       }
     }
+    .btn-primary {
+      background-color: @accent;
+      border-color: @accent;
+      color: @base !important;
+
+      &.focus,
+      &:focus,
+      &:hover,
+      &:not(:disabled):not(.disabled).active,
+      &:not(:disabled):not(.disabled):active,
+      .show > &.dropdown-toggle {
+        background-color: var(--accent-darker);
+        border-color: var(--accent-darker);
+      }
+    }
     .Button__flat,
     .flat-button,
     .Button__flat-primary,
@@ -512,6 +527,7 @@
     .form-control-gray:focus {
       color: @text;
       background-color: @surface1;
+      border-color: @accent;
     }
     .InputContainer {
       &__labelContainer {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -139,6 +139,9 @@
     .color-teal {
       color: @teal;
     }
+    .color-yellow {
+      color: @yellow;
+    }
     .RatingWithLogo__yellowRating {
       color: @yellow;
     }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -241,6 +241,11 @@
     // Notifications popup
     .popover {
       background-color: @surface0;
+
+      &-header {
+        background-color: @surface1;
+        border-bottom-color: @accent;
+      }
     }
     .NotificationButtonLoaded__popover .popover {
       border-color: @accent;
@@ -580,9 +585,20 @@
         border-color: @accent;
       }
     }
-    .LargeIconButton:focus, .LargeIconButton:hover {
-      background-color: @surface0;
+    .LargeIconButton {
+      &:focus, &:hover {
+        background-color: @surface0;
+      }
+
+      svg[color="#000000"], svg[color="#6c757d"] {
+        color: @text;
+      }
+      svg[color="#1877f2"] {
+        // Facebook logo
+        color: @blue;
+      }
     }
+
     .Button__indigo, .Button__purple {
       background-color: @accent;
       border-color: @accent;
@@ -2927,12 +2943,33 @@
           border-color: @surface2;
         }
       }
+
+      .ExpandableText__inlineButton {
+        background: linear-gradient(
+          90deg,
+          hsla(0, 0%, 100%, 0),
+          fade(@surface0, 80%) 16px,
+          @surface0 32px
+        );
+      }
     }
     .PlacesListPageLoaded {
       &__floatingBottomButton {
         // Back to top button
         .Button__default {
-          background-color: @surface0;
+          background-color: @accent;
+          color: @base;
+
+          svg {
+            color: @base;
+          }
+
+          &:not(.Button__disabled):active,
+          &:not(.Button__disabled):hover,
+          &:not(.Button__disabled):focus,
+          &:not(.Button__disabled).Button__focused {
+            background-color: var(--accent-darker);
+          }
         }
       }
     }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -449,6 +449,21 @@
         color: @subtext0;
       }
     }
+    .Button__outline-brand {
+      background-color: transparent;
+      border-color: @accent;
+
+      &, .Button__icon, &:hover {
+        color: @accent;
+      }
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused {
+        border-color: var(--accent-darker);
+        color: var(--accent-darker);
+      }
+    }
 
     // Badges
     .Badge__light,

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -482,7 +482,9 @@
         color: @text;
       }
 
-      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused {
         background-color: transparent;
         border-color: transparent;
         .Button__icon {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -153,11 +153,14 @@
     .bg-light {
       background-color: @surface0 !important;
     }
-    .bg-primary {
+    .bg-primary, .bg-primary-darkest {
       background-color: @accent !important;
     }
     .bg-success {
       background-color: var(--success) !important;
+    }
+    .bg-warning {
+      background-color: var(--warning) !important;
     }
 
     // Navbar
@@ -208,6 +211,9 @@
     }
 
     // Borders
+    .border {
+      border-color: @accent !important;
+    }
     .border-top {
       border-top-color: @text !important;
     }
@@ -371,9 +377,11 @@
     .Button__default-dark,
     .Button__default-dark .Button__icon {
       background-color: @accent;
+      border-color: @accent;
 
       &:hover, &:active, &:not(.Button__disabled):hover .Button__icon {
         background-color: var(--accent-darker);
+        border-color: var(--accent-darker);
       }
     }
     .Button__flat-white,
@@ -625,6 +633,11 @@
       .Badge__closeButtonIcon {
         background-color: transparent;
       }
+    }
+    .Badge__whiteWithIndigoTextAndOutline {
+      background-color: @surface0;
+      border-color: @blue;
+      color: @blue;
     }
 
     .VerifiedBadge {
@@ -2545,6 +2558,125 @@
 
       &Button__indicator {
         color: @base;
+      }
+    }
+
+    // Map place card
+    .PlanMapPlaceOverlay__selectedCardInner {
+      // Dropdown for which list the item is added to
+      .SplitDropdownToggle__divider {
+        &_light-gray {
+          // When added to list
+          background-color: @surface0;
+        }
+
+        &_brand {
+          // When not added to list
+          background-color: @accent;
+        }
+      }
+      .SplitDropdownToggle__line {
+        &_light-gray {
+          // When added to list
+          background-color: @surface1;
+        }
+
+        &_brand {
+          // When not added to list
+          background-color: var(--accent-darker);
+        }
+      }
+      .Button__light-gray {
+        // We don't want the accent border when the place is added to a list
+        border-color: @surface0;
+        &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+          border-color: @surface1;
+        }
+      }
+
+      .Button__iconOnly svg {
+        // Place list selection dropdown symbol
+
+        &[color="#6c757d"] {
+          // When added to list
+          color: @text;
+        }
+
+        &[color="#ffffff"] {
+          // When not added to list
+          color: @base;
+        }
+      }
+
+      .PlaceDetails__links a.Button__default-dark {
+        // "Open in" buttons
+        color: @base;
+      }
+
+      .list-group-numbered div[style^="color: rgb(178, 186, 244);"] {
+        // "Why you should go" list numbers
+        color: @accent !important;
+      }
+
+      .bg-primary-darkest {
+        // Reviews tab big rating numbers
+        color: @base !important;
+      }
+
+      .progress {
+        // Reviews tab progress bar background
+        background-color: @overlay0;
+      }
+
+      .Badge__light {
+        .text-muted {
+          color: @base !important;
+        }
+
+        .color-gray-400 {
+          color: @surface2;
+        }
+      }
+    }
+    .MinimalPlaceDetails__rating {
+      // Place rating
+      color: @yellow;
+    }
+    .IconRow__icon {
+      color: @text;
+    }
+    .BookingPriceCard__border {
+      border-color: @accent;
+    }
+    .DayBadge {
+      background-color: @surface0;
+      color: @text;
+
+      &__closed {
+        background: linear-gradient(
+          to left top,
+          @surface1 44%,
+          @overlay2 45.5%,
+          @overlay2 49.5%,
+          @surface1 51%
+        );
+
+        &Overlay {
+          background: linear-gradient(
+            to left top,
+            hsla(0, 0%, 100%, 0) 42%,
+            @overlay2 43.5%,
+            @overlay2 45.5%,
+            hsla(0, 0%, 100%, 0) 47%
+          );
+        }
+      }
+    }
+    .PlaceDetailsIconRows__showHideTimes {
+      color: @blue;
+
+      &:hover, &:active {
+        color: darken(@blue, 5%) !important;
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -610,6 +610,10 @@
     .bs-tooltip-top .arrow::before {
       border-top-color: @mantle;
     }
+    .bs-tooltip-auto[x-placement^="bottom"] .arrow::before,
+    .bs-tooltip-bottom .arrow::before {
+      border-bottom-color: @mantle;
+    }
     .ChildrenTargetedTooltip__tooltipInner__error {
       background-color: @red;
       color: @base;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -151,7 +151,7 @@
       &,
       &:hover,
       &:active,
-      & .Button__icon,
+      .Button__icon,
       &:not(.Button__disabled).Button__focused,
       &:not(.Button__disabled):active,
       &:not(.Button__disabled).Button__focused .Button__icon,
@@ -417,7 +417,7 @@
 
         .rating {
           background-color: @base;
-          border: @base;
+          border-color: @base;
         }
 
         .star-filled {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -580,7 +580,11 @@
         color: @subtext1;
       }
 
-      &:hover, &:active {
+      &:hover,
+      &:active,
+      &:not(:disabled):not(.disabled).active,
+      &:not(:disabled):not(.disabled):active,
+      .show > &.dropdown-toggle {
         background-color: @surface1;
         border-color: @accent;
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1620,5 +1620,18 @@
         color: @text;
       }
     }
+
+    .PlanPageLoaded {
+      &__grayBackground {
+        background-color: @base;
+      }
+      &__footer {
+        background-color: @mantle;
+      }
+    }
+
+    .PlanBoard__spacer {
+      background-color: @mantle;
+    }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1962,7 +1962,8 @@
 
     // Sidebar
     .PlanNavSidebar {
-      &__fixed {
+      &__fixed,
+      &__mobileModalBody {
         background-color: @mantle;
         border-right-color: @accent;
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -551,6 +551,18 @@
     .VisitGeosBadgeIcon__gold {
       color: @peach;
     }
+    .Badge__warning {
+      background-color: var(--warning);
+      color: @base;
+
+      &.Badge__button:active, &.Badge__button:focus, &.Badge__button:hover {
+        background-color: @yellow;
+      }
+
+      & .Badge__closeButtonIcon {
+        background-color: transparent;
+      }
+    }
 
     .VerifiedBadge {
       background-color: @accent;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -77,8 +77,10 @@
       }
     }
 
-    svg[color="#212529"] {
-      color: @text;
+    svg {
+      &[color="#212529"], &[color="#adb5bd"] {
+        color: @text;
+      }
     }
 
     hr {
@@ -633,6 +635,19 @@
       &__boldUnfocusedLabel {
         color: @text;
       }
+
+      &__darkGray {
+        background-color: @surface2;
+      }
+
+      &__withLeftContent {
+        border-color: @accent;
+      }
+      &__iconButton {
+        svg[color="#6c757d"] {
+          color: @subtext1;
+        }
+      }
     }
     .InputButton__button,
     .InputButton__button:focus:not([data-focus-visible-added]):not(
@@ -724,6 +739,11 @@
       }
       &__focusedDate {
         color: @accent;
+      }
+
+      &Input__withBorder {
+        border-color: transparent;
+        background-color: transparent;
       }
     }
 
@@ -1746,6 +1766,9 @@
         }
       }
     }
+    .SectionItemControls__control {
+      color: @accent;
+    }
 
     // Notes text box
     .SectionComponent__box {
@@ -1754,6 +1777,77 @@
     .SectionComponent__textOnly .ql-editor {
       li::before {
         color: @accent;
+      }
+    }
+
+    // Reservations
+    .ReservationItemView {
+      &__contents .fa-arrow-right {
+        color: @accent;
+      }
+      &__grayBackground {
+        background-color: @surface0;
+      }
+
+      &__verticalLine {
+        border-left-color: @accent;
+      }
+
+      // Reservation notes
+      &__quill {
+        color: @text;
+      }
+      &__smallCaps {
+        color: @subtext1;
+      }
+    }
+    .ReservationItemEdit {
+      background-color: @surface0;
+
+      &__inputLabel {
+        color: @subtext1;
+      }
+      &__input, &__input:focus {
+        background-color: @surface1;
+        color: @text;
+      }
+
+      &__verticalLine {
+        border-left-color: @accent;
+      }
+
+      // Reservation notes
+      &__quill {
+        background-color: @surface1;
+        &, & .ql-editor {
+          color: @text;
+        }
+      }
+    }
+    // Flights
+    .FlightsSectionItemView {
+      &__city, &__smallCaps {
+        color: @subtext0;
+      }
+    }
+    .FlightsSectionItemEdit {
+      &__inputLabel {
+        color: @subtext1;
+      }
+      &__input, &__input:focus {
+        background-color: @surface1;
+        color: @text;
+      }
+    }
+    .FlightAutosuggest__input button {
+      // Flight number
+      color: @text;
+    }
+    .FlightStopRow {
+      &__date,
+      &__timeInput {
+        background-color: @surface1;
+        color: @text;
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -287,6 +287,12 @@
       &:not(.Button__disabled):active .Button__icon {
         color: var(--accent-darker);
       }
+
+      &.Button__disabled,
+      &.Button__disabled .Button__icon,
+      &.Button__disabled:hover {
+        color: fade(@accent, 60%);
+      }
     }
     .Button__brand,
     .Button__brand .Button__icon,

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -195,9 +195,23 @@
       }
 
       &:not(.Button__disabled):hover,
-      &:not(.Button__disabled):active {
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled):focus,
+      &:not(.Button__disabled).Button__focused {
         background-color: var(--accent-darker);
         border-color: var(--accent-darker);
+        color: @base;
+      }
+
+      &.Button__disabled {
+        background-color: fade(@accent, 40%);
+        border-color: fade(@accent, 40%);
+        color: @subtext0 !important;
+      }
+      &.Button__disabled,
+      &.Button__disabled .Button__icon,
+      &.Button__disabled:hover {
+        color: @subtext0;
       }
     }
     .brand-button {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1828,7 +1828,7 @@
       // Reservation notes
       &__quill {
         background-color: @surface1;
-        &, & .ql-editor {
+        &, .ql-editor {
           color: @text;
         }
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -495,6 +495,9 @@
         color: @base;
       }
     }
+    .ProBadgeCircular {
+      border-color: @text;
+    }
 
     // Bubbles
     .UserBubblesList__bubble {
@@ -541,6 +544,14 @@
     // Tooltips
     .tooltip.show {
       opacity: 1;
+    }
+    .tooltip-inner {
+      background-color: @mantle;
+      color: @text;
+    }
+    .bs-tooltip-auto[x-placement^="top"] .arrow::before,
+    .bs-tooltip-top .arrow::before {
+      border-top-color: @mantle;
     }
     .ChildrenTargetedTooltip__tooltipInner__error {
       background-color: @red;
@@ -1466,6 +1477,49 @@
     // General weather stats
     .StatIcon svg {
       color: @accent;
+    }
+
+    /* Trip planner */
+
+    // Card when there are no places in the planner
+    .PlanMapNoPlacesCard {
+      background-color: fade(@base, 95%);
+
+      svg[data-icon="location-dot"] {
+        color: @accent;
+      }
+
+      .btn {
+        background-color: @accent !important;
+        color: @base !important;
+
+        &:hover, &:active {
+          background-color: var(--accent-darker) !important;
+        }
+      }
+    }
+
+    .PlanPageHeader {
+      &__header {
+        background-color: @surface0;
+      }
+
+      &__title {
+        color: @text;
+      }
+
+      svg[data-icon="user-plus"] {
+        color: @text;
+      }
+
+      .ProBadgeCircular svg[color="#ffffff"] {
+        color: @surface0;
+      }
+    }
+
+    .HoverTextInput__editableContainer:hover .HoverTextInput__dummyInput,
+    .HoverTextInput__input:focus + .HoverTextInput__dummyInput {
+      background-color: @surface1;
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1567,6 +1567,37 @@
 
     /* Trip planner */
 
+    // Top bar item view button fix
+    .HorizontalCollapse .Button__default-dark {
+      background-color: @surface2;
+      border-color: @accent;
+
+      .Button__icon {
+        background-color: @surface2;
+        color: @text;
+      }
+
+      &:hover {
+        background-color: var(--accent-darker);
+
+        .Button__icon {
+          color: @base;
+        }
+      }
+
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):active {
+        background-color: @accent;
+        border-color: @accent;
+        color: @base;
+
+        .Button__icon {
+          background-color: @accent;
+          color: @base;
+        }
+      }
+    }
+
     // Card when there are no places in the planner
     .PlanMapNoPlacesCard {
       background-color: fade(@base, 95%);

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -76,6 +76,9 @@
     .text-muted {
       color: @subtext1 !important;
     }
+    .text-danger {
+      color: @red !important;
+    }
 
     // Backgrounds
     .bg-white {
@@ -183,6 +186,17 @@
       color: @text;
       background-color: @surface0;
     }
+    .InputContainer {
+      &__labelContainer {
+        color: @subtext1;
+      }
+      &__labelFocused {
+        color: @text;
+      }
+    }
+    .InputButton__button {
+      border-color: @accent;
+    }
 
     // Dropdowns
     .DropdownMenu {
@@ -247,6 +261,11 @@
     #hero-section-video-mobile,
     #hero-section-video-web {
       border-color: @accent;
+    }
+
+    // Download app popup
+    .AppDownloadPopoverInner__verticalLine {
+      border-left-color: @accent;
     }
 
     // Reviews section

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -2681,5 +2681,10 @@
         color: darken(@blue, 5%) !important;
       }
     }
+
+    // Arrangement and color modal
+    .RearrangeSectionRow__section {
+      background-color: @surface0;
+    }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -184,7 +184,7 @@
     }
     .form-control {
       color: @text;
-      background-color: @surface0;
+      background-color: @surface1;
     }
     .InputContainer {
       &__labelContainer {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -303,8 +303,7 @@
       &:not(.Button__disabled):active .Button__icon,
       &:not(.Button__disabled).Button__focused,
       &:not(.Button__disabled):active,
-      &:not(.Button__disabled).Button__focused .Button__icon,
-      &:not(.Button__disabled):active .Button__icon {
+      &:not(.Button__disabled).Button__focused .Button__icon {
         color: var(--accent-darker);
       }
 
@@ -314,8 +313,6 @@
         color: fade(@accent, 60%);
       }
     }
-    .Button__brand,
-    .Button__brand .Button__icon,
     .Button__brand:hover,
     .Button__brand:not(.Button__disabled):hover .Button__icon {
       color: @base;
@@ -551,7 +548,7 @@
         border-color: var(--accent-darker);
         color: @base;
 
-        & .Button__icon {
+        .Button__icon {
           color: @base;
         }
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -249,7 +249,7 @@
       background-color: @surface1;
       border-color: @surface1;
 
-      &, & .Button__icon, &:hover {
+      &, .Button__icon, &:hover {
         color: @subtext1;
       }
 
@@ -258,7 +258,7 @@
         border-color: @surface2;
         color: @text;
 
-        & .Button__icon {
+        .Button__icon {
           color: @text;
         }
       }
@@ -266,7 +266,7 @@
       &.Button__disabled {
         background-color: @surface0;
 
-        &, & .Button__icon, &:hover {
+        &, .Button__icon, &:hover {
           color: @subtext0 !important;
         }
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -104,11 +104,17 @@
     .text-muted {
       color: @subtext1 !important;
     }
+    .text-success {
+      color: var(--success) !important;
+    }
     .text-danger {
       color: @red !important;
     }
     .text-secondary {
       color: @subtext0 !important;
+    }
+    .text-dark {
+      color: @text !important;
     }
     .link-unstyled,
     .link-unstyled:active,
@@ -125,6 +131,9 @@
     }
     .bg-gray-100 {
       background-color: @mantle;
+    }
+    .bg-yellow-lightest {
+      background-color: @surface1;
     }
     .bg-light {
       background-color: @surface0 !important;
@@ -285,6 +294,14 @@
         }
       }
     }
+    .Button__default-dark,
+    .Button__default-dark .Button__icon {
+      background-color: @accent;
+
+      &:hover, &:active, &:not(.Button__disabled):hover .Button__icon {
+        background-color: var(--accent-darker);
+      }
+    }
     .Button__flat-white,
     .Button__flat-white .Button__icon {
       color: @text;
@@ -387,20 +404,22 @@
         }
       }
     }
-    .Button__transparent-black-outline {
+    .Button__transparent-black-outline, .Button__light-brand {
+      background-color: transparent !important;
       border-color: @accent;
 
       &, .Button__icon {
         color: @text;
       }
       &:hover, &:active {
-        color: @subtext1;
+        color: @subtext0;
       }
 
       &:not(.Button__disabled):hover,
       &:not(.Button__disabled):active,
       &:not(.Button__disabled).Button__focused {
         border-color: var(--accent-darker);
+        color: @subtext0;
       }
     }
 
@@ -446,6 +465,14 @@
       &__gray200 {
         background-color: @surface1;
         color: @text;
+      }
+      &__whiteOnGreen {
+        background-color: @green;
+        color: @base;
+      }
+      &__whiteOnYellow {
+        background-color: @yellow;
+        color: @base;
       }
     }
 
@@ -501,6 +528,10 @@
     .IconLabelCounterRow__counter {
       border-color: @accent;
     }
+    .TextArea__label {
+      color: @text;
+    }
+
     // Date inputs
     .InputDateRangePicker {
       &__date {
@@ -588,6 +619,10 @@
           background-color: @surface1;
         }
       }
+
+      &-header {
+        color: @accent;
+      }
     }
     .StyledDropdownMenu {
       &__toggle:focus {
@@ -636,6 +671,58 @@
       }
     }
 
+    // Styled radio buttons
+    .StyledRadio {
+      &__circle {
+        border-color: @accent;
+      }
+    }
+    .FormButton {
+      &:active .FormButton__icon,
+      &:active .FormButton__label,
+      &:hover .FormButton__icon,
+      &:hover .FormButton__label {
+        color: @subtext1;
+      }
+
+      &:active .FormButton__sublabel, &:hover .FormButton__sublabel {
+        color: @subtext0;
+      }
+
+      &__label {
+        color: @text;
+      }
+
+      &__sublabel {
+        color: @subtext0;
+      }
+    }
+
+    // Checkboxes
+    .Checkbox {
+      &__box {
+        background: @text;
+        border-color: @surface1;
+      }
+
+      &__checked {
+        .Checkbox__box {
+          background-color: @accent;
+          color: @base;
+        }
+        .Checkbox__edit:active + .Checkbox__box,
+        .Checkbox__edit:hover + .Checkbox__box {
+          background-color: var(--accent-darker);
+        }
+      }
+    }
+    .Checkbox__edit:active + .Checkbox__box,
+    .Checkbox__edit:focus + .Checkbox__box,
+    .Checkbox__edit:hover + .Checkbox__box {
+      background-color: fade(@accent, 60%);
+      color: @base;
+    }
+
     // Toggle switches
     .react-switch-bg {
       background-color: @surface0 !important;
@@ -651,6 +738,26 @@
     // Share menu
     .LinkSharing {
       border-color: @accent;
+    }
+
+    // Pro modal
+    .ProPromotionsCarousel__slide {
+      svg[data-icon="star"] {
+        color: @yellow;
+      }
+
+      .Button__translucent-white {
+        background-color: @accent;
+      }
+    }
+    .SubscribeButton {
+      &__selected {
+        background-color: fade(@accent, 10%);
+        border-color: @accent;
+      }
+      &__radioCircleSelected {
+        border-color: @accent;
+      }
     }
 
     // Footer
@@ -824,7 +931,7 @@
     }
 
     // Travel guides section
-    .travel-guides-section {
+    .tra vel-guides-section {
       background-color: @base;
     }
     .avatar-name-views-likes-icon {
@@ -1036,6 +1143,41 @@
       .Badge__light {
         background-color: @surface0;
         color: @subtext1;
+      }
+    }
+
+    /* Settings page */
+    // Account
+    .EditUserDetailsInner__separator {
+      border-bottom-color: @accent;
+    }
+
+    // Pro membership
+    .SubscriptionStatusBox {
+      background-color: @surface0;
+    }
+
+    // User preferences
+    svg[data-icon="globe"][color="#6c757d"] {
+      color: @text !important;
+    }
+    div[style='font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; background-color: rgba(33, 37, 41, 0.8); pointer-events: all; display: flex; align-items: center; margin: 20px auto 0px; width: 100%; box-shadow: rgba(0, 0, 0, 0.2) 0px 4px 24px; max-width: 600px; min-width: 284px; min-height: 64px; color: white; font-size: 16px; border-radius: 8px; opacity: 1; transition: opacity 0.2s ease-in-out;'] {
+      background-color: @accent !important;
+      color: @base !important;
+
+      button {
+        color: @base !important;
+      }
+    }
+
+    //Side tabs
+    .Tabs__tab {
+      .active {
+        border-bottom-color: @accent !important;
+        color: @accent !important;
+      }
+      .nav-link {
+        color: @text;
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1520,6 +1520,7 @@
       }
     }
 
+    // Editable text titles and subtitles
     .HoverTextInput__editableContainer:hover .HoverTextInput__dummyInput,
     .HoverTextInput__input:focus + .HoverTextInput__dummyInput {
       background-color: @surface1;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -72,6 +72,11 @@
       color: @blue;
     }
 
+    // Wanderlog animated loading logo
+    .Loading__logo {
+      filter: @accent-filter;
+    }
+
     // Text
     .text-muted {
       color: @subtext1 !important;
@@ -114,6 +119,11 @@
     }
     .Logo__logoMd {
       filter: @accent-filter;
+    }
+
+    // Fake progress bar between SPA pages
+    .FakeTopProgressBar {
+      background-color: @accent;
     }
 
     // Buttons

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -536,6 +536,26 @@
         border-color: @accent;
       }
     }
+    .Button__indigo {
+      background-color: @accent;
+      border-color: @accent;
+
+      &, .Button__icon, &:hover {
+        color: @base;
+      }
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled).Button__focused,
+      &:not(.Button__disabled):active {
+        background-color: var(--accent-darker);
+        border-color: var(--accent-darker);
+        color: @base;
+
+        & .Button__icon {
+          color: @base;
+        }
+      }
+    }
 
     // Badges
     .Badge__light,
@@ -595,6 +615,10 @@
         background-color: @mantle;
         color: @text;
       }
+      &__gray100DarkForeground {
+        background-color: @surface2;
+        color: @text;
+      }
       &__gray200 {
         background-color: @surface1;
         color: @text;
@@ -649,15 +673,28 @@
     .bs-tooltip-bottom .arrow::before {
       border-bottom-color: @crust;
     }
-    .ChildrenTargetedTooltip__tooltipInner__error {
-      background-color: @red;
-      color: @base;
-
-      .Button__icon {
-        color: @surface0;
-      }
-      .Button:hover .Button__icon, .Button:active .Button__icon {
+    .ChildrenTargetedTooltip__tooltipInner {
+      &__error {
+        background-color: @red;
         color: @base;
+
+        .Button__icon {
+          color: @surface0;
+        }
+        .Button:hover .Button__icon, .Button:active .Button__icon {
+          color: @base;
+        }
+      }
+
+      &__primary {
+        background-color: @accent;
+        color: @base;
+
+        .Button__flat-white,
+        .Button__flat-white .Button__icon,
+        .Button__flat-white:hover {
+          color: @base;
+        }
       }
     }
     .bs-tooltip-auto[x-placement^="bottom"]
@@ -670,6 +707,16 @@
       .ChildrenTargetedTooltip__arrow__error::before,
     .bs-tooltip-top .ChildrenTargetedTooltip__arrow__error::before {
       border-top-color: @red !important;
+    }
+    .bs-tooltip-auto[x-placement^="bottom"]
+      .ChildrenTargetedTooltip__arrow__primary::before,
+    .bs-tooltip-bottom .ChildrenTargetedTooltip__arrow__primary::before {
+      border-bottom-color: @accent !important;
+    }
+    .bs-tooltip-auto[x-placement^="top"]
+      .ChildrenTargetedTooltip__arrow__primary::before,
+    .bs-tooltip-top .ChildrenTargetedTooltip__arrow__primary::before {
+      border-top-color: @accent !important;
     }
 
     // Inputs
@@ -806,6 +853,14 @@
         background-color: transparent;
       }
     }
+    .StartEndTimePickerInner {
+      &__input, &__input:focus {
+        background-color: @surface1 !important;
+      }
+      &__dash {
+        background-color: @accent;
+      }
+    }
 
     // Dropdowns
     .DropdownMenu {
@@ -856,6 +911,14 @@
     }
     .Select {
       border-color: @accent;
+
+      &__option {
+        background-color: @surface0;
+
+        &:checked {
+          background-color: @surface1;
+        }
+      }
     }
     // When autocomplete location dropdown don't get a good match
     .LowMatchStaticGeoAutosuggestSuggestion__suggestion {
@@ -1759,16 +1822,19 @@
       }
     }
 
+    // Spacers
     .PlanBoard__spacer {
       background-color: @mantle;
+    }
+    .InsertSectionSpacer {
+      &__dividerInner {
+        border-top-color: @accent;
+      }
     }
 
     // Explore section
     .PlanInspirationsInner__title {
       color: @text;
-    }
-    .InsertSectionSpacer__dividerInner {
-      border-top-color: @subtext0;
     }
 
     // Add reservations and budget snapshot section
@@ -1840,6 +1906,11 @@
       }
     }
     .SectionItemControls {
+      &__mainItem > .form-control-gray {
+        // Note items
+        background-color: @surface0;
+      }
+
       &__control {
         color: @accent;
 
@@ -2008,6 +2079,87 @@
     .BoardBlockSeparator__horizontalLine {
       // Cruise itinerary separator
       border-top-color: @text;
+    }
+
+    // List items
+    .ChecklistSectionItem__container {
+      background-color: @surface0;
+
+      .text-muted {
+        color: @subtext0 !important;
+      }
+    }
+    .ChecklistItemRow {
+      &__input,
+      &__input:focus {
+        background-color: transparent;
+      }
+
+      &__controls {
+        color: @subtext0;
+      }
+    }
+    .PictureViewItem {
+      // When items are in picture view
+      &__leftContainer,
+      &__text {
+        background-color: @surface0;
+      }
+
+      &__descriptionInfoIcon svg {
+        color: @accent;
+      }
+    }
+    .ListViewItem {
+      background-color: @surface0;
+
+      &__placeButton:focus, &__placeButton:hover {
+        color: @subtext0 !important;
+      }
+    }
+    .MapsPlaceRecommendation {
+      // Recommended places under list items
+
+      &Carousel__small-subtitle {
+        color: @subtext1;
+      }
+
+      &Card__container {
+        border-color: @accent;
+      }
+
+      &Card__loadingIcon {
+        background-color: fade(@overlay0, 80%);
+
+        svg {
+          color: @text;
+        }
+      }
+    }
+    .BlockDividerContainer .BlockDividerDefault {
+      // Space between list items
+
+      &__placeSectionItemBottom {
+        // "Added by ..." text in the bottom right
+        background-color: @base;
+      }
+
+      &__horizontalLine {
+        .DashedLine line {
+          stroke: @text !important;
+        }
+      }
+      &__addBlockButton {
+        background-color: @base;
+        color: @accent;
+      }
+      &__addBlockIcon {
+        color: @accent;
+      }
+    }
+    .NoteSectionItem__noteIcon {
+      background-color: @accent;
+      color: @base;
     }
 
     // Budgeting section

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -2508,7 +2508,6 @@
         }
       }
     }
-
     .PlaceMapCardsPaginationButton__container {
       // When there are multiple place map cards (e.g. when searching on map and multiple results show up)
 

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -674,7 +674,8 @@
       color: @text;
     }
     .DateRangePickerInput__withBorder {
-      border-color: @accent;
+      border-color: transparent;
+      background-color: transparent;
     }
 
     // Dropdowns

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -94,6 +94,9 @@
     .text-brand {
       color: @accent;
     }
+    .text-primary {
+      color: @accent !important;
+    }
     a.text-brand:active, a.text-brand:focus, a.text-brand:hover {
       color: var(--accent-darker);
     }
@@ -144,6 +147,12 @@
     }
     .bg-light {
       background-color: @surface0 !important;
+    }
+    .bg-primary {
+      background-color: @accent !important;
+    }
+    .bg-success {
+      background-color: var(--success) !important;
     }
 
     // Navbar
@@ -468,6 +477,17 @@
       &:not(.Button__disabled).Button__focused {
         border-color: var(--accent-darker);
         color: var(--accent-darker);
+      }
+    }
+    .close {
+      color: @text;
+      text-shadow: none;
+      opacity: 1;
+
+      &:not(:disabled):not(.disabled):focus,
+      &:not(:disabled):not(.disabled):hover {
+        color: @subtext0;
+        opacity: 1;
       }
     }
 
@@ -966,6 +986,13 @@
           fill: @accent;
         }
       }
+    }
+
+    // Alerts
+    .alert-warning {
+      background-color: var(--warning);
+      border-color: var(--warning);
+      color: @base;
     }
 
     // Footer
@@ -1524,6 +1551,60 @@
     .HoverTextInput__editableContainer:hover .HoverTextInput__dummyInput,
     .HoverTextInput__input:focus + .HoverTextInput__dummyInput {
       background-color: @surface1;
+    }
+
+    // Select planner header background image
+    .ImageSelectCard {
+      &__button {
+        // Select image button
+        .Button__primary {
+          background-color: @accent;
+          color: @base;
+
+          &:not(.Button__disabled):hover,
+          &:not(.Button__disabled):active,
+          &:not(.Button__disabled):focus,
+          &:not(.Button__disabled).Button__focused {
+            background-color: var(--accent-darker);
+            border-color: var(--accent-darker);
+            color: @base;
+          }
+        }
+      }
+
+      &__externalLink {
+        background: radial-gradient(
+          circle 24px,
+          fade(@base, 100%),
+          transparent
+        );
+        color: @text;
+
+        &:hover, &:active {
+          color: @subtext0;
+        }
+      }
+    }
+    .ImageButton {
+      &__button {
+        background-color: @surface0;
+      }
+      &__selected, &__selected:focus {
+        box-shadow: 0 0 0 4px @accent;
+      }
+    }
+    .ImageUploadingCard {
+      &__card {
+        background-color: @surface0;
+      }
+
+      &__progressBar {
+        background-color: @base;
+      }
+
+      &__message {
+        color: @text;
+      }
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -2991,6 +2991,22 @@
       }
     }
 
+    // Zoom into location and center map button
+    .MapGLMapWithMarkers__fitButtons .Button__translucent-black {
+      // NOTE: As these buttons use .Button__translucent-black which has its background set to transparent, we need to add a background back
+      background-color: fade(@base, 90%);
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused {
+        background-color: @base;
+        border-color: transparent;
+        .Button__icon {
+          color: @text;
+        }
+      }
+    }
+
     // Photo gallery
     .lg-counter {
       color: @subtext0;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -2322,7 +2322,7 @@
 
     // Planner tip
     .TipToast__container {
-      background-color: fade(@base, 90%);
+      background-color: fade(@base, 95%);
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -287,7 +287,9 @@
         &:not(.Button__disabled):hover,
         &:not(.Button__disabled):hover .Button__icon,
         &:not(.Button__disabled):active,
-        &:not(.Button__disabled):active .Button__icon {
+        &:not(.Button__disabled):active .Button__icon,
+        &:not(.Button__disabled).Button__focused,
+        &:not(.Button__disabled).Button__focused .Button__icon {
           color: @subtext1;
         }
       }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -2521,5 +2521,32 @@
         background-color: @base;
       }
     }
+
+    // Map layers toggle menu
+    .MapLayers {
+      &Overlay {
+        background-color: @surface0;
+      }
+
+      &List__separator {
+        color: @text;
+      }
+
+      &List__horizontalLine {
+        color: @accent;
+      }
+
+      &ListRow:active, &ListRow:focus, &ListRow:hover {
+        color: @subtext0;
+      }
+
+      &Button__indicatorContainer {
+        background-color: @accent;
+      }
+
+      &Button__indicator {
+        color: @base;
+      }
+    }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -559,7 +559,7 @@
         background-color: @yellow;
       }
 
-      & .Badge__closeButtonIcon {
+      .Badge__closeButtonIcon {
         background-color: transparent;
       }
     }
@@ -574,7 +574,7 @@
     .ProBadgeCircular {
       border-color: @text;
 
-      & svg[color="#ffffff"] {
+      svg[color="#ffffff"] {
         color: @surface0;
       }
     }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -741,6 +741,10 @@
         background-color: @text;
         color: @surface1;
       }
+      &__gray500 {
+        background-color: @text;
+        color: @surface2;
+      }
       &__blueBase {
         background-color: @blue;
         color: @base;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -538,7 +538,7 @@
       border-color: @accent;
     }
     .EditorBubble__container {
-      background-color: @accent;
+      background-color: @text;
     }
     .TextBubble__colorTheme {
       &__white {
@@ -548,6 +548,10 @@
       &__gray200 {
         background-color: @surface1;
         color: @text;
+      }
+      &__gray300 {
+        background-color: @text;
+        color: @surface1;
       }
       &__whiteOnGreen {
         background-color: @green;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -63,7 +63,8 @@
     --accent-darker: darken(@accent, 5%);
 
     /* General */
-    body {
+    body:has(#react-main), .body {
+      // HACK: Use the #react-main child to ensure the chatbot iframe doesn't get styled
       background-color: @base;
       color: @text;
     }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -330,6 +330,13 @@
         &:not(.Button__disabled).Button__focused .Button__icon {
           color: @subtext1;
         }
+
+        &.Button__disabled,
+        &.Button__disabled .Button__icon,
+        &.Button__disabled:hover,
+        &.Button__disabled:hover .Button__icon {
+          color: @overlay1;
+        }
       }
     }
     .Button__default, .Button__primary {
@@ -490,6 +497,9 @@
         .Button__icon {
           color: @text;
         }
+      }
+      &.Button__shadow {
+        border-color: transparent;
       }
     }
     .Button__transparent-black-outline, .Button__light-brand {
@@ -2415,6 +2425,100 @@
 
       &__divider {
         background-color: @accent;
+      }
+    }
+
+    // Map buttons
+    .PlanMapWebMap {
+      &__topLeftBtns,
+      &__topMiddleBtns,
+      &__topRightBtns,
+      &__exitBtn,
+      &__exportBtn {
+        // NOTE: As these buttons use .Button__translucent-black which has its background set to transparent, we need to add a background back
+        .Button__translucent-black {
+          background-color: fade(@base, 90%);
+
+          &:not(.Button__disabled):hover,
+          &:not(.Button__disabled):active,
+          &:not(.Button__disabled).Button__focused {
+            background-color: @base;
+            border-color: transparent;
+            .Button__icon {
+              color: @text;
+            }
+          }
+        }
+      }
+    }
+    .GoogleMapWithMarkers__zoomButtons .Button__translucent-black,
+    #placeCardDismissButton {
+      // "Fit map to" button and place card overlay close button
+
+      // NOTE: As these buttons use .Button__translucent-black which has its background set to transparent, we need to add a background back
+      background-color: fade(@base, 90%);
+
+      &:not(.Button__disabled):hover,
+      &:not(.Button__disabled):active,
+      &:not(.Button__disabled).Button__focused {
+        background-color: @base;
+        border-color: transparent;
+        .Button__icon {
+          color: @text;
+        }
+      }
+    }
+    .GoogleMapGeolocationButton__button {
+      color: @subtext1;
+
+      &:hover {
+        color: @text;
+      }
+    }
+    .gm-bundled-control {
+      // Google map zoom button group
+      > .gmnoprint > div {
+        // Zoom button group background
+        background-color: @base !important;
+      }
+      .gm-control-active {
+        // Zoom buttons
+        background-color: @base !important;
+
+        > img {
+          &:nth-child(1) {
+            // Default zoom button symbol
+            filter: @text-filter;
+          }
+
+          &:nth-child(2), &:nth-child(3) {
+            // On hover and on active
+            filter: @subtext0-filter;
+          }
+
+          &:nth-child(4) {
+            // When disabled (e.g. fully zoomed out)
+            filter: @surface2-filter;
+          }
+        }
+
+        + div {
+          // Zoom button divider line
+          background-color: @surface1 !important;
+        }
+      }
+    }
+
+    .PlaceMapCardsPaginationButton__container {
+      // When there are multiple place map cards (e.g. when searching on map and multiple results show up)
+
+      background-color: fade(@base, 90%);
+      color: @text;
+
+      &:hover,
+      &.Button__focused,
+      &:active {
+        background-color: @base;
       }
     }
   }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -542,7 +542,6 @@
       &:not(.Button__disabled):active,
       &:not(.Button__disabled).Button__focused,
       &:not(.Button__disabled):hover .Button__icon,
-      &:not(.Button__disabled):active,
       &:not(.Button__disabled):active .Button__icon {
         border-color: var(--accent-darker);
         color: @subtext0;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -1599,6 +1599,9 @@
     .HoverTextInput__input:focus + .HoverTextInput__dummyInput {
       background-color: @surface1;
     }
+    svg.HoverTextInput__edit {
+      color: @subtext1 !important;
+    }
 
     // Select planner header background image
     .ImageSelectCard {
@@ -1729,6 +1732,19 @@
     }
     .ForwardEmailInner__noEmails {
       color: @subtext0;
+    }
+
+    // Common section components
+    .SectionComponentHeader {
+      color: @text;
+
+      &__subheading {
+        color: @subtext1;
+
+        &Container::after {
+          background-color: @base;
+        }
+      }
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -605,6 +605,9 @@
         // Facebook logo
         color: @blue;
       }
+      svg[color="#e23e57"] {
+        color: @red;
+      }
     }
 
     .Button__indigo, .Button__purple {
@@ -2082,6 +2085,9 @@
       &__dividerInner {
         border-top-color: @accent;
       }
+      &__textDivider {
+        color: @accent;
+      }
     }
 
     // Explore section
@@ -3051,6 +3057,55 @@
 
     .RelatedGuidesSection__relatedGuidesContainer {
       background-color: @mantle;
+    }
+
+    // Additional writing guide theming
+    .SectionComponentHeader__menuToggle {
+      background-color: @base;
+    }
+    .GuideDayPlanHeader {
+      &__dayButton, &__dayContainer {
+        color: @text;
+      }
+
+      &__buttonContainer:hover {
+        background-color: @surface0;
+      }
+
+      &__dayInput {
+        color: @text;
+      }
+    }
+    .PlanViewPageContainerPad .Button__default {
+      background-color: @base;
+    }
+    .RatingsOption {
+      // Rate guide items as "must go", "hidden gem", and "skip it"
+
+      background-color: @surface0;
+
+      // The options
+      &, &__text {
+        &[style="color: rgb(173, 181, 189);"] {
+          // Unselected
+          color: @subtext1 !important;
+        }
+
+        &[style="color: rgb(222, 112, 60);"] {
+          // Must go
+          color: @peach !important;
+        }
+
+        &[style="color: rgb(56, 164, 166);"] {
+          // Hidden gem
+          color: @blue !important;
+        }
+
+        &[style="color: rgb(226, 62, 87);"] {
+          // Skip it
+          color: @red !important;
+        }
+      }
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -234,6 +234,25 @@
         color: @subtext1;
       }
     }
+    .Button__icon-lightest-gray {
+      background-color: @surface0;
+      border-color: @surface0;
+
+      &,
+      .Button__icon,
+      &:hover {
+        color: @text;
+      }
+
+      &:not(.Button__disabled):hover, &:not(.Button__disabled):active {
+        background-color: @surface1;
+        border-color: @surface1;
+
+        .Button__icon {
+          color: @text;
+        }
+      }
+    }
     .Button__dark {
       background-color: @text;
       border-color: @text;

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -2299,7 +2299,7 @@
       background-color: @surface0;
 
       &__placeButton:focus, &__placeButton:hover {
-        color: @subtext0 !important;
+        color: @subtext1 !important;
       }
     }
     .MapsPlaceRecommendation {

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -634,7 +634,10 @@
         color: @text;
       }
     }
-    .InputButton__button {
+    .InputButton__button,
+    .InputButton__button:focus:not([data-focus-visible-added]):not(
+      .InputButton__focused
+    ) {
       border-color: @accent;
     }
     .IconLabelCounterRow__counter {
@@ -715,6 +718,14 @@
       border-color: transparent;
       background-color: transparent;
     }
+    .SingleDatePicker {
+      &__icon {
+        color: @text;
+      }
+      &__focusedDate {
+        color: @accent;
+      }
+    }
 
     // Dropdowns
     .DropdownMenu {
@@ -759,6 +770,12 @@
       &__suggestion--highlighted {
         background-color: @surface1;
       }
+    }
+    .GooglePlaceSuggestion__inner {
+      color: @text;
+    }
+    .Select {
+      border-color: @accent;
     }
     // When autocomplete location dropdown don't get a good match
     .LowMatchStaticGeoAutosuggestSuggestion__suggestion {
@@ -1656,6 +1673,62 @@
     }
     .InsertSectionSpacer__dividerInner {
       border-top-color: @subtext0;
+    }
+
+    // Add reservations and budget snapshot section
+    .AddReservationButtons {
+      // Section with the different icons
+      background-color: @surface0;
+      &__separator {
+        background-color: @accent;
+        color: @accent;
+      }
+    }
+    .AddReservationDropdownItem__count {
+      background-color: @accent;
+      color: @base;
+    }
+    .BudgetSnapshot {
+      // Budget snapshot on right
+      background-color: @surface0;
+      .text-secondary {
+        color: @accent !important;
+      }
+
+      .Button__labelText {
+        color: @subtext1;
+      }
+    }
+    .IconAndTextButton {
+      // Icon and text in add reservations section
+      &__text {
+        color: @subtext1;
+      }
+
+      &__count {
+        background-color: @accent;
+        color: @base;
+      }
+
+      &__proBadge .ProBadgeCircular__icon {
+        color: @base !important;
+      }
+    }
+    // Add already booked reservations
+    .ImportEmailsModalInner {
+      &__or {
+        color: @text;
+      }
+
+      &__yellowBackgroundWide {
+        background-color: fade(@yellow, 30%);
+      }
+    }
+    .CopyEmailButton {
+      border-color: @accent;
+    }
+    .ForwardEmailInner__noEmails {
+      color: @subtext0;
     }
   }
 }

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -60,7 +60,53 @@
     --gray--900: @text;
     --gray--900-2: @text;
 
-    --accent-darker: darken(@accent, 5%);
+    --accent-darker: mix(@accent, @base, 90%);
+    @accent-darker: mix(@accent, @base, 90%);
+
+    @hover: 8%;
+    @active: -10%;
+
+    --accent-hover: lighten(@accent, @hover);
+    --accent-active: lighten(@accent, @active);
+
+    // Mixins
+
+    // Stroke refers to border; stroke shortforms better :>
+    // Background | Foreground | Stroke
+    // Hover Background | Hover Foreground | Hover Stroke
+    // Active Background | Active Foreground | Active Stroke
+    // Disabled Background | Disabled Foreground | Disabled Stroke
+    .ctp-stateful(@bg: null; @fg: null; @st: null; @hbg: null; @hfg: null; @hst: null; @abg: null; @afg: null; @ast: null; @dbg: null; @dfg: null; @dst: null; @notState: ~"";) {
+      background-color: @bg;
+      color: @fg;
+      border-color: @st;
+      &:not(@{notState}) {
+        &:hover,
+        // messy!!
+        &.Button__focused {
+          & when not (@hbg = null) {
+            background-color: @hbg;
+          }
+          & when not (@hfg = null) {
+            color: @hfg;
+          }
+          & when not (@hst = null) {
+            border-color: @hst;
+          }
+        }
+        &:active {
+          & when not (@abg = null) {
+            background-color: @abg;
+          }
+          & when not (@afg = null) {
+            color: @afg;
+          }
+          & when not (@ast = null) {
+            border-color: @ast;
+          }
+        }
+      }
+    }
 
     /* General */
     body:has(#react-main), .body {
@@ -99,8 +145,11 @@
     .text-primary {
       color: @accent !important;
     }
-    a.text-brand:active, a.text-brand:focus, a.text-brand:hover {
-      color: var(--accent-darker);
+    a.text-brand:focus, a.text-brand:hover {
+      color: var(--accent-hover);
+    }
+    a.text-brand:active {
+      color: var(--accent-active);
     }
     .text-white {
       color: @text !important;
@@ -258,114 +307,87 @@
     }
 
     // Buttons
-    .Button__brand, .Button__dark {
-      background-color: @accent;
-      border-color: @accent;
-
-      &, &:hover, &:active, .Button__icon {
-        color: @base;
+    .Button__brand {
+      .ctp-stateful(
+        @bg: @accent;
+        @fg: @base;
+        @st: @accent;
+        @hbg: var(--accent-hover);
+        @hfg: @base;
+        @hst: var(--accent-hover);
+        @abg: var(--accent-active);
+        @afg: @base;
+        @ast: var(--accent-active);
+        @dbg: fade(@accent, 40%);
+        @dfg: @subtext0;
+        @dst: fade(@accent, 40%);
+        @notState: ~'.Button__disabled'
+      );
+      .Button__icon {
+        color: inherit !important;
       }
-
-      &:not(.Button__disabled):hover,
-      &:not(.Button__disabled):active,
-      &:not(.Button__disabled):focus,
-      &:not(.Button__disabled).Button__focused {
-        background-color: var(--accent-darker);
-        border-color: var(--accent-darker);
-        color: @base;
-      }
-
-      &.Button__disabled {
-        background-color: fade(@accent, 40%);
-        border-color: fade(@accent, 40%);
-        color: @subtext0 !important;
-      }
-      &.Button__disabled,
-      &.Button__disabled .Button__icon,
-      &.Button__disabled:hover {
-        color: @subtext0;
-      }
-
-      &:not(.Button__disabled).Button__focused .Button__icon,
-      &:not(.Button__disabled):active .Button__icon,
-      &:not(.Button__disabled):hover .Button__icon {
-        color: @base;
+    }
+    .Button__dark {
+      .ctp-stateful(
+        @bg: @text;
+        @fg: @base;
+        @st: @text;
+        @hbg: lighten(@text, @hover);
+        @hfg: @base;
+        @hst: lighten(@text, @hover);
+        @abg: lighten(@text, @active);
+        @afg: @base;
+        @ast: lighten(@text, @active);
+        @dbg: fade(@text, 40%);
+        @dfg: @subtext0;
+        @dst: fade(@text, 40%);
+        @notState: ~'.Button__disabled'
+      );
+      .Button__icon {
+        color: inherit !important;
       }
     }
     .brand-button {
       color: @base !important;
 
-      &:hover, &:active {
-        background-color: var(--accent-darker);
+      &:hover {
+        background-color: var(--accent-hover);
+      }
+      &:active {
+        background-color: var(--accent-active);
       }
     }
     .btn-primary {
-      background-color: @accent;
-      border-color: @accent;
-      color: @base !important;
+      .Button__brand();
 
-      &.focus,
-      &:focus,
-      &:hover,
-      &:not(:disabled):not(.disabled).active,
-      &:not(:disabled):not(.disabled):active,
       .show > &.dropdown-toggle {
         background-color: var(--accent-darker);
         border-color: var(--accent-darker);
       }
     }
-    .Button__flat,
     .flat-button,
+    .Button__flat,
     .Button__flat-primary,
-    .Button__flat-primary .Button__icon,
-    .Button__flat .Button__icon,
-    .Button__flat:hover,
-    .Button__flat-primary:hover,
-    .Button__flat-brand,
-    .Button__flat-brand .Button__icon,
-    .Button__flat-brand:hover {
-      color: @accent;
-
-      &:hover,
-      &:active,
-      &:not(.Button__disabled):hover .Button__icon,
-      &:not(.Button__disabled):active .Button__icon,
-      &:not(.Button__disabled).Button__focused,
-      &:not(.Button__disabled):active,
-      &:not(.Button__disabled).Button__focused .Button__icon {
-        color: var(--accent-darker);
-      }
-
-      &.Button__disabled,
-      &.Button__disabled .Button__icon,
-      &.Button__disabled:hover {
-        color: fade(@accent, 60%);
-      }
+    .Button__flat-brand {
+      .ctp-stateful(
+        @fg: @accent;
+        @hfg: @accent-darker;
+        @afg: @accent-darker;
+        @dfg: fade(@accent, 60%);
+        @notState: ~'.Button__disabled'
+      );
     }
-    .Button__brand:hover,
-    .Button__brand:not(.Button__disabled):hover .Button__icon {
-      color: @base;
-    }
+
     .Button__flat-secondary, .btn {
-      &, .Button__icon {
-        color: @text;
-
-        &:hover,
-        &:not(.Button__disabled):hover,
-        &:not(.Button__disabled):hover .Button__icon,
-        &:not(.Button__disabled):active,
-        &:not(.Button__disabled):active .Button__icon,
-        &:not(.Button__disabled).Button__focused,
-        &:not(.Button__disabled).Button__focused .Button__icon {
-          color: @subtext1;
-        }
-
-        &.Button__disabled,
-        &.Button__disabled .Button__icon,
-        &.Button__disabled:hover,
-        &.Button__disabled:hover .Button__icon {
-          color: @overlay1;
-        }
+      .ctp-stateful(
+        @fg: @text;
+        @hfg: @subtext1;
+        @afg: @subtext1;
+        @dfg: @overlay1;
+        @notState: ~'.Button__disabled'
+      );
+      .Button__icon {
+        color: inherit !important;
       }
     }
     .Button__default, .Button__primary {
@@ -391,29 +413,43 @@
         border-color: var(--accent-darker);
       }
 
+      .ctp-stateful(
+        @bg: transparent;
+        @fg: @text;
+        @st: @accent;
+        @hfg: @text;
+        @hst: @accent-darker;
+        @afg: @text;
+        @ast: @accent-darker;
+        @dbg: @surface0;
+        @dfg: @subtext0;
+        @dst: @accent-darker;
+        @notState: ~'.Button__disabled'
+      );
+
       .Button__icon {
+        color: inherit !important;
         img {
           filter: @text-filter;
         }
       }
     }
-    .Button__default-dark,
-    .Button__default-dark .Button__icon {
-      background-color: @accent;
-      border-color: @accent;
-
-      &:hover, &:active, &:not(.Button__disabled):hover .Button__icon {
-        background-color: var(--accent-darker);
-        border-color: var(--accent-darker);
-      }
+    .Button__default-dark {
+      .ctp-stateful(
+        @bg: @accent;
+        @fg: @base;
+        @st: @accent;
+        @hbg: @accent-darker;
+        @hst: @accent-darker;
+        @notState: ~'.Button__disabled'
+      );
     }
     .Button__flat-white,
     .Button__flat-white .Button__icon {
-      color: @text;
-
-      &:hover, &:active {
-        color: @subtext1;
-      }
+      .ctp-stateful(
+        @fg: @text;
+        @hfg: @subtext0;
+      );
     }
     .Button__flat-purple,
     .Button__flat-purple .Button__icon,


### PR DESCRIPTION
## 🎉 Theme for [Wanderlog](https://wanderlog.com) 🎉

Wanderlog is a platform for everything travel itinerary related. It helps you plan and organize your trips and there are collaborative features where you can share you travel plans with others and can ideas from published plans.

<!--
You should give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6a3a604a-56eb-40f0-9b75-9921a191a5b0" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/133d36a3-893e-4bfc-9556-7f45c9f44b6c" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/5faf27e6-783d-4a85-bec5-324e66e43f6d" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/61c1574b-9e49-41e8-9269-6a6d8933d44a" />

## 💬 Additional Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

Note that I do not have Wanderlog pro so therefore pro-only features are most likely not themed. Also, due to Wanderlog's dark mode being a pro feature, I don't know how well the theming works when it's enabled, therefore I suggest using this userstyle in Wanderlog's light mode (unless someone tests that it still works). 

Not sure how to theme these images in the hotels page that have backgrounds that are the same as the original background color:
<img width="508" height="679" alt="image" src="https://github.com/user-attachments/assets/7c5bdac7-6b08-41d5-a64a-f22bf10807bf" />

Don't know how to theme the Wanderlog pro payment form as it is an iframe
<img width="483" height="764" alt="image" src="https://github.com/user-attachments/assets/383b3da5-3a9e-444d-9b0b-948038f18f04" />

The location pins and colors seem to be implemented in a lot of different ways in different scenarios. I don't know the nicest way to represent each of the colors and the darker versions of them. The most difficult part is that I can't find a way to theme the pins that are on the maps in the planner and guides. Edit: It seems like those pins are canvas elements which I recall can't be styled through stylus?
<img width="329" height="108" alt="image" src="https://github.com/user-attachments/assets/67bd0e47-8d3a-4e2e-9482-4943351a8c6e" />
<img width="771" height="613" alt="image" src="https://github.com/user-attachments/assets/a54389cb-c134-4111-852e-1834949a8985" />
<img width="62" height="317" alt="image" src="https://github.com/user-attachments/assets/872cc6cd-f3f5-4495-8b03-4ab1cd8afe20" />
<img width="54" height="382" alt="image" src="https://github.com/user-attachments/assets/5e990176-b2e1-474f-8c6a-3fc100ee8fa4" />
<img width="140" height="162" alt="image" src="https://github.com/user-attachments/assets/d1a228b8-7397-485e-b9d7-799090f446fc" />
<img width="426" height="475" alt="image" src="https://github.com/user-attachments/assets/4301b7e6-ccd7-4d9e-b4ff-4dd6f30fa0fe" />

<img width="323" height="289" alt="image" src="https://github.com/user-attachments/assets/6b40288f-3daa-420d-aab6-b09374720d91" />

## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [submission guidelines](https://userstyles.catppuccin.com/contributing/creating-userstyles/).
- [X] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [X] I have ensured that the new directory is in **lower-kebab-case**.
  - [X] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [X] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [X] I have included the following files:
  - [X] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.

My checklist of things to theme (can be ignored):

- [x] Planner page
  - [X] Header change photo modal
  - [x] Three dot menu on top bar pages
  - [X] Editor bubbles
- [x] Travel guides
  - [X] List that is accessed from home page
  - [x] Actual travel guides
  - [x] Explore city guides (i.e. [London guide](https://wanderlog.com/explore/9613/london))
- [X] Hotels page
- [X] Log in and Sign up page
- [X] Plan a new trip page
- [X] Write guide page
- [x] Write a guide editor/planner
- [X] All the pages in the footer
- [X] Weather pages (e.g. https://wanderlog.com/weather/1/12/tokyo-weather-in-december)
- [X] Deals page (after logged in)
- [X] Get Wanderlog pro popup
- [X] Notifications menu
- [x] Profile page
- [X] Settings page
- [X] History page