### PR TITLE
docs: update secondary action to contributing

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -13,6 +13,6 @@ hero:
       icon: right-arrow
     - text: Contribute
       link: /contributing/
-      icon: rocket
+      icon: right-arrow
       variant: secondary
 ---


### PR DESCRIPTION
We should link to our contributing documentation rather than directly to the GitHub I think. Icon shouldn't be external anymore, I'm thinking `rocket` but open to suggestions (https://starlight.astro.build/reference/icons/#all-icons).