### PR TITLE
docs(guides/syntax-highlighting): use prismjs important stylesheet

### DIFF
--- a/docs/src/content/docs/contributing/guides/syntax-highlighting.md
+++ b/docs/src/content/docs/contributing/guides/syntax-highlighting.md
@@ -32,7 +32,7 @@ After including the CSS variables with the mixin specified above, add the follow
 After including the CSS variables with the mixin specified above, add the following line at the top of the userstyle, beneath the `@-moz-document` line.
 
 ```css
-@import url("https://prismjs.catppuccin.com/variables.css");
+@import url("https://prismjs.catppuccin.com/variables.important.css");
 ```
 
 ## Chroma


### PR DESCRIPTION
For consistency with the other URLs which are already suggested with the important variant.