### PR TITLE
chore(alacritty): add icon

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -83,7 +83,7 @@ userstyles:
     link: https://alacritty.org
     categories: [terminal, development]
     icon: alacritty
-    color: red
+    color: peach
     current-maintainers: [*AlwaysNur]
   alternativeto:
     name: AlternativeTo


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
Adds the `alacritty` icon to the `userstyles.yml` file.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
