### PR TITLE
docs(contributing/guides/raw-color-values): standard library links

### DIFF
--- a/docs/src/content/docs/contributing/guides/raw-color-values.md
+++ b/docs/src/content/docs/contributing/guides/raw-color-values.md
@@ -7,8 +7,8 @@ sidebar:
 
 ## Obtaining RGB values
 
-See [`#lib.rgbify()`](/contributing/standard-library/#librgbify).
+See [`#lib.rgbify()`](../standard-library.md/#librgbify).
 
 ## Obtaining HSL values
 
-See [`#lib.hslify()`](/contributing/standard-library/#libhslify).
+See [`#lib.hslify()`](../standard-library.md/#libhslify).


### PR DESCRIPTION
These two links in the contributing guides are currently broken.

<img width="863" height="459" alt="image" src="https://github.com/user-attachments/assets/9560e058-e9b0-4311-a195-2092741d1bf4" />