### PR TITLE
feat(arch-wiki): support chinese version

### DIFF
--- a/styles/arch-wiki/catppuccin.user.less
+++ b/styles/arch-wiki/catppuccin.user.less
@@ -17,7 +17,7 @@
 
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
-@-moz-document domain("wiki.archlinux.org"), domain("wiki.archlinuxcn.org") {
+@-moz-document domain("wiki.archlinux.org"), domain("wiki.archlinuxcn.org"), domain("wiki.archlinux.de") {
   :root.skin-theme-clientpref-os,
   .vector-feature-night-mode-enabled,
   .skin-invert,


### PR DESCRIPTION
(Apologies to Google Translate)
[Arch CN Wiki](https://wiki.archlinuxcn.org) is the Chinese version of Arch Wiki.
It uses the exact same style as Arch Wiki, so the same files can be reused.
I considered it part of Arch Wiki, so I didn't add an entry for it in userstyles.yml.