### PR TITLE
fix(modrinth): use style guide link colours

### DIFF
--- a/styles/modrinth/catppuccin.user.less
+++ b/styles/modrinth/catppuccin.user.less
@@ -55,9 +55,9 @@
       --color-divider: @surface0;
       --color-heading: @text;
       --color-icon: @text;
-      --color-link-active: @teal;
+      --color-link-active: @sapphire;
       --color-link-hover: @sky;
-      --color-link: @sapphire;
+      --color-link: @blue;
       --color-raised-bg: @base;
       --color-blue: @sapphire;
       --color-special-blue: @sapphire;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

Changes the colour of links from sapphire to Blue, and the colour of active links from Teal to Sapphire to more accurately match the Catppuccin Style Guide.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
