### PR TITLE
feat(hoppscotch): less contrast, selection colors, surface elements

### DIFF
--- a/styles/hoppscotch/catppuccin.user.less
+++ b/styles/hoppscotch/catppuccin.user.less
@@ -49,9 +49,9 @@
     --secondary-color: @subtext0;
     --secondary-light-color: @subtext0;
     --secondary-dark-color: @subtext1;
-    --divider-color: fade(@overlay2, 10%);
-    --divider-light-color: fade(@overlay2, 10%);
-    --divider-dark-color: fade(@overlay2, 10%);
+    --divider-color: @surface0;
+    --divider-light-color: @surface0;
+    --divider-dark-color: @surface0;
     --error-color: @red;
     --tooltip-color: @text;
     --popover-color: @crust;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Improve theming for _hoppscotch_.

* reduce contrast for outlines
* improve selection color and text selected color on the editor
* improve the inactive color for the tabs, and dimmed elements

## Before
<img width="1655" height="1016" alt="image" src="https://github.com/user-attachments/assets/9ba254dc-c915-4368-bdc3-79a97026b43e" />


## After
<img width="1655" height="1016" alt="image" src="https://github.com/user-attachments/assets/30283bed-8d33-43d1-81f9-60b36b9db581" />



## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
