### PR TITLE
feat(lib/m3)!: base surface elevation scale

### DIFF
--- a/lib/m3.less
+++ b/lib/m3.less
@@ -69,7 +69,7 @@
     // Elevation scale
     .token(surface-container-lowest, @crust);
     .token(surface-dim, @mantle);
-    .token(surface-container-low, lighten(@base, if(@flavor = latte, -5%, 5%));
+    .token(surface-container-low, lighten(@base, if(@flavor = latte, -5%, 5%)));
     .token-content(surface, @base, @text);
     .token(surface-container, @surface0);
     .token(surface-container-high, @surface1);


### PR DESCRIPTION
Updates the M3 library to use Base as the surface colour, and minorly darkens surface-container-low to compensate.