### PR TITLE
feat(hoppscotch): less contrast, selection colors, surface elements

### DIFF
--- a/styles/hoppscotch/catppuccin.user.less
+++ b/styles/hoppscotch/catppuccin.user.less
@@ -29,27 +29,23 @@
   #catppuccin(@flavor) {
     #lib.palette();
     #lib.defaults();
-    // TODO: Do we need to set the selection color in the defaults? Why is it necessary here but not elsewhere?
-    ::selection {
-      color: @text !important;
-    }
 
     @accent-light-alpha: 1.1;
-    @accent-dark-alpha: 0.9;
+    @accent-dark-alpha: 80%;
     @accent-gradient-from-color: 1.05;
     @accent-gradient-via-color: 1.2;
     @accent-gradient-to-color: 0.85;
 
     --primary-color: @base;
-    --primary-light-color: @surface1;
+    --primary-light-color: @mantle;
     --primary-dark-color: @crust;
     --primary-contrast-color: @mantle;
     --secondary-color: @subtext0;
     --secondary-light-color: @subtext0;
     --secondary-dark-color: @subtext1;
-    --divider-color: @overlay0;
-    --divider-light-color: @overlay1;
-    --divider-dark-color: @surface2;
+    --divider-color: @surface0;
+    --divider-light-color: @surface0;
+    --divider-dark-color: @surface0;
     --error-color: @red;
     --tooltip-color: @text;
     --popover-color: @crust;
@@ -73,17 +69,26 @@
     --gradient-to-color: fade(@accent, @accent-gradient-to-color);
 
     --editor-process-color: @text;
+    --banner-info-color: fade(@blue, 20%);
 
-    .ͼ1 .cm-placeholder {
-      color: @text;
+    .cm-editor {
+      background: @mantle;
+
+      .cm-placeholder {
+        color: @text;
+      }
     }
 
     .cm-focused .cm-activeLine {
-      background-color: @surface0;
+      background-color: @base;
     }
 
     .cm-focused .cm-activeLineGutter {
-      background-color: @surface2;
+      background-color: @surface0;
+    }
+      
+    .cm-selectionBackground { 
+      background: fade(@accent, 30%) !important; 
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Improve theming for _hoppscotch_.

* reduce contrast for outlines
* improve selection color and text selected color on the editor
* improve the inactive color for the tabs, and dimmed elements

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
