### PR TITLE
fix(hoppscotch): method types and response status colors

### DIFF
--- a/styles/hoppscotch/catppuccin.user.less
+++ b/styles/hoppscotch/catppuccin.user.less
@@ -71,6 +71,21 @@
     --editor-process-color: @text;
     --banner-info-color: fade(@blue, 20%);
 
+    --method-get-color: @green;
+    --method-post-color: @yellow;
+    --method-put-color: @sapphire;
+    --method-patch-color: @mauve;
+    --method-delete-color: @red;
+    --method-head-color: @teal;
+    --method-options-color: @lavender;
+    --method-default-color: @overlay1;
+    --status-info-color: @blue;
+    --status-success-color: @green;
+    --status-redirect-color: @peach;
+    --status-critical-error-color: @red;
+    --status-server-error-color: @red;
+    --status-missing-data-color: @overlay0;
+
     .cm-editor {
       background: @mantle;
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

For example, "GET" and "POST" in this screenshot.

<img width="762" height="152" alt="CleanShot 2025-12-05 at 12 43 33@2x" src="https://github.com/user-attachments/assets/3352f8ed-d764-45ce-bda5-703e9449c4a4" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
