### PR TITLE
feat(noogle): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -991,4 +991,10 @@ userstyles:
     categories: [productivity]
     color: peach
     current-maintainers: [*ashish0kumar]
+  noogle.dev:
+    name: Noogle
+    link: https://noogle.dev/
+    categories: [search_engine, wiki]
+    color: blue
+    current-maintainers: [*nuexq]
 # yaml-language-server: $schema=userstyles.schema.json

--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -991,7 +991,7 @@ userstyles:
     categories: [productivity]
     color: peach
     current-maintainers: [*ashish0kumar]
-  noogle.dev:
+  noogle:
     name: Noogle
     link: https://noogle.dev/
     categories: [search_engine, wiki]

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -15,6 +15,7 @@
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
 @import "https://userstyles.catppuccin.com/lib/lib.less";
+@import "https://raw.githubusercontent.com/catppuccin/userstyles/feat/mui-lib/lib/mui.less";
 
 @-moz-document domain("noogle.dev") {
   @import url("https://unpkg.com/@catppuccin/highlightjs@1.0.0/css/catppuccin-variables.important.css");
@@ -41,47 +42,8 @@
     #lib.palette();
     #lib.defaults();
     #lib.css-variables();
-
-    .rgbify(@color) {
-      @rgb: red(@color) green(@color) blue(@color);
-    }
-
-    --mui-palette-background-paper: @base;
-    --mui-palette-background-default: lighten(@base,
-      3%);
-    --mui-palette-primary-main: @accent;
-    --mui-palette-text-primary: @text;
-    --mui-palette-primary-contrastText: @mantle;
-    --mui-palette-primary-mainChannel: .rgbify(@accent) [];
-    --mui-palette-misc-a: lighten(@accent, 5%);
-    --mui-palette-action-active: @text;
-    --mui-palette-action-hover: @surface0;
-    --mui-opacity-inputPlaceholder: @surface2;
-    --mui-palette-text-secondary: @subtext0;
-    --mui-palette-divider: @surface0;
-    --mui-palette-text-primaryChannel: .rgbify(@surface2) [];
-    --mui-palette-code-bg: @mantle;
-    --mui-palette-example-main: @accent;
-    --mui-palette-fenced-bg: if(@flavor =latte,
-      @mantle,
-      @surface0);
-    --mui-palette-header-default: if(@flavor =latte,
-      lighten(@accent, 10%),
-      @mantle);
-    --mui-palette-secondary-main: fade(@accent,
-      30%);
-    --mui-palette-primary-light: lighten(@accent,
-      5%);
-    --mui-palette-warning-main: @yellow;
-    --mui-palette-warning-mainChannel: .rgbify(@yellow) [];
-    --mui-palette-tip-main: @green;
-    --mui-palette-Tooltip-bg: @surface2;
-    --mui-palette-info-light: @blue;
-    --mui-palette-error-main: @red;
+    #__mui.base();
+    
     --ctp-base: @mantle !important;
-
-    mark {
-      background-color: @accent;
-    }
   }
 }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -49,37 +49,21 @@
       misc-tableBorder,
       darken(@accent, 25%));
     
-    // example
-    #__mui.override(
-      example-main,
+    #__mui.override-main(
+      example,
       @teal);
-    #__mui.override(
-      example-mainChannel,
-    red(@teal) green(@teal) blue(@teal));
     
-    // caution
-    #__mui.override(
-      caution-main,
+    #__mui.override-main(
+      caution,
     @yellow);
-    #__mui.override(
-      caution-mainChannel,
-    red(@yellow) green(@yellow) blue(@yellow));
     
-    // important
-    #__mui.override(
-      important-main,
+    #__mui.override-main(
+      important,
     @red);
-    #__mui.override(
-      important-mainChannel,
-    red(@red) green(@red) blue(@red));
 
-    // note
-    #__mui.override(
-      note-main,
+    #__mui.override-main(
+      note,
     @blue);
-    #__mui.override(
-      note-mainChannel,
-    red(@blue) green(@blue) blue(@blue));
     
     --ctp-base: @mantle !important;
   }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -55,7 +55,7 @@
       @teal);
     #__mui.override(
       example-mainChannel,
-    red(@teal) green(@teal) blue(@teal) []);
+    red(@teal) green(@teal) blue(@teal));
     
     // caution
     #__mui.override(
@@ -63,7 +63,7 @@
     @yellow);
     #__mui.override(
       caution-mainChannel,
-    red(@yellow) green(@yellow) blue(@yellow) []);
+    red(@yellow) green(@yellow) blue(@yellow));
     
     // important
     #__mui.override(
@@ -71,7 +71,7 @@
     @red);
     #__mui.override(
       important-mainChannel,
-    red(@red) green(@red) blue(@red) []);
+    red(@red) green(@red) blue(@red));
 
     // note
     #__mui.override(
@@ -79,7 +79,7 @@
     @blue);
     #__mui.override(
       note-mainChannel,
-    red(@blue) green(@blue) blue(@blue) []);
+    red(@blue) green(@blue) blue(@blue));
     
     --ctp-base: @mantle !important;
   }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -78,7 +78,6 @@
     --mui-palette-Tooltip-bg: @surface2;
     --mui-palette-info-light: @blue;
     --mui-palette-error-main: @red;
-    --ctp-base: @mantle !important;
 
     mark {
       background-color: @accent;

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -61,6 +61,7 @@
     #__mui.override(
       caution-mainChannel,
     .rgbify(@yellow) []);
+    
     // important
     #__mui.override(
       important-main,
@@ -68,6 +69,14 @@
     #__mui.override(
       important-mainChannel,
     .rgbify(@red) []);
+
+    // note
+    #__mui.override(
+      note-main,
+    @blue);
+    #__mui.override(
+      note-mainChannel,
+    .rgbify(@blue) []);
     
     --ctp-base: @mantle !important;
   }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -43,7 +43,5 @@
     #lib.defaults();
     #lib.css-variables();
     #__mui.base();
-    
-    --ctp-base: @mantle !important;
   }
 }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -45,12 +45,20 @@
     #__mui.override(
       background-default,
       lighten(@base, 3%));
+    // example
     #__mui.override(
       example-main,
       @teal);
     #__mui.override(
       example-mainChannel,
     .rgbify(@teal) []);
+    // caution
+    #__mui.override(
+      caution-main,
+    @yellow);
+    #__mui.override(
+      caution-mainChannel,
+    .rgbify(@yellow) []);
     
     --ctp-base: @mantle !important;
   }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -14,8 +14,10 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
+
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 @import "https://raw.githubusercontent.com/catppuccin/userstyles/feat/mui-lib/lib/mui.less";
+
 @-moz-document domain("noogle.dev") {
   @import url("https://unpkg.com/@catppuccin/highlightjs@1.0.0/css/catppuccin-variables.important.css");
 
@@ -41,7 +43,9 @@
     #lib.palette();
     #lib.defaults();
     #lib.css-variables();
+
     #__mui.base();
+
     #__mui.override(
       background-default,
       lighten(@base, 3%));

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -1,0 +1,86 @@
+/* ==UserStyle==
+@name Noogle Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/noogle.dev
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/noogle.dev
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/noogle.dev/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3noogle.devA
+@description Soothing pastel theme for Noogle
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+@import "https://userstyles.catppuccin.com/lib/lib.less";
+
+@-moz-document domain("noogle.dev") {
+  @import url("https://unpkg.com/@catppuccin/highlightjs@1.0.0/css/catppuccin-variables.important.css");
+
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  :root[data-mui-color-scheme="dark"] {
+    #catppuccin(@darkFlavor);
+  }
+
+  :root[data-mui-color-scheme="light"] {
+    #catppuccin(@lightFlavor);
+  }
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+    #lib.defaults();
+    #lib.css-variables();
+
+    .rgbify(@color) {
+      @rgb: red(@color) green(@color) blue(@color);
+    }
+
+    --mui-palette-background-paper: @base;
+    --mui-palette-background-default: lighten(@base,
+      3%);
+    --mui-palette-primary-main: @accent;
+    --mui-palette-text-primary: @text;
+    --mui-palette-primary-contrastText: @mantle;
+    --mui-palette-primary-mainChannel: .rgbify(@accent) [];
+    --mui-palette-misc-a: lighten(@accent, 5%);
+    --mui-palette-action-active: @text;
+    --mui-opacity-inputPlaceholder: @surface2;
+    --mui-palette-text-secondary: @subtext0;
+    --mui-palette-divider: @surface0;
+    --mui-palette-text-primaryChannel: .rgbify(@surface2) [];
+    --mui-palette-code-bg: @mantle;
+    --mui-palette-example-main: @accent;
+    --mui-palette-fenced-bg: if(@flavor =latte,
+      @mantle,
+      @surface0);
+    --mui-palette-header-default: if(@flavor =latte,
+      lighten(@accent, 10%),
+      @mantle);
+    --mui-palette-secondary-main: fade(@accent,
+      30%);
+    --mui-palette-primary-light: lighten(@accent,
+      5%);
+    --mui-palette-warning-main: @yellow;
+    --mui-palette-warning-mainChannel: .rgbify(@yellow) [];
+    --mui-palette-tip-main: @green;
+    --mui-palette-Tooltip-bg: @surface2;
+    --mui-palette-info-light: @blue;
+    --mui-palette-error-main: @red;
+    --ctp-base: @mantle !important;
+
+    mark {
+      background-color: @accent;
+    }
+  }
+}

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -78,6 +78,7 @@
     --mui-palette-Tooltip-bg: @surface2;
     --mui-palette-info-light: @blue;
     --mui-palette-error-main: @red;
+    --ctp-base: @mantle !important;
 
     mark {
       background-color: @accent;

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -55,7 +55,7 @@
       @teal);
     #__mui.override(
       example-mainChannel,
-    .rgbify(@teal) []);
+    red(@teal) green(@teal) blue(@teal) []);
     
     // caution
     #__mui.override(
@@ -63,7 +63,7 @@
     @yellow);
     #__mui.override(
       caution-mainChannel,
-    .rgbify(@yellow) []);
+    red(@yellow) green(@yellow) blue(@yellow) []);
     
     // important
     #__mui.override(
@@ -71,7 +71,7 @@
     @red);
     #__mui.override(
       important-mainChannel,
-    .rgbify(@red) []);
+    red(@red) green(@red) blue(@red) []);
 
     // note
     #__mui.override(
@@ -79,7 +79,7 @@
     @blue);
     #__mui.override(
       note-mainChannel,
-    .rgbify(@blue) []);
+    red(@blue) green(@blue) blue(@blue) []);
     
     --ctp-base: @mantle !important;
   }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -43,5 +43,7 @@
     #lib.defaults();
     #lib.css-variables();
     #__mui.base();
+
+    --ctp-base: @mantle !important;
   }
 }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -45,6 +45,9 @@
     #__mui.override(
       background-default,
       lighten(@base, 3%));
+    #__mui.override(
+      misc-tableBorder,
+      darken(@accent, 25%));
     
     // example
     #__mui.override(

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -55,6 +55,7 @@
     --mui-palette-primary-mainChannel: .rgbify(@accent) [];
     --mui-palette-misc-a: lighten(@accent, 5%);
     --mui-palette-action-active: @text;
+    --mui-palette-action-hover: @surface0;
     --mui-opacity-inputPlaceholder: @surface2;
     --mui-palette-text-secondary: @subtext0;
     --mui-palette-divider: @surface0;

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -45,6 +45,12 @@
     #__mui.override(
       background-default,
       lighten(@base, 3%));
+    #__mui.override(
+      example-main,
+      @teal);
+    #__mui.override(
+      example-mainChannel,
+    .rgbify(@teal) []);
     
     --ctp-base: @mantle !important;
   }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -45,6 +45,7 @@
     #__mui.override(
       background-default,
       lighten(@base, 3%));
+    
     // example
     #__mui.override(
       example-main,
@@ -52,6 +53,7 @@
     #__mui.override(
       example-mainChannel,
     .rgbify(@teal) []);
+    
     // caution
     #__mui.override(
       caution-main,
@@ -59,6 +61,13 @@
     #__mui.override(
       caution-mainChannel,
     .rgbify(@yellow) []);
+    // important
+    #__mui.override(
+      important-main,
+    @red);
+    #__mui.override(
+      important-mainChannel,
+    .rgbify(@red) []);
     
     --ctp-base: @mantle !important;
   }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -16,7 +16,6 @@
 ==/UserStyle== */
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 @import "https://raw.githubusercontent.com/catppuccin/userstyles/feat/mui-lib/lib/mui.less";
-
 @-moz-document domain("noogle.dev") {
   @import url("https://unpkg.com/@catppuccin/highlightjs@1.0.0/css/catppuccin-variables.important.css");
 
@@ -43,7 +42,10 @@
     #lib.defaults();
     #lib.css-variables();
     #__mui.base();
-
+    #__mui.override(
+      background-default,
+      lighten(@base, 3%));
+    
     --ctp-base: @mantle !important;
   }
 }

--- a/styles/noogle.dev/catppuccin.user.less
+++ b/styles/noogle.dev/catppuccin.user.less
@@ -4,7 +4,7 @@
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/noogle.dev
 @version 2000.01.01
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/noogle.dev/catppuccin.user.less
-@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3noogle.devA
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anoogle.dev
 @description Soothing pastel theme for Noogle
 @author Catppuccin
 @license MIT

--- a/styles/noogle/catppuccin.user.less
+++ b/styles/noogle/catppuccin.user.less
@@ -1,10 +1,10 @@
 /* ==UserStyle==
 @name Noogle Catppuccin
-@namespace github.com/catppuccin/userstyles/styles/noogle.dev
-@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/noogle.dev
+@namespace github.com/catppuccin/userstyles/styles/noogle
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/noogle
 @version 2000.01.01
-@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/noogle.dev/catppuccin.user.less
-@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anoogle.dev
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/noogle/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Anoogle
 @description Soothing pastel theme for Noogle
 @author Catppuccin
 @license MIT
@@ -52,15 +52,15 @@
     #__mui.override(
       misc-tableBorder,
       darken(@accent, 25%));
-    
+
     #__mui.override-main(
       example,
       @teal);
-    
+
     #__mui.override-main(
       caution,
     @yellow);
-    
+
     #__mui.override-main(
       important,
     @red);
@@ -68,7 +68,7 @@
     #__mui.override-main(
       note,
     @blue);
-    
+
     --ctp-base: @mantle !important;
   }
 }


### PR DESCRIPTION
## 🎉 Theme for [Noogle](https://noogle.dev) 🎉

![catwalk](https://github.com/user-attachments/assets/32e4f70a-3797-4b39-a516-ded6c5d9121c)

## 💬 Additional Comments 💬

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://userstyles.catppuccin.com/contributing/creating-userstyles/).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
