### PR TITLE
fix(reddit): theme credit bar background

### DIFF
--- a/styles/reddit/catppuccin.user.less
+++ b/styles/reddit/catppuccin.user.less
@@ -22,6 +22,7 @@
   :root:not(.theme-dark).theme-rpl,
   :root:not(.theme-dark) .theme-beta,
   :root:not(.theme-dark).theme-beta,
+  :root:not(.theme-dark) #pdp-credit-bar,
   .theme-light {
     #catppuccin(@lightFlavor);
   }
@@ -30,6 +31,7 @@
   :root:not(.theme-light).theme-rpl,
   :root:not(.theme-light) .theme-beta,
   :root:not(.theme-light).theme-beta,
+  :root:not(.theme-light) #pdp-credit-bar,
   .theme-dark {
     #catppuccin(@darkFlavor);
   }
@@ -1075,11 +1077,6 @@
     /* tab bar below banner */
     ._1gVVmSnHZpkUgVShsn7-ua {
       background: @mantle !important;
-    }
-
-    /* credit bar (subreddit, OP username, time posted) */
-    div#pdp-credit-bar {
-      background-color: @base !important;
     }
 
     /* MULTIREDDITS/CUSTOM FEEDS */


### PR DESCRIPTION
This fixes the` pdp-credit-bar` element's background color that shows the subreddit name, OP username, and time since it was posted (e.g. 3h ago) which was displaying with `--color-neutral-background` instead of matching the `@base` color.

The `--color-neutral-background` on both light/dark modes seems like Reddit's unthemed default colors.

## Before screenshots
**Latte:** 
<img width="1186" height="188" alt="image" src="https://github.com/user-attachments/assets/ce49fc40-34a1-4253-bd72-6b50677a1e95" />

**Macchiato:** 
<img width="1176" height="191" alt="image" src="https://github.com/user-attachments/assets/f87a7021-a818-4a1f-a850-84c4c2fea599" />

## After screenshots
**Latte:** 
<img width="1168" height="198" alt="image" src="https://github.com/user-attachments/assets/d4b95fb7-af31-4eaa-a950-ff27579ccb84" />

**Macchiato:**
<img width="1206" height="183" alt="image" src="https://github.com/user-attachments/assets/899aed9a-118b-4156-bf8f-083e2d4b6dbe" />

