### PR TITLE
fix(youtube): Make frosted glass opaque and match the palette again.

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -398,6 +398,7 @@
     #background.ytd-masthead,
     #frosted-glass {
       --yt-frosted-glass-desktop: @base;
+      --yt-spec-frosted-glass-desktop: @base;
     }
 
     ytd-feed-filter-chip-bar-renderer[expand-instead-of-scroll]


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the top bar on YouTube, as the variable's name has changed causing the styling to break, and for it to look like frosted glass instead of matching the style.

I've left the old one in since YouTube has a habit of things rolling out very slowly and I don't want it to break anyone else's theming.

Closes #2025

Before:
<img width="1915" height="226" alt="image" src="https://github.com/user-attachments/assets/f68ea1ad-342a-4d66-b15c-b7c70ea7e683" />

After:
<img width="2641" height="154" alt="image" src="https://github.com/user-attachments/assets/bd0ebc15-51f4-43d3-9123-c6066d04cc9b" />

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
