### PR TITLE
fix(go.dev): CVE banner

### DIFF
--- a/styles/go.dev/catppuccin.user.less
+++ b/styles/go.dev/catppuccin.user.less
@@ -2,7 +2,7 @@
 @name go.dev Catppuccin
 @namespace github.com/catppuccin/userstyles/styles/go.dev
 @homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/go.dev
-@version 2025.09.06
+@version 2025.12.23
 @updateURL https://github.com/catppuccin/userstyles/raw/main/styles/go.dev/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ago.dev
 @description Soothing pastel theme for go.dev
@@ -432,6 +432,11 @@
       );
       content: url("data:image/svg+xml,@{svg}");
       filter: none;
+    }
+    // CVE notice
+    .go-Message--alert {
+      background-color: @base;
+      border-left: solid 4px @red;
     }
     // Pkg.go Subheader
     .go-Main-header {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

The CVE notice at the top of some Go package pages was unstyled and near unreadable.

<img width="2256" height="1504" alt="Screenshot_2025-12-23_17-46-12" src="https://github.com/user-attachments/assets/e79bbbd1-2222-400f-a1eb-4d88f1c4527e" />

There's no good way to do this with a red background, so I opted for a border instead.

<img width="2256" height="1504" alt="Screenshot_2025-12-23_17-47-15" src="https://github.com/user-attachments/assets/575f1bfe-2e84-46d5-9428-86298276ccb5" />

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
