### PR TITLE
fix(google-gemini): chat input background color

### DIFF
--- a/styles/google-gemini/catppuccin.user.less
+++ b/styles/google-gemini/catppuccin.user.less
@@ -189,6 +189,7 @@
     --gem-sys-color--primary-fixed: @text;
     --gem-sys-color--on-secondary: fade(@accent, 30%);
     --gem-sys-color--surface-variant: @surface0;
+    --gem-sys-color--surface-bright: @surface0;
 
     --og-theme-color: @text;
 
@@ -353,11 +354,6 @@
     }
     input-container::before {
       background: unset;
-    }
-      
-    /* Gemini chat input */
-    .discovery-feed-theme {
-        background-color: @surface0;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->
- Fix the chat input was not themed.

**Before:**
<img width="777" height="138" alt="image" src="https://github.com/user-attachments/assets/33007814-2ba6-43cd-bf80-5b2e19917674" />

**After:**
<img width="809" height="146" alt="image" src="https://github.com/user-attachments/assets/4f36cbfd-ff76-4355-8bdc-631cfa4021c2" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
