### PR TITLE
fix(dev.to): apply theme when logged out

### DIFF
--- a/styles/dev.to/catppuccin.user.less
+++ b/styles/dev.to/catppuccin.user.less
@@ -26,6 +26,14 @@
   body.light-theme {
     #catppuccin(@lightFlavor);
   }
+  body[data-user-status="logged-out"] {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
 
   #catppuccin(@flavor) {
     #lib.palette();


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Adds a theme selector to apply the `#catppuccin` mixin based on system preference when logged out.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
