### PR TITLE
fix(youtube): add toggle for hiding color sampled tint

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -354,7 +354,7 @@
     /* Misc */
     
     & when (@hideColorSampleTint = 1) {
-      // Thumbnail/video preview hover effect
+      // Recommended video card hover effect
       .yt-spec-touch-feedback-shape__hover-effect {
         background-color: @surface0 !important;
       }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes #2014. Adds a toggle called "Hide color-sampled tint" (color sampling appears to be what the feature is called based on an attribute in the tree, `enable-color-sampling`). Toggle is ENABLED BY DEFAULT, meaning the tint is hidden by default for users unless disabled. Undoes the tint for video cards on hover as well as in the video description text/background.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
