### PR TITLE
fix(lastfm): only invert placeholder cover art

### DIFF
--- a/styles/lastfm/catppuccin.user.less
+++ b/styles/lastfm/catppuccin.user.less
@@ -395,8 +395,10 @@
       }
 
       .cover-art {
-        mix-blend-mode: screen;
-        filter: invert(1);
+        img[src="https://lastfm.freetls.fastly.net/i/u/64s/c6f59c1e5e7240a4c0d427abd71f3dbb.jpg"] {
+          mix-blend-mode: screen;
+          filter: invert(1);
+        }
 
         &::after {
           box-shadow: inset 0 0 0 1px fade(@subtext0, 7%);


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes https://github.com/catppuccin/userstyles/pull/2037#issuecomment-3700099554. Closes #2050.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
