### PR TITLE
fix(youtube): disabled buttons

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -597,8 +597,7 @@
     }
 
     .yt-spec-button-shape-next--disabled {
-      background-color: fade(@overlay0, 50%);
-      color: @subtext0;
+      color: @overlay1;
     }
 
     .yt-spec-button-shape-next--overlay {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Removes the background color and further dims the text color of disabled buttons. Testable in the comment section of https://www.youtube.com/watch?v=YgeYScYe8wI (paused comments).

| Default | Before | After |
| --- | --- | --- |
| <img width="475" height="144" alt="image" src="https://github.com/user-attachments/assets/9f638009-a948-4224-8798-b4ce08065d61" /> | <img width="478" height="148" alt="image" src="https://github.com/user-attachments/assets/9c169514-a3f1-4bb7-b71c-6e3b1f7ba6c7" /> | <img width="478" height="148" alt="image" src="https://github.com/user-attachments/assets/1eb397f0-4953-4309-b3ac-a4683d181dc2" /> |



## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
