### PR TITLE
feat(lib/mediawiki): add a.extiw

### DIFF
--- a/lib/mediawiki.less
+++ b/lib/mediawiki.less
@@ -253,7 +253,7 @@
       }
     }
 
-    .mw-parser-output a {
+    :where(.mw-parser-output a) {
       &.external {
         @svg: escape(
           '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="@{accent}" d="M6 1h5v5L8.86 3.85 4.7 8 4 7.3l4.15-4.16zM2 3h2v1H2v6h6V8h1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1"/></svg>'


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

<!--
You should give a short description of the fixes/updates implemented in your PR, and add "Closes #<ISSUE-NUMBER>" below if so
E.g. Fixes unthemed buttons on the home page.
-->

### Current Suggestion:

- Adds `a.extiw` - interwiki links icon!
- Adds check for `:not(.plainlinks)` - plainlinks have no mw parsing, and thus cause the image to be repeated at every single letter's x position. Add a check, to only apply our icon to all non-plainlinks.


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
