### PR TITLE
fix(duckduckgo): lavender visited links

### DIFF
--- a/styles/duckduckgo/catppuccin.user.less
+++ b/styles/duckduckgo/catppuccin.user.less
@@ -44,11 +44,11 @@
     --theme-col-txt-page-separator: @text !important;
     --theme-col-page-separator: @text !important;
     --theme-col-txt-url: @text !important;
-    --theme-col-txt-title-visited: @mauve !important;
+    --theme-col-txt-title: @blue !important;
+    --theme-col-txt-title-visited: @lavender !important;
     --theme-col-txt-snippet: @text !important;
     --theme-col-txt-card-title: @text;
     --theme-col-txt-url-domain: @subtext1 !important;
-    --theme-col-txt-title: @blue !important;
     --theme-col-bg-card: @surface0 !important;
     --theme-col-about-link: @blue;
     --theme-col-border-ui: @surface1 !important;


### PR DESCRIPTION
As per style guide, visited ("followed") links should be lavender.