### PR TITLE
feat(pronouns.page): add language-specific domains

### DIFF
--- a/styles/pronouns.page/catppuccin.user.less
+++ b/styles/pronouns.page/catppuccin.user.less
@@ -17,7 +17,14 @@
 
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
-@-moz-document domain("pronouns.page") {
+@-moz-document domain("pronouns.page"),
+  domain("pronomen.net"),
+  domain("pronombr.es"),
+  domain("pronomejo.net"),
+  domain("fornovn.fo"),
+  domain("pronoms.fr"),
+  domain("pronom.it"),
+  domain("zaimki.pl") {
   body:not([data-theme="dark"]) {
     #catppuccin(@lightFlavor);
   }


### PR DESCRIPTION
hey so pronouns.page uses different domains for some languages. this adds them all.
see https://pronouns.page

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
