### PR TITLE
fix(youtube): fix shorts navigation bar background

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -73,6 +73,7 @@ collaborators:
   - &ImenaOphelia ImenaOphelia
   - &koibtw koibtw
   - &TheAnonymousCrusher TheAnonymousCrusher
+  - &scarcekoi scarcekoi
 
 userstyles:
   advent-of-code:

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -1238,6 +1238,11 @@
         color: @text;
       }
     }
+
+    /* Fix shorts navigation bar background */
+    .navigation-container.ytd-shorts {
+      background: @base;
+    }
   }
 }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the shorts navigation bar (shown on the right in screenshots: #1959 in the first screenshot)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
