### PR TITLE
fix(wikipedia): style buttons in fullscreen image previews

### DIFF
--- a/styles/wikipedia/catppuccin.user.less
+++ b/styles/wikipedia/catppuccin.user.less
@@ -385,8 +385,8 @@
     }
 
     /* Fullscreen images */
-    .cdx-button,
-    .mw-mmv-current-image-number {
+    .mw-mmv-pre-image .cdx-button,
+    .mw-mmv-pre-image .mw-mmv-current-image-number {
       background-color: fade(@surface0, 65%);
       color: @text;
 
@@ -395,7 +395,7 @@
       }
     }
 
-    .cdx-button .mw-mmv-icon {
+    .mw-mmv-pre-image .cdx-button .mw-mmv-icon {
       background-color: @text;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unstyled buttons in the image previews/carousel. Closes #1850 

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
