### PR TITLE
fix(duckduckgo): add duck.ai domain

### DIFF
--- a/styles/duckduckgo/catppuccin.user.less
+++ b/styles/duckduckgo/catppuccin.user.less
@@ -17,7 +17,7 @@
 
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
-@-moz-document domain("duckduckgo.com") {
+@-moz-document domain("duckduckgo.com"), domain("duck.ai") {
   :root:not(.dark-bg, .no-theme) {
     #catppuccin(@lightFlavor);
   }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

duck.ai recently migrated to a new domain https://duck.ai

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
