### PR TITLE
fix(reddit): trending carousel cards text

### DIFF
--- a/styles/reddit/catppuccin.user.less
+++ b/styles/reddit/catppuccin.user.less
@@ -66,7 +66,7 @@
     --color-primary-background: @accent !important;
     --color-primary-background-hover: darken(@accent, 5%) !important;
     --color-primary-background-selected: darken(@accent, 5%) !important;
-    --color-primary-onBackground: @text !important;
+    --color-primary-onBackground: @base !important;
     --color-primary-onBackground-selected: @crust !important;
     --color-secondary: @subtext0 !important;
     --color-secondary-hover: @subtext1 !important;
@@ -551,6 +551,19 @@
       --videoModal-button-color: @mantle !important;
     }
 
+    /* Trending news carousel on https://www.reddit.com/r/popular/. */
+    shreddit-gallery-carousel {
+      // Headline
+      .text-primary-onBackground {
+        color: @text;
+      }
+      
+      // r/... *and more*
+      .text-coolgray-350 {
+        color: @subtext1;
+      }
+    }
+    
     /* site background */
     div.ListingLayout-backgroundContainer::before {
       background: @base !important;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes black/unreadable text on the Trending Today carousel cards on the Reddit homepage.

The `text-primary-onBackground` class uses `--color-primary-onBackground`, which the theme sets to a dark color. This breaks text that appears over image cards with gradient overlays.

Fix targets elements inside gradient backgrounds and forces white text: