### PR TITLE
fix(chess.com): outside board coordinates

### DIFF
--- a/styles/chess.com/catppuccin.user.less
+++ b/styles/chess.com/catppuccin.user.less
@@ -614,11 +614,16 @@
         background-image: url("data:image/svg+xml,@{board}");
       }
 
+      /* Coordinates - Inside */
       .coordinate-light {
         fill: @dark-cell;
       }
       .coordinate-dark {
         fill: @light-cell;
+      }
+      /* Coordinates - Outside */
+      .coordinate-grey {
+        fill: @subtext0;
       }
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed coordinates when the board config has coordinates outside of the board rather than within.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
