### PR TITLE
refactor(wanderlog): POC of button mixins

### DIFF
--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -61,6 +61,54 @@
     --gray--900-2: @text;
 
     --accent-darker: darken(@accent, 5%);
+    @accent-darker: darken(@accent, 5%);
+
+    // Mixins
+
+    // Stroke refers to border; stroke shortforms better :>
+    // Background | Foreground | Stroke
+    // Hover Background | Hover Foreground | Hover Stroke
+    // Active Background | Active Foreground | Active Stroke
+    // Disabled Background | Disabled Foreground | Disabled Stroke
+    .ctp-stateful(@bg; @fg; @st; @hbg; @hfg; @hst; @abg; @afg; @ast; @dbg; @dfg; @dst; @notState;) {
+      background-color: @bg;
+      color: @fg;
+      border-color: @st;
+      &:hover:not(@notState) {
+        & when (@hbg) {
+          background-color: @hbg; 
+        }
+        & when (@hfg) {
+          color: @hfg;
+        }
+        & when (@hst) {
+          border-color: @hst;
+        }
+      }
+      &:active:not(@notState) {
+        & when (@abg) {
+          background-color: @abg; 
+        }
+        & when (@afg) {
+          color: @afg;
+        }
+        & when (@ast) {
+          border-color: @ast;
+        }
+      } 
+      // When not state (what is the syntax???)
+      & {
+        & when (@abg) {
+          background-color: @abg; 
+        }
+        & when (@afg) {
+          color: @afg;
+        }
+        & when (@ast) {
+          border-color: @ast;
+        }
+      } 
+    }
 
     /* General */
     body:has(#react-main), .body {
@@ -259,37 +307,23 @@
 
     // Buttons
     .Button__brand, .Button__dark {
-      background-color: @accent;
-      border-color: @accent;
-
-      &, &:hover, &:active, .Button__icon {
-        color: @base;
-      }
-
-      &:not(.Button__disabled):hover,
-      &:not(.Button__disabled):active,
-      &:not(.Button__disabled):focus,
-      &:not(.Button__disabled).Button__focused {
-        background-color: var(--accent-darker);
-        border-color: var(--accent-darker);
-        color: @base;
-      }
-
-      &.Button__disabled {
-        background-color: fade(@accent, 40%);
-        border-color: fade(@accent, 40%);
-        color: @subtext0 !important;
-      }
-      &.Button__disabled,
-      &.Button__disabled .Button__icon,
-      &.Button__disabled:hover {
-        color: @subtext0;
-      }
-
-      &:not(.Button__disabled).Button__focused .Button__icon,
-      &:not(.Button__disabled):active .Button__icon,
-      &:not(.Button__disabled):hover .Button__icon {
-        color: @base;
+      .ctp-stateful(
+        @bg: @accent,
+        @fg: @base,
+        @st: @accent,
+        @hbg: @accent-darker;
+        @hfg: @base;
+        @hst: @accent-darker;
+        @afg: @base;
+        @ast: @accent-darker;
+        @dbg: fade(@accent, 40%);
+        @dfg: @subtext0;
+        @dst: fade(@accent, 40%);
+        // Pseudo code: what is the syntax for this?
+        @notState: '.Button__disabled'
+      );
+      .Button__icon {
+        color: inherit !important;
       }
     }
     .brand-button {
@@ -300,72 +334,38 @@
       }
     }
     .btn-primary {
-      background-color: @accent;
-      border-color: @accent;
-      color: @base !important;
+      .Button__brand();
 
-      &.focus,
-      &:focus,
-      &:hover,
-      &:not(:disabled):not(.disabled).active,
-      &:not(:disabled):not(.disabled):active,
       .show > &.dropdown-toggle {
         background-color: var(--accent-darker);
         border-color: var(--accent-darker);
       }
     }
-    .Button__flat,
     .flat-button,
+    .Button__flat,
     .Button__flat-primary,
-    .Button__flat-primary .Button__icon,
-    .Button__flat .Button__icon,
-    .Button__flat:hover,
-    .Button__flat-primary:hover,
-    .Button__flat-brand,
-    .Button__flat-brand .Button__icon,
-    .Button__flat-brand:hover {
-      color: @accent;
-
-      &:hover,
-      &:active,
-      &:not(.Button__disabled):hover .Button__icon,
-      &:not(.Button__disabled):active .Button__icon,
-      &:not(.Button__disabled).Button__focused,
-      &:not(.Button__disabled):active,
-      &:not(.Button__disabled).Button__focused .Button__icon {
-        color: var(--accent-darker);
-      }
-
-      &.Button__disabled,
-      &.Button__disabled .Button__icon,
-      &.Button__disabled:hover {
-        color: fade(@accent, 60%);
-      }
+    .Button__flat-brand {
+      .ctp-stateful(
+        @fg: @accent,
+        @hfg: @accent-darker;
+        @afg: @accent-darker;
+        @dfg: fade(@accent, 60%);
+        // Pseudo code: what is the syntax for this?
+        @notState: '.Button__disabled'
+      );
     }
-    .Button__brand:hover,
-    .Button__brand:not(.Button__disabled):hover .Button__icon {
-      color: @base;
-    }
+
     .Button__flat-secondary, .btn {
-      &, .Button__icon {
-        color: @text;
-
-        &:hover,
-        &:not(.Button__disabled):hover,
-        &:not(.Button__disabled):hover .Button__icon,
-        &:not(.Button__disabled):active,
-        &:not(.Button__disabled):active .Button__icon,
-        &:not(.Button__disabled).Button__focused,
-        &:not(.Button__disabled).Button__focused .Button__icon {
-          color: @subtext1;
-        }
-
-        &.Button__disabled,
-        &.Button__disabled .Button__icon,
-        &.Button__disabled:hover,
-        &.Button__disabled:hover .Button__icon {
-          color: @overlay1;
-        }
+      .ctp-stateful(
+        @fg: @text,
+        @hfg: @subtext1;
+        @afg: @subtext1;
+        @dfg: @overlay1;
+        // Pseudo code: what is the syntax for this?
+        @notState: '.Button__disabled'
+      );
+      .Button__icon {
+        color: inherit !important;
       }
     }
     .Button__default, .Button__primary {
@@ -391,29 +391,45 @@
         border-color: var(--accent-darker);
       }
 
+      .ctp-stateful(
+        @bg: transparent,
+        @fg: @text,
+        @st: @accent,
+        @hfg: @text;
+        @hst: @accent-darker;
+        @afg: @text;
+        @ast: @accent-darker;
+        @dbg: @surface0;
+        @dfg: @subtext0;
+        @dst: @accent-darker;
+        // Pseudo code: what is the syntax for this?
+        @notState: '.Button__disabled'
+      );
+
       .Button__icon {
+        color: inherit !important;
         img {
           filter: @text-filter;
         }
       }
     }
-    .Button__default-dark,
-    .Button__default-dark .Button__icon {
-      background-color: @accent;
-      border-color: @accent;
-
-      &:hover, &:active, &:not(.Button__disabled):hover .Button__icon {
-        background-color: var(--accent-darker);
-        border-color: var(--accent-darker);
-      }
+    .Button__default-dark {
+      .ctp-stateful(
+        @bg: @accent,
+        @fg: @base,
+        @st: @accent,
+        @hbg: @accent-darker;
+        @hst: @accent-darker;
+        // Pseudo code: what is the syntax for this?
+        @notState: '.Button__disabled'
+      );
     }
     .Button__flat-white,
     .Button__flat-white .Button__icon {
-      color: @text;
-
-      &:hover, &:active {
-        color: @subtext1;
-      }
+      .ctp-stateful(
+        @fg: @text;
+        @hfg: @subtext0;
+      );
     }
     .Button__flat-purple,
     .Button__flat-purple .Button__icon,

--- a/styles/wanderlog/catppuccin.user.less
+++ b/styles/wanderlog/catppuccin.user.less
@@ -60,8 +60,14 @@
     --gray--900: @text;
     --gray--900-2: @text;
 
-    --accent-darker: darken(@accent, 5%);
-    @accent-darker: darken(@accent, 5%);
+    --accent-darker: mix(@accent, @base, 90%);
+    @accent-darker: mix(@accent, @base, 90%);
+
+    @hover: 8%;
+    @active: -10%;
+
+    --accent-hover: lighten(@accent, @hover);
+    --accent-active: lighten(@accent, @active);
 
     // Mixins
 
@@ -70,44 +76,36 @@
     // Hover Background | Hover Foreground | Hover Stroke
     // Active Background | Active Foreground | Active Stroke
     // Disabled Background | Disabled Foreground | Disabled Stroke
-    .ctp-stateful(@bg; @fg; @st; @hbg; @hfg; @hst; @abg; @afg; @ast; @dbg; @dfg; @dst; @notState;) {
+    .ctp-stateful(@bg: null; @fg: null; @st: null; @hbg: null; @hfg: null; @hst: null; @abg: null; @afg: null; @ast: null; @dbg: null; @dfg: null; @dst: null; @notState: ~"";) {
       background-color: @bg;
       color: @fg;
       border-color: @st;
-      &:hover:not(@notState) {
-        & when (@hbg) {
-          background-color: @hbg; 
+      &:not(@{notState}) {
+        &:hover,
+        // messy!!
+        &.Button__focused {
+          & when not (@hbg = null) {
+            background-color: @hbg;
+          }
+          & when not (@hfg = null) {
+            color: @hfg;
+          }
+          & when not (@hst = null) {
+            border-color: @hst;
+          }
         }
-        & when (@hfg) {
-          color: @hfg;
-        }
-        & when (@hst) {
-          border-color: @hst;
+        &:active {
+          & when not (@abg = null) {
+            background-color: @abg;
+          }
+          & when not (@afg = null) {
+            color: @afg;
+          }
+          & when not (@ast = null) {
+            border-color: @ast;
+          }
         }
       }
-      &:active:not(@notState) {
-        & when (@abg) {
-          background-color: @abg; 
-        }
-        & when (@afg) {
-          color: @afg;
-        }
-        & when (@ast) {
-          border-color: @ast;
-        }
-      } 
-      // When not state (what is the syntax???)
-      & {
-        & when (@abg) {
-          background-color: @abg; 
-        }
-        & when (@afg) {
-          color: @afg;
-        }
-        & when (@ast) {
-          border-color: @ast;
-        }
-      } 
     }
 
     /* General */
@@ -147,8 +145,11 @@
     .text-primary {
       color: @accent !important;
     }
-    a.text-brand:active, a.text-brand:focus, a.text-brand:hover {
-      color: var(--accent-darker);
+    a.text-brand:focus, a.text-brand:hover {
+      color: var(--accent-hover);
+    }
+    a.text-brand:active {
+      color: var(--accent-active);
     }
     .text-white {
       color: @text !important;
@@ -306,21 +307,41 @@
     }
 
     // Buttons
-    .Button__brand, .Button__dark {
+    .Button__brand {
       .ctp-stateful(
-        @bg: @accent,
-        @fg: @base,
-        @st: @accent,
-        @hbg: @accent-darker;
+        @bg: @accent;
+        @fg: @base;
+        @st: @accent;
+        @hbg: var(--accent-hover);
         @hfg: @base;
-        @hst: @accent-darker;
+        @hst: var(--accent-hover);
+        @abg: var(--accent-active);
         @afg: @base;
-        @ast: @accent-darker;
+        @ast: var(--accent-active);
         @dbg: fade(@accent, 40%);
         @dfg: @subtext0;
         @dst: fade(@accent, 40%);
-        // Pseudo code: what is the syntax for this?
-        @notState: '.Button__disabled'
+        @notState: ~'.Button__disabled'
+      );
+      .Button__icon {
+        color: inherit !important;
+      }
+    }
+    .Button__dark {
+      .ctp-stateful(
+        @bg: @text;
+        @fg: @base;
+        @st: @text;
+        @hbg: lighten(@text, @hover);
+        @hfg: @base;
+        @hst: lighten(@text, @hover);
+        @abg: lighten(@text, @active);
+        @afg: @base;
+        @ast: lighten(@text, @active);
+        @dbg: fade(@text, 40%);
+        @dfg: @subtext0;
+        @dst: fade(@text, 40%);
+        @notState: ~'.Button__disabled'
       );
       .Button__icon {
         color: inherit !important;
@@ -329,8 +350,11 @@
     .brand-button {
       color: @base !important;
 
-      &:hover, &:active {
-        background-color: var(--accent-darker);
+      &:hover {
+        background-color: var(--accent-hover);
+      }
+      &:active {
+        background-color: var(--accent-active);
       }
     }
     .btn-primary {
@@ -346,23 +370,21 @@
     .Button__flat-primary,
     .Button__flat-brand {
       .ctp-stateful(
-        @fg: @accent,
+        @fg: @accent;
         @hfg: @accent-darker;
         @afg: @accent-darker;
         @dfg: fade(@accent, 60%);
-        // Pseudo code: what is the syntax for this?
-        @notState: '.Button__disabled'
+        @notState: ~'.Button__disabled'
       );
     }
 
     .Button__flat-secondary, .btn {
       .ctp-stateful(
-        @fg: @text,
+        @fg: @text;
         @hfg: @subtext1;
         @afg: @subtext1;
         @dfg: @overlay1;
-        // Pseudo code: what is the syntax for this?
-        @notState: '.Button__disabled'
+        @notState: ~'.Button__disabled'
       );
       .Button__icon {
         color: inherit !important;
@@ -392,9 +414,9 @@
       }
 
       .ctp-stateful(
-        @bg: transparent,
-        @fg: @text,
-        @st: @accent,
+        @bg: transparent;
+        @fg: @text;
+        @st: @accent;
         @hfg: @text;
         @hst: @accent-darker;
         @afg: @text;
@@ -402,8 +424,7 @@
         @dbg: @surface0;
         @dfg: @subtext0;
         @dst: @accent-darker;
-        // Pseudo code: what is the syntax for this?
-        @notState: '.Button__disabled'
+        @notState: ~'.Button__disabled'
       );
 
       .Button__icon {
@@ -415,13 +436,12 @@
     }
     .Button__default-dark {
       .ctp-stateful(
-        @bg: @accent,
-        @fg: @base,
-        @st: @accent,
+        @bg: @accent;
+        @fg: @base;
+        @st: @accent;
         @hbg: @accent-darker;
         @hst: @accent-darker;
-        // Pseudo code: what is the syntax for this?
-        @notState: '.Button__disabled'
+        @notState: ~'.Button__disabled'
       );
     }
     .Button__flat-white,


### PR DESCRIPTION
Rough POC of button mixins for Wanderlog. The intention was to have it like https://github.com/WalkQuackBack/FlaxBBThemeV2/blob/main/sass/base/_mixins.scss in another project, but this is not implemented very well. More research is needed on the Less.js syntax to port it.