### PR TITLE
fix(github): feed link color

### DIFF
--- a/styles/github/catppuccin.user.less
+++ b/styles/github/catppuccin.user.less
@@ -463,7 +463,7 @@ regexp(
     --outline-focus: @blue solid 2px;
 
     /* Feed Links */
-    .feed-item-content a tt {
+    .feed-item-content a code, .feed-item-content a tt {
       color: @accent;
     }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Small fix: color of links in feed, they sometimes are not styled, got a hardcoded color apparently

(It's not all links, I think it's just the ones in a md code block, not sure)

Before:
<img width="821" height="341" alt="image" src="https://github.com/user-attachments/assets/4492eee9-3f5f-4bf7-ad5c-57e4c2fdff5e" />

After:
<img width="821" height="341" alt="image" src="https://github.com/user-attachments/assets/d9207c4c-e971-4934-8804-6a7dba37c53d" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
