### PR TITLE
fix(youtube): hide sampled tint

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -354,14 +354,15 @@
     /* Misc */
 
     & when (@hideColorSampleTint = 1) {
-      // Recommended video card hover effect
+      // Thumbnail/video preview hover effect
       .yt-spec-touch-feedback-shape__hover-effect {
         background-color: @surface0 !important;
       }
       // Video description background (collapsed on hover)
-      ytd-watch-metadata[enable-color-sampling] {
+      ytd-watch-metadata {
         --yt-saturated-raised-background: @surface1;
         --yt-saturated-text-primary: @text;
+        --yt-saturated-text-secondary: @subtext1;
       }
       // Video description text (expanded)
       .yt-core-attributed-string--link-inherit-color {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes the hide color sample tint option not working in some cases (video descriptions) since they removed an attribute and added a new CSS variable.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
