### PR TITLE
fix(youtube): video hover preview and shorts progress bars

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -908,6 +908,19 @@
 
     /* Video player */
 
+    // Shorts and video hover preview progress bars
+    yt-progress-bar {
+      .ytProgressBarLineProgressBarPlayed,
+      .ytProgressBarPlayheadProgressBarPlayheadDot {
+        background: @accent;
+      }
+
+      .ytProgressBarLineProgressBarHovered,
+      .ytProgressBarLineProgressBarBackground {
+        background: @text; // (background) opacity is already adequately set
+      }
+    }
+
     .ytp-cards-button {
       .ytp-cards-button-icon {
         use {
@@ -1046,11 +1059,6 @@
       .YtdDesktopShortsVolumeControlsBackgroundScrim {
         background-color: fade(@black, 60%);
         color: @white;
-      }
-
-      .YtProgressBarLineProgressBarPlayed,
-      .YtProgressBarPlayheadProgressBarPlayheadDot {
-        background-color: @accent;
       }
 
       .yt-spec-button-shape-next--overlay-dark.yt-spec-button-shape-next--filled {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes https://github.com/catppuccin/userstyles/pull/1150#issuecomment-3902214758, and also the YouTube Shorts progress bars (the classes changed with the first letter capitalization). Both use the same web component so we can target that.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
