### PR TITLE
feat(radarr): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -74,6 +74,7 @@ collaborators:
   - &ImenaOphelia ImenaOphelia
   - &koibtw koibtw
   - &TheAnonymousCrusher TheAnonymousCrusher
+  - &DontDDoS DontDDoS
 
 userstyles:
   advent-of-code:
@@ -804,6 +805,13 @@ userstyles:
     categories: [productivity]
     color: blue
     current-maintainers: [*thismoon]
+  radarr:
+    name: Radarr
+    link: https://radarr.video/
+    categories: [entertainment]
+    color: peach
+    current-maintainers: [*DontDDoS]
+    note: This is ment to theme self-hosted instances of Radarr, not radarr.video
   react.dev:
     name: React.dev
     link: https://react.dev

--- a/styles/radarr/catppuccin.user.less
+++ b/styles/radarr/catppuccin.user.less
@@ -1,9 +1,9 @@
 /* ==UserStyle==
 @name Radarr Catppuccin
-@namespace github.com/catppuccin/userstyles/stylesradarr
-@homepageURL https://github.com/catppuccin/userstyles/tree/main/stylesradarr
+@namespace github.com/catppuccin/userstyles/styles/radarr
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/radarr
 @version 2000.01.01
-@updateURL https://github.com/catppuccin/userstyles/raw/main/stylesradarr/catppuccin.user.less
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/radarr/catppuccin.user.less
 @supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aradarr
 @description Soothing pastel theme for Radarr
 @author Catppuccin

--- a/styles/radarr/catppuccin.user.less
+++ b/styles/radarr/catppuccin.user.less
@@ -1,0 +1,57 @@
+/* ==UserStyle==
+@name Radarr Catppuccin
+@namespace github.com/catppuccin/userstyles/stylesradarr
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/stylesradarr
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/stylesradarr/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aradarr
+@description Soothing pastel theme for Radarr
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@import "https://userstyles.catppuccin.com/lib/lib.less";
+
+@-moz-document domain("*radarr*") {
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+    #lib.defaults();
+
+    body {
+      --successColor: @green;
+      --dangerColor: @red;
+      --warningColor: @peach;
+      --queueColor: @mauve;
+      --primaryColor: @sapphire;
+      --borderColor: @crust;
+      --inputBackgroundColor: @mantle;
+    }
+
+    [class^="PageContent"] {
+      background-color: @base;
+    }
+
+    [class^="PageHeader"], [class^="PageSidebar"] {
+      background-color: @crust;
+    }
+
+    [class^="PageToolbar"], [class^="MovieIndexPoster-title"], [class^="MovieCreditPoster-title"], [class*="Table"], [class^="Card"], [class^="AddNewMovie-searchIconContainer"] {
+      background-color: @mantle;
+    }
+  }
+}

--- a/styles/radarr/catppuccin.user.less
+++ b/styles/radarr/catppuccin.user.less
@@ -17,7 +17,7 @@
 
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
-@-moz-document domain("*radarr*") {
+@-moz-document regexp("https?://.*radarr(?!\\.video).*") {
   :root {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);

--- a/styles/radarr/catppuccin.user.less
+++ b/styles/radarr/catppuccin.user.less
@@ -40,6 +40,10 @@
       --primaryColor: @sapphire;
       --borderColor: @crust;
       --inputBackgroundColor: @mantle;
+      --textColor: @text;
+      --sidebarColor: @text;
+      --toolbarColor: @text;
+      --toolbarLabelColor: @text;
     }
 
     [class^="PageContent"] {
@@ -52,6 +56,10 @@
 
     [class^="PageToolbar"], [class^="MovieIndexPoster-title"], [class^="MovieCreditPoster-title"], [class*="Table"], [class^="Card"], [class^="AddNewMovie-searchIconContainer"] {
       background-color: @mantle;
+    }
+
+    [class^="MovieDetails"] {
+      color: @text;
     }
   }
 }


### PR DESCRIPTION
## 🎉 Theme for Radarr 🎉
Radarr is a self-hosted movie index manager for managing media libaries 

<img width="3684" height="2454" alt="CleanShot 2026-03-02 at 12 18 34@2x" src="https://github.com/user-attachments/assets/625c10bf-fbd8-4476-b60e-0b33c0cd16f4" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://userstyles.catppuccin.com/contributing/creating-userstyles/).
- [x] I have made a new directory underneath `/styles/radarr` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
