### PR TITLE
fix(vercel): prismjs syntax highlighting

### DIFF
--- a/styles/vercel/catppuccin.user.less
+++ b/styles/vercel/catppuccin.user.less
@@ -18,6 +18,8 @@
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
 @-moz-document domain("vercel.com"), domain("nextjs.org") {
+  @import url("https://prismjs.catppuccin.com/variables.important.css");
+
   :root.dark-theme {
     #catppuccin(@darkFlavor);
   }
@@ -28,6 +30,7 @@
   #catppuccin(@flavor) {
     #lib.palette();
     #lib.defaults();
+    #lib.css-variables();
 
     --geist-foreground: @text;
     --geist-background: @mantle;


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Pages including syntax highlighting with Prism:
- https://vercel.com/blog/we-ralph-wiggumed-webstreams-to-make-them-10x-faster
- https://vercel.com/docs/rest-api/bulk-redirects/gets-project-level-redirects
- etc

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
