### PR TITLE
fix(chess.com): appearance mode selectors

### DIFF
--- a/styles/chess.com/catppuccin.user.less
+++ b/styles/chess.com/catppuccin.user.less
@@ -24,11 +24,11 @@
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
 @-moz-document domain("chess.com") {
-  :root {
+  .light-mode {
     #catppuccin(@lightFlavor);
   }
 
-  :root.dark-mode {
+  .dark-mode {
     #catppuccin(@darkFlavor);
   }
 


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Matches the selectors Chess.com uses (i.e. no `:root`), fixes one modal I saw where the light/dark -mode class was used on non-root.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
