### PR TITLE
feat(searxng): apply filter to logo image

### DIFF
--- a/styles/searxng/catppuccin.user.less
+++ b/styles/searxng/catppuccin.user.less
@@ -141,6 +141,10 @@
       stroke: @accent;
     }
 
+    .index .title {
+      filter: @accent-filter;
+    }
+
     & when (@additions = 1) {
       article.result {
         background-color: var(--color-result-background);


### PR DESCRIPTION
| before | after |
|-|-|
| <img width="759" height="281" src="https://github.com/user-attachments/assets/792a4f85-0b47-4f6a-b533-373d07b9d8dc" /> | <img width="759" height="281" src="https://github.com/user-attachments/assets/2bd62a0e-e5fa-42ff-a156-fca0f5f09aca" /> |