### PR TITLE
fix(web.dev): exclude subdomains

### DIFF
--- a/styles/web.dev/catppuccin.user.less
+++ b/styles/web.dev/catppuccin.user.less
@@ -17,7 +17,8 @@
 
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
-@-moz-document domain("web.dev") {
+// Exclude https://pagespeed.web.dev/, which is (currently) poorly themed.
+@-moz-document url-prefix("https://web.dev") {
   :root {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);


### PR DESCRIPTION
Update the document rule to use url-prefix for the root web.dev in order to exclude pagespeed.web.dev, which doesn't look too good with our userstyle on.