### PR TITLE
fix(nixos-search): misc

### DIFF
--- a/styles/nixos-search/catppuccin.user.less
+++ b/styles/nixos-search/catppuccin.user.less
@@ -32,7 +32,7 @@
     #lib.defaults();
 
     --background-color: @base;
-    --badge-background: @accent;
+    --badge-background: @surface2;
     --button-active-background: @surface1;
     --button-active-hover-background: @surface2;
     --button-background: @surface0;
@@ -54,21 +54,18 @@
     --search-sidebar-selected-link-background: @accent;
     --search-sidebar-selected-link-color: @crust;
     --terminal-background: @surface0;
-    --terminal-color: @red;
+    --terminal-color: @text;
     --text-color: @text;
     --text-color-light: @text;
     --text-color-warning: @yellow;
 
-    // hardcoded to #fff
-    .label,
     .badge {
-      color: @crust;
-    }
-
-    // hardcoded to #005580
-    a:hover,
-    a:focus {
       color: @text;
+    }
+    /* Experimental Flakes label */
+    .label {
+      color: @base;
+      text-shadow: none;
     }
   }
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Removes the overuse of accent and use of red for code.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
