### PR TITLE
fix(ghostty): brand buttons and active sidebar, homepage terminal

### DIFF
--- a/styles/ghostty.org/catppuccin.user.less
+++ b/styles/ghostty.org/catppuccin.user.less
@@ -55,23 +55,15 @@
     --callout-warning: @yellow;
     --callout-caution: @red;
 
-    div[class*="Terminal_adwaita"] {
+    div[class^="Terminal-module"] {
       --adw-headerbar-color: @mantle !important;
-
-      svg[class*="Terminal_icon"], p[class*="Terminal_title"] {
-        color: @text !important;
-      }
-
-      li[class*="Terminal_circularButton"] {
-        > svg {
-          color: @base !important;
-        }
-        background-color: @accent !important;
-      }
+      --color-sunset-orange: @red;
+      --color-pastel-orange: @peach;
+      --color-malachite: @green;
     }
 
-    [class*="Link_buttonLink"]:hover,
-    ul [class*="NavTree_active"] {
+    [class*="__buttonLink"][class*="__brand"]:hover,
+    ul[class*="NavTree-module__"] [class*="__active"] {
       color: @crust !important;
     }
 
@@ -95,8 +87,9 @@
   }
 }
 
+/* #lib.hslify() with spaces instead of commas. */
 #hslify(@color) {
   @raw: e(
-    %("%s, %s%, %s%", hue(@color), saturation(@color), lightness(@color))
+    %("%s %s% %s%", hue(@color), saturation(@color), lightness(@color))
   );
 }


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes a few issues with Ghostty.

1. Homepage terminal animation buttons
<img width="236" height="130" alt="CleanShot 2026-03-09 at 19 24 45@2x" src="https://github.com/user-attachments/assets/27379553-c5ae-4dd1-bc1a-c970375c42d0" />

2. Correct contrasting fg on brand bg
<img width="762" height="186" alt="CleanShot 2026-03-09 at 19 24 51@2x" src="https://github.com/user-attachments/assets/e08c90a5-0047-45d6-927a-2774285103d2" />

3. Donation button (var was invalid since hslify had commas instead of spaces)
<img width="1582" height="274" alt="CleanShot 2026-03-09 at 19 25 07@2x" src="https://github.com/user-attachments/assets/11c1a5a6-ad7d-465a-9347-b8f557c01fc5" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
