### PR TITLE
feat(hb-appstore): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -409,6 +409,12 @@ userstyles:
     categories: [productivity]
     color: blue
     current-maintainers: [*trinkey]
+  hb-appstore:
+    name: Homebrew App Store
+    link: https://hb-app.store
+    categories: [package_registry]
+    color: red
+    current-maintainers: [*gradylink]
   holodex:
     name: Holodex
     link: https://holodex.net

--- a/styles/hb-appstore/catppuccin.user.less
+++ b/styles/hb-appstore/catppuccin.user.less
@@ -1,0 +1,84 @@
+/* ==UserStyle==
+@name Homebrew App Store Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/hb-appstore
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/hb-appstore
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/hb-appstore/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Ahb-appstore
+@description Soothing pastel theme for Homebrew App Store
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@import "https://userstyles.catppuccin.com/lib/lib.less";
+
+@-moz-document domain("hb-app.store") {
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+    #lib.defaults();
+
+    --main-background: @base;
+    --text-color: @text;
+    --searchColor: @text;
+    --footerTextColor: @text;
+    --footerBackgroundColor: @crust;
+    --menuColor: @text;
+    --dropDownColor: @text;
+    --buttonColor: @text;
+    --buttonBgColor: @text;
+    --dropDownBgColor: @crust;
+    --secondaryButtonColor: @surface0;
+    --dlButtonColor: @red;
+
+    .Sidebar {
+      background-color: @mantle;
+
+      .text {
+        color: @text;
+      }
+
+      .icon path {
+        fill: @text;
+      }
+    }
+
+    .ToolTipPortal > div {
+      background-color: @crust !important;
+
+      span {
+        border-right-color: @crust !important;
+      }
+    }
+
+    .Footer button {
+      background-color: @base;
+    }
+
+    .sidebar-item:hover {
+      background-color: @crust;
+    }
+
+    .sidebar-item.selected {
+      background-color: @crust;
+      border-color: @surface1;
+    }
+
+    select {
+      border-color: @surface2;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Replace "Website" with a markdown link to the website that you have themed. -->

## 🎉 Theme for Homebrew App Store 🎉

Homebrew App Store is a homebrew app repo and store for the Nintendo Wii U and Nintendo Switch.

## 💬 Additional Comments 💬

Honestly, homebrew app repos/stores might be a little too niche for this repo, if they're not, I'll also make themes for Open Shop Channel (for the Wii) and Universal DB (for the 3DS and DS) as those are the other 2 biggest ones.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [submission guidelines](https://userstyles.catppuccin.com/contributing/creating-userstyles/).
- [x] I have made a new directory underneath `/styles/<name-of-website>` containing the contents of the [`/template`](https://github.com/catppuccin/userstyles/blob/main/template/) directory.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have followed the template and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have made sure to update the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.
- [x] I have included the following files:
  - [x] `catppuccin.user.less` - all the CSS for the userstyle, based on the template.
