### PR TITLE
fix(claude): send message button color

### DIFF
--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -74,6 +74,8 @@
     --text-300: #hslify(@subtext0)[];
     --text-400: #hslify(@subtext1)[];
     --text-500: #hslify(@subtext0)[];
+    --brand-000: #hslify(@accent)[];
+    --brand-200: #hslify(lighten(@accent, 8%))[];
 
     /* Side bar */
     nav.\!bg-bg-200 {


### PR DESCRIPTION
## 🔧 What does this fix? 🔧

Fixes unthemed "Send Message" button (and potentially more?)

quick update to the color variables --brand-000 and 200, naming might suggest there's more, but didn't check yet, this fixes the most visible unthemed part for now, might come back later to check if there's more :)

previous: 
<img width="885" height="267" alt="image" src="https://github.com/user-attachments/assets/41ddd740-f3a0-41a4-888a-3ae7518657c3" />


fixed:
<img width="885" height="267" alt="image" src="https://github.com/user-attachments/assets/3613190f-caec-4b0f-a909-070b78a7c359" />


## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [contributing guidelines](https://userstyles.catppuccin.com/contributing/).
