### PR TITLE
chore(hyperpipe): remove `jn-sena` as maintainer

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -453,7 +453,8 @@ userstyles:
     link: https://hyperpipe.surge.sh
     categories: [music]
     color: teal
-    current-maintainers: [*jn-sena]
+    current-maintainers: []
+    past-maintainers: [*jn-sena]
   ichi.moe:
     name: ichi.moe
     link: https://ichi.moe

--- a/styles/hyperpipe/catppuccin.user.less
+++ b/styles/hyperpipe/catppuccin.user.less
@@ -17,20 +17,7 @@
 
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
-@-moz-document domain("hyperpipe.surge.sh"),
-  domain("hyperpipe.esmailelbob.xyz"),
-  domain("listen.whatever.social"),
-  domain("music.adminforge.de"),
-  domain("music.pfcd.me"),
-  domain("listen.whateveritworks.org"),
-  domain("hyperpipe.frontendfriendly.xyz"),
-  domain("hyperpipe.drgns.space"),
-  domain("hyperpipe.projectsegfau.lt"),
-  domain("hp.ggtyler.dev"),
-  domain("hyperpipe.lunar.icu"),
-  domain("hp.iqbalrifai.eu.org"),
-  domain("hp.ngn.tf"),
-  domain("hyperpipe.ducks.party") {
+@-moz-document domain("hyperpipe.surge.sh") {
   body {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);


### PR DESCRIPTION
Removed myself from Hyperpipe maintainers as it was [discontinued](https://codeberg.org/Hyperpipe/Hyperpipe/commit/06ff9c5058806e0d290ded65ad522b44cab50c33) a while ago and therefore I don't use it anymore. 