### PR TITLE
fix(chatgpt): sidebar, settings, tooltips

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -18,7 +18,7 @@
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
 @-moz-document domain("chatgpt.com") {
-  @import url("https://unpkg.com/@catppuccin/highlightjs@1.0.0/css/catppuccin-variables.important.css");
+  // TODO: Codemirror syntax highlighting.
 
   .light {
     #catppuccin(@lightFlavor);
@@ -31,7 +31,6 @@
   #catppuccin(@flavor) {
     #lib.palette();
     #lib.defaults();
-    #lib.css-variables();
 
     &, .popover {
       --text-primary: @text;
@@ -41,8 +40,13 @@
       --bg-primary: @base;
       --bg-secondary: @surface0;
       --bg-tertiary: @surface1;
+      
+      --bg-secondary-surface: @mantle; // sidebar
 
-      --bg-elevated-secondary: @mantle; // sidebar
+      --bg-elevated-primary: @base; // settings main panel
+      --bg-elevated-secondary: @mantle;
+      
+      --bg-tooltip: @crust;
 
       --main-surface-primary: @base;
       --main-surface-secondary: @surface0;
@@ -201,6 +205,7 @@
     --text-primary: @text;
     --text-secondary: @subtext1;
     --text-tertiary: @subtext0;
+    --text-placeholder: @subtext0;
 
     --accent-blue: @accent;
     --link: @accent;

--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -205,7 +205,7 @@
     --text-primary: @text;
     --text-secondary: @subtext1;
     --text-tertiary: @subtext0;
-    --text-placeholder: @subtext0;
+    --text-placeholder: @subtext0; // form field labels above the input (e.g. "Email" and "Password")
 
     --accent-blue: @accent;
     --link: @accent;


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

Closes #2210. Fixes the sidebar being unthemed and the main panel of settings being unthemed (new variables). I also noticed tooltip (backgrounds) were unthemed and fixed those, as well as the labels for inputs in the login screen with `--text-placeholder`. I removed the now unused Highlight.js syntax highlighting since all of it seems to use Codemirror now.

## 🔍 Reproduction Steps 🔍

Sidebar is plainly visible. Settings main panel can be seen by clicking on username/profile picture and clicking settings. Tooltips can be seen by hovering over e.g. the microphone button. Login field labels can be seen by logging out and going to the login page.