### PR TITLE
fix(codeberg): forgejo logo

### DIFF
--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -59,6 +59,7 @@
       }
     }
 
+    // LOGOS
     #codeberg-logo(@color) {
       @svg: escape(
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><defs><linearGradient id="b" x1="42519.285" x2="42575.336" y1="-7078.7891" y2="-6966.9312" gradientUnits="userSpaceOnUse" href="#a"/><linearGradient id="a"><stop color="@{color}" offset="0" stop-opacity="0"/><stop offset=".495" stop-color="@{color}" stop-opacity=".3"/><stop offset="1" stop-color="@{color}" stop-opacity=".3"/></linearGradient></defs><path fill="url(#b)" d="M42519.285-7078.79a.76.568 0 0 0-.738.675l33.586 125.888a87.2 87.2 0 0 0 39.381-33.763l-71.565-92.52a.76.568 0 0 0-.664-.28" transform="translate(-5840.572 980.524)scale(.13766)"/><path fill="@{color}" d="M12.003.525A12.003 12.003 0 0 0 0 12.533 11.9 11.9 0 0 0 1.826 18.9L11.838 5.956c.068-.09.25-.09.324 0l10.007 12.939A11.9 11.9 0 0 0 24 12.522 12.003 12.003 0 0 0 12.003.525"/></svg>'
@@ -66,13 +67,21 @@
       content: url("data:image/svg+xml,@{svg}");
     }
 
-    .branding img {
-      #codeberg-logo(@text);
+    #navbar {
+      a#navbar-logo {
+        img {
+          #codeberg-logo(@accent);
+        }
+
+        &:hover img {
+          #codeberg-logo(@base);
+        }
+      }
     }
 
-    #navbar {
-      #navbar-logo img {
-        #codeberg-logo(@crust);
+    .branding {
+      img[src^="https://design.codeberg.org/logo-kit/"] {
+        #codeberg-logo(@text);
       }
 
       .menu {


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

Fixes the cb logo being squashed into where the forgejo logo should be.

## 🔍 Reproduction Steps 🔍

- Scroll to footer of Codeberg page
- Note squashed CB logo instead of Forgejo.

Isolates CB Icon overwriting Forgejo fix from https://github.com/catppuccin/userstyles/pull/2113.
