### PR TITLE
fix(youtube): frosted glass header background

### DIFF
--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -429,6 +429,7 @@
     #frosted-glass {
       --yt-frosted-glass-desktop: @base;
       --yt-spec-frosted-glass-desktop: @base;
+      --yt-sys-color-baseline--frosted-glass-desktop: @base;
     }
 
     ytd-feed-filter-chip-bar-renderer[expand-instead-of-scroll]

--- a/styles/youtube/catppuccin.user.less
+++ b/styles/youtube/catppuccin.user.less
@@ -737,8 +737,7 @@
       --yt-saturated-text-secondary: @subtext1 !important;
     }
     // Video description text (expanded)
-    ytd-text-inline-expander
-      .ytAttributedStringLinkInheritColor:not(
+    ytd-text-inline-expander .ytAttributedStringLinkInheritColor:not(
         .ytAttributedStringLink
       ) {
       color: @text !important;


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [X] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

<!--
Give a short description of the fixes/updates implemented in this pull request, and add "Closes #<ISSUE-NUMBER>" below for any relevant issues.
E.g. Fixes unthemed buttons on the home page.
-->

Fixed unthemed masthead and chip bar on the homepage of YouTube.
Fixes file formatting by running the recommend [deno fmt](https://userstyles.catppuccin.com/contributing/#development-environment) command.

## 🔍 Reproduction Steps 🔍

<!--
Provide a series of instruction steps, relevant URLs, and/or screenshots to be able to reproduce or demonstrate the underlying issue.
E.g. Unthemed button can be found in the navigation bar on https://example.com/pages/foo, by hovering over the third link in the header.
-->

Open YouTube to the home page and view the masthead and chip bar at the top.

<!-- You may want to use the following before/after table template to show your changes. Paste/move an image into the textbox and use the resulting <img> in the appropriate cell of the table. -->

| Before | After |
| ------ | ----- |
| <img width="1390" height="153" alt="Screenshot 2026-04-16 at 7 18 53 AM" src="https://github.com/user-attachments/assets/e2b6ca54-0f83-485f-a28e-ba4c18c9ecef" /> | <img width="1390" height="176" alt="Screenshot 2026-04-16 at 7 18 31 AM" src="https://github.com/user-attachments/assets/e08c96bb-abca-4403-958c-b3432d856722" /> |