### PR TITLE
chore(ISSUE_TEMPLATE): fix image uploads

### DIFF
--- a/scripts/generate/templates/userstyle-issue.yml
+++ b/scripts/generate/templates/userstyle-issue.yml
@@ -22,15 +22,15 @@ body:
   - id: description
     type: textarea
     attributes:
-      label: Describe your problem.
-      description: Also tell us, what do you expect to see?
+      label: Description
+      description: Describe the problem and what you expect to see instead.
       placeholder: The navigation bar on the website is highlighted incorrectly...
     validations:
       required: true
   - id: screenshots
-    type: upload
+    type: textarea
     attributes:
-      label: Attach screenshots.
+      label: Relevant screenshots
       description: If applicable, attach screenshots which clearly highlight the issue.
   - id: browser_version
     type: input


### PR DESCRIPTION
I didn't realize the `upload` type doesn't preview/show image uploads. This reverts that input back to a textarea. Also slightly adjusts the text/descriptions.