### PR TITLE
fix(claude): syntax highlighting

### DIFF
--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -126,7 +126,7 @@
 
         /* Cyan - constants / nunmbers */
         span.token[style="color: rgb(94, 237, 237);"] {
-          color: @sky !important;
+          color: @peach !important;
         }
 
         /* Magenta - built in functions / keywords */

--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -91,10 +91,17 @@
     nav.\!bg-bg-200 {
       background: @mantle !important;
     }
+    /* Target the specific element with all those classes */
 
+    .text-text-500.font-small.p-3\.5.pb-0 {
+        background-color: @crust !important;
+       /* Optional: Add padding or border-radius if the bg looks cramped */
+        border-radius: 8px 8px 0px 0px !important;
+    }
     /* Code blocks */
     .code-block__code {
       background: @crust !important;
+      border-radius: 0px 0px 8px 8px !important; 
 
       code {
         /* Default color */

--- a/styles/claude/catppuccin.user.less
+++ b/styles/claude/catppuccin.user.less
@@ -102,33 +102,33 @@
           color: @text !important;
         }
 
-        /* Green */
-        span.token[style="color: rgb(152, 195, 121);"] {
+        /* Green - strings */
+        span.token[style="color: rgb(155, 233, 99);"] {
           color: @green !important;
         }
 
-        /* Yellow */
-        span.token[style="color: rgb(209, 154, 102);"] {
+        /* Yellow - types */
+        span.token[style="color: rgb(251, 173, 96);"] {
           color: @yellow !important;
         }
 
-        /* Blue */
-        span.token[style="color: rgb(97, 175, 239);"] {
+        /* Blue - functions */
+        span.token[style="color: rgb(112, 184, 255);"] {
           color: @blue !important;
         }
 
-        /* Red */
-        span.token[style="color: rgb(224, 108, 117);"] {
-          color: @red !important;
+        /* Cyan - constants / nunmbers */
+        span.token[style="color: rgb(94, 237, 237);"] {
+          color: @sky !important;
         }
 
-        /* Magenta */
-        span.token[style="color: rgb(198, 120, 221);"] {
+        /* Magenta - built in functions / keywords */
+        span.token[style="color: rgb(204, 123, 244);"] {
           color: @mauve !important;
         }
 
-        /* Gray */
-        span.token[style="color: rgb(171, 178, 191);"] {
+        /* Gray - comments */
+        span.token[style="color: rgb(129, 136, 152);"] {
           color: @overlay2 !important;
         }
       }


### PR DESCRIPTION
Claude codeblocks was broken and didn't show up syntaxt highlight colours
Default:
<img width="795" height="760" alt="{649A716E-4313-4871-95BE-1304EDDB1240}" src="https://github.com/user-attachments/assets/7a60600d-fe4f-4aa8-af13-3e25f46cb68c" />

Catppuccini:
<img width="891" height="839" alt="{94629C77-88B7-4A1C-932C-790B17F69ADA}" src="https://github.com/user-attachments/assets/51778ed9-7f4c-46cb-b8f0-05b608807e35" />

Fixed:
<img width="777" height="916" alt="image" src="https://github.com/user-attachments/assets/f929c326-08b9-441e-bed9-033e01f3f750" />
