### PR TITLE
feat(codeberg): accessible header, landing page

### DIFF
--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -14,17 +14,18 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
+
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
 @-moz-document domain("codeberg.org") {
-  // GITEA
+  /* GITEA */
   @import (css)
     url("https://catppuccin.github.io/gitea/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
     (prefers-color-scheme: light);
   @import (css)
     url("https://catppuccin.github.io/gitea/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
     (prefers-color-scheme: dark);
-  // We need CodeMirror lib too!
+  /* @import url(CM_LIB_URL); */
 }
 
 @-moz-document domain("blog.codeberg.org") {
@@ -35,9 +36,11 @@
   @import url("https://prismjs.catppuccin.com/variables.important.css");
 }
 
-// @-moz-document domain("donate.codeberg.org") {
-//   @import url(PICO_LIB_URL);
-// }
+/*
+ * @-moz-document domain("donate.codeberg.org") {
+ *   @import url(PICO_LIB_URL);
+ * }
+ */
 
 @-moz-document domain("codeberg.org") {
   [data-theme="codeberg-dark"],
@@ -54,7 +57,10 @@
 
   #catppuccin(@flavor) {
     #lib.palette();
-    // #lib.defaults(); isn't needed, themed in upstream Gitea port.
+    /*
+     * #lib.defaults();
+     * This isn't needed, themed in upstream Gitea port.
+     */
 
     --color-body: @base;
     --color-nav-text: @crust;
@@ -242,7 +248,9 @@
           background-color: darken(@accent, 10%);
         }
       }
-    } // HOMEPAGE
+    }
+
+    /* HOMEPAGE */
     main {
       a.button {
         svg {
@@ -304,7 +312,9 @@
       }
 
       section#home-section-support {
-        color: @text; // Yellow buttons
+        color: @text;
+
+        /* Yellow buttons */
         div a {
           color: @base;
           text-shadow: -1px -2px 0 @yellow;
@@ -314,7 +324,9 @@
             text-shadow: -1px -2px 0 darken(@yellow, 10%);
             background-color: darken(@yellow, 5%);
           }
-        } // Your support helps us grow! :hearts:
+        }
+
+        /* Your support helps us grow! :hearts: */
         h3 svg.svg.codeberg-icon-hearts {
           path:nth-child(1) {
             fill: @peach !important;

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -18,29 +18,13 @@
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
 @-moz-document domain("codeberg.org") {
-  /* GITEA */
   @import (css)
     url("https://catppuccin.github.io/gitea/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
     (prefers-color-scheme: light);
   @import (css)
     url("https://catppuccin.github.io/gitea/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
     (prefers-color-scheme: dark);
-  /* @import url(CM_LIB_URL); */
 }
-
-@-moz-document domain("blog.codeberg.org") {
-  @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
-}
-
-@-moz-document domain("docs.codeberg.org") {
-  @import url("https://prismjs.catppuccin.com/variables.important.css");
-}
-
-/*
- * @-moz-document domain("donate.codeberg.org") {
- *   @import url(PICO_LIB_URL);
- * }
- */
 
 @-moz-document domain("codeberg.org") {
   [data-theme="codeberg-dark"],
@@ -57,10 +41,7 @@
 
   #catppuccin(@flavor) {
     #lib.palette();
-    /*
-     * #lib.defaults();
-     * This isn't needed, themed in upstream Gitea port.
-     */
+    // #lib.defaults(); // Not needed, themed in upstream Gitea port.
 
     --color-body: @base;
     --color-nav-text: @crust;
@@ -98,12 +79,24 @@
       }
     }
 
-    .sha.label.isSigned.isVerified {
-      color: @green;
-    }
+    .sha.label {
+      &.isSigned {
+        &.isVerified {
+          color: @green;
 
-    .sha.label.isSigned.isVerified .signature {
-      --color-light: fade(@green, 30%);
+          .signature {
+            --color-light: fade(@green, 30%);
+          }
+        }
+
+        .isWarning {
+          color: @red;
+
+          .signature {
+            --color-light: fade(@red, 30%);
+          }
+        }
+      }
     }
 
     /* HUNK HEADER */

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -89,7 +89,7 @@
           }
         }
 
-        .isWarning {
+        &.isWarning {
           color: @red;
 
           .signature {

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -68,19 +68,16 @@
     --color-link: @blue;
     --color-footer-text: @text;
 
-    .ui.secondary.menu .dropdown.item:hover,
-    .ui.secondary.menu a.item:hover,
-    .ui.secondary.menu a.active.item:hover {
-      background-color: var(--color-nav-hover-bg);
-    }
+    .ui.secondary.menu {
+      :is(.dropdown.item, a.item, a.active.item) {
+        &:hover {
+          background-color: var(--color-nav-hover-bg);
+        }
 
-    .ui.secondary.menu .dropdown.item:focus,
-    .ui.secondary.menu .dropdown.item:active,
-    .ui.secondary.menu a.item:focus,
-    .ui.secondary.menu a.item:active,
-    .ui.secondary.menu a.active.item:focus,
-    .ui.secondary.menu a.active.item:active {
-      background-color: var(--color-nav-active-bg);
+        &:is(:focus, :active) {
+          background-color: var(--color-nav-active-bg);
+        }
+      }
     }
 
     .ui.basic.red.buttons .button,

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -24,8 +24,10 @@
   @import (css)
     url("https://catppuccin.github.io/gitea/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
     (prefers-color-scheme: dark);
-
   // We need CodeMirror lib too!
+}
+
+@-moz-document domain("codeberg.org") {
   [data-theme="codeberg-dark"],
   [data-theme="codeberg-light"],
   [data-theme="codeberg-auto"] {
@@ -143,6 +145,31 @@
           color: @base !important;
         }
 
+        a.item.active,
+        details.dropdown > summary.active,
+        details.dropdown[open] > summary,
+        button.item.active {
+          background-color: @accent !important;
+          color: @base !important;
+        }
+
+        a.item.active:hover,
+        details.dropdown > summary.active:hover,
+        button.item.active:hover {
+          background-color: darken(@accent, 5%) !important;
+          color: @base !important;
+        }
+
+        a.item.active:focus,
+        a.item.active:active,
+        details.dropdown > summary.active:focus,
+        details.dropdown > summary.active:active,
+        button.item.active:focus,
+        button.item.active:active {
+          background-color: darken(@accent, 10%) !important;
+          color: @base !important;
+        }
+
         a.donation-pretty {
           --donation-pretty-gradient-color-1: @accent;
           --donation-pretty-gradient-color-2: darken(@accent, 5%);
@@ -168,10 +195,6 @@
 
       img[src^="/assets/img/svg/forgejo-wordmark"] {
         filter: @text-filter;
-      }
-
-      a.item.active {
-        color: @base !important;
       }
     }
 
@@ -298,4 +321,44 @@
   }
 }
 
-@-moz-document domain("donate.codeberg.org") {}
+@-moz-document domain("donate.codeberg.org") {
+  [data-theme="codeberg-dark"],
+  [data-theme="codeberg-light"],
+  [data-theme="codeberg-auto"] {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+
+    // TODO: import pico lib here once it's written.
+    --pico-background-color: @base;
+    --pico-color: @text;
+    --pico-text-selection-color: fade(@overlay2, 30%);
+    // etc...
+  }
+}
+
+@-moz-document domain("") {
+  [data-theme="codeberg-dark"],
+  [data-theme="codeberg-light"],
+  [data-theme="codeberg-auto"] {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+  }
+}

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -78,6 +78,12 @@
           background-color: var(--color-nav-active-bg);
         }
       }
+
+      &.pointing {
+        :is(.active.item, .dropdown.item:is(:hover, :focus)) {
+          color: var(--color-text-dark);
+        }
+      }
     }
 
     .ui.basic.red.buttons .button,
@@ -88,14 +94,6 @@
         border-color: var(--color-light-border);
         color: @crust;
       }
-    }
-
-    .ui.secondary.pointing.menu .active.item,
-    .ui.secondary.pointing.menu .active.item:hover,
-    .ui.secondary.pointing.menu .active.item:focus,
-    .ui.secondary.pointing.menu .dropdown.item:hover,
-    .ui.secondary.pointing.menu .dropdown.item:focus {
-      color: var(--color-text-dark);
     }
 
     .sha.label.isSigned.isVerified {

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -19,13 +19,25 @@
 @-moz-document domain("codeberg.org") {
   // GITEA
   @import (css)
-    url("https://catppuccin.github.io/gitea/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
+    url("http://localhost:8000/gitea/dist/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
     (prefers-color-scheme: light);
   @import (css)
-    url("https://catppuccin.github.io/gitea/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
+    url("http://localhost:8000/gitea/dist/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
     (prefers-color-scheme: dark);
   // We need CodeMirror lib too!
 }
+
+@-moz-document domain("blog.codeberg.org") {
+  @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css");
+}
+
+@-moz-document domain("docs.codeberg.org") {
+  @import url("https://prismjs.catppuccin.com/variables.important.css");
+}
+
+// @-moz-document domain("donate.codeberg.org") {
+//   @import url(PICO_LIB_URL);
+// }
 
 @-moz-document domain("codeberg.org") {
   [data-theme="codeberg-dark"],
@@ -318,47 +330,5 @@
         }
       }
     }
-  }
-}
-
-@-moz-document domain("donate.codeberg.org") {
-  [data-theme="codeberg-dark"],
-  [data-theme="codeberg-light"],
-  [data-theme="codeberg-auto"] {
-    @media (prefers-color-scheme: light) {
-      #catppuccin(@lightFlavor);
-    }
-
-    @media (prefers-color-scheme: dark) {
-      #catppuccin(@darkFlavor);
-    }
-  }
-
-  #catppuccin(@flavor) {
-    #lib.palette();
-
-    // TODO: import pico lib here once it's written.
-    --pico-background-color: @base;
-    --pico-color: @text;
-    --pico-text-selection-color: fade(@overlay2, 30%);
-    // etc...
-  }
-}
-
-@-moz-document domain("") {
-  [data-theme="codeberg-dark"],
-  [data-theme="codeberg-light"],
-  [data-theme="codeberg-auto"] {
-    @media (prefers-color-scheme: light) {
-      #catppuccin(@lightFlavor);
-    }
-
-    @media (prefers-color-scheme: dark) {
-      #catppuccin(@darkFlavor);
-    }
-  }
-
-  #catppuccin(@flavor) {
-    #lib.palette();
   }
 }

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -65,11 +65,13 @@
     --color-body: @base;
     --color-nav-text: @crust;
     --color-secondary-nav-bg: @surface0;
+    --color-nav-hover-bg: @surface1;
+    --color-nav-active-bg: @surface2;
     --color-link: @blue;
     --color-footer-text: @text;
 
     .ui.secondary.menu {
-      .dropdown.item, a.item, a.active.item {
+      .dropdown.item, .item, .active.item {
         &:hover {
           background-color: var(--color-nav-hover-bg);
         }

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -69,18 +69,18 @@
     --color-footer-text: @text;
 
     .ui.secondary.menu {
-      :is(.dropdown.item, a.item, a.active.item) {
+      .dropdown.item, a.item, a.active.item {
         &:hover {
           background-color: var(--color-nav-hover-bg);
         }
 
-        &:is(:focus, :active) {
+        &:active, &:focus {
           background-color: var(--color-nav-active-bg);
         }
       }
 
       &.pointing {
-        :is(.active.item, .dropdown.item:is(:hover, :focus)) {
+        .active.item, .dropdown.item:is(:hover, :focus) {
           color: var(--color-text-dark);
         }
       }
@@ -138,60 +138,53 @@
         details > summary,
         button {
           color: @text !important;
+
+          &.item {
+            &:hover {
+              background-color: @accent !important;
+              color: @base !important;
+            }
+
+            &:active, &:focus {
+              background-color: darken(@accent, 5%) !important;
+              color: @base !important;
+            }
+
+            &.active {
+              background-color: @accent !important;
+              color: @base !important;
+
+              &:hover {
+                background-color: darken(@accent, 5%) !important;
+                color: @base !important;
+              }
+
+              &:active, &:focus {
+                background-color: darken(@accent, 10%) !important;
+                color: @base !important;
+              }
+            }
+          }
         }
 
-        a.item:hover,
-        details.dropdown > summary:hover,
-        button.item:hover {
+        details.dropdown[open] > summary {
           background-color: @accent !important;
-          color: @base !important;
-        }
-
-        a.item:focus,
-        a.item:active,
-        details.dropdown > summary:focus,
-        details.dropdown > summary:active,
-        details.dropdown[open] > summary,
-        button.item:focus,
-        button.item:active {
-          background-color: darken(@accent, 5%) !important;
-          color: @base !important;
-        }
-
-        a.item.active,
-        details.dropdown > summary.active,
-        details.dropdown[open] > summary,
-        button.item.active {
-          background-color: @accent !important;
-          color: @base !important;
-        }
-
-        a.item.active:hover,
-        details.dropdown > summary.active:hover,
-        button.item.active:hover {
-          background-color: darken(@accent, 5%) !important;
-          color: @base !important;
-        }
-
-        a.item.active:focus,
-        a.item.active:active,
-        details.dropdown > summary.active:focus,
-        details.dropdown > summary.active:active,
-        button.item.active:focus,
-        button.item.active:active {
-          background-color: darken(@accent, 10%) !important;
           color: @base !important;
         }
 
         a.donation-pretty {
           --donation-pretty-gradient-color-1: @accent;
           --donation-pretty-gradient-color-2: darken(@accent, 5%);
-
           color: @base !important;
 
           &:hover {
             --donation-pretty-gradient-color-1: darken(@accent, 5%);
             --donation-pretty-gradient-color-2: darken(@accent, 10%);
+          }
+
+          &:active, &:focus {
+            --donation-pretty-gradient-color-1: darken(@accent, 10%);
+            --donation-pretty-gradient-color-2: darken(@accent, 15%);
           }
         }
       }
@@ -227,20 +220,21 @@
       }
 
       .language.button {
+        &:not(.active) {
+          &:hover {
+            color: @base;
+            background-color: darken(@accent, 5%);
+          }
+
+          &:active, &:focus {
+            color: @base;
+            background-color: darken(@accent, 10%);
+          }
+        }
+
         &.active {
           color: @base;
           background-color: @accent;
-        }
-
-        &:hover {
-          color: @base;
-          background-color: darken(@accent, 5%);
-        }
-
-        &:active,
-        &:focus {
-          color: @base;
-          background-color: darken(@accent, 10%);
         }
       }
     }
@@ -310,6 +304,7 @@
         color: @text;
 
         /* Yellow buttons */
+
         div a {
           color: @base;
           text-shadow: -1px -2px 0 @yellow;
@@ -322,6 +317,7 @@
         }
 
         /* Your support helps us grow! :hearts: */
+
         h3 svg.svg.codeberg-icon-hearts {
           path:nth-child(1) {
             fill: @peach !important;

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -14,25 +14,25 @@
 @var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
 @var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
 ==/UserStyle== */
-
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
 @-moz-document domain("codeberg.org") {
+  // GITEA
   @import (css)
     url("https://catppuccin.github.io/gitea/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
     (prefers-color-scheme: light);
   @import (css)
     url("https://catppuccin.github.io/gitea/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
     (prefers-color-scheme: dark);
-}
 
-@-moz-document domain("codeberg.org") {
+  // We need CodeMirror lib too!
   [data-theme="codeberg-dark"],
   [data-theme="codeberg-light"],
   [data-theme="codeberg-auto"] {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);
     }
+
     @media (prefers-color-scheme: dark) {
       #catppuccin(@darkFlavor);
     }
@@ -40,14 +40,28 @@
 
   #catppuccin(@flavor) {
     #lib.palette();
-    // #lib.defaults(); // Not needed, themed in upstream Gitea port.
+    // #lib.defaults(); isn't needed, themed in upstream Gitea port.
 
     --color-body: @base;
     --color-nav-text: @crust;
-    --color-nav-hover-bg: darken(@accent, 5%);
     --color-secondary-nav-bg: @surface0;
     --color-link: @blue;
     --color-footer-text: @text;
+
+    .ui.secondary.menu .dropdown.item:hover,
+    .ui.secondary.menu a.item:hover,
+    .ui.secondary.menu a.active.item:hover {
+      background-color: var(--color-nav-hover-bg);
+    }
+
+    .ui.secondary.menu .dropdown.item:focus,
+    .ui.secondary.menu .dropdown.item:active,
+    .ui.secondary.menu a.item:focus,
+    .ui.secondary.menu a.item:active,
+    .ui.secondary.menu a.active.item:focus,
+    .ui.secondary.menu a.active.item:active {
+      background-color: var(--color-nav-active-bg);
+    }
 
     .ui.basic.red.buttons .button,
     .ui.basic.red.button {
@@ -56,6 +70,33 @@
         background-color: @red;
         border-color: var(--color-light-border);
         color: @crust;
+      }
+    }
+
+    .ui.secondary.pointing.menu .active.item,
+    .ui.secondary.pointing.menu .active.item:hover,
+    .ui.secondary.pointing.menu .active.item:focus,
+    .ui.secondary.pointing.menu .dropdown.item:hover,
+    .ui.secondary.pointing.menu .dropdown.item:focus {
+      color: var(--color-text-dark);
+    }
+
+    .sha.label.isSigned.isVerified {
+      color: @green;
+    }
+
+    .sha.label.isSigned.isVerified .signature {
+      --color-light: fade(@green, 30%);
+    }
+
+    /* HUNK HEADER */
+    .tag-code,
+    .tag-code td {
+      color: @peach !important;
+      background-color: @surface0 !important;
+
+      &.lines-num {
+        background-color: @surface1 !important;
       }
     }
 
@@ -72,27 +113,71 @@
       }
     }
 
+    /* NAVBAR */
     #navbar {
+      background-color: var(--color-nav-bg) !important;
+
+      > .menu,
+      > .menu .menu {
+        a,
+        button,
+        details > summary {
+          color: @text;
+        }
+
+        a.item:hover,
+        details.dropdown > summary:hover,
+        button.item:hover {
+          background-color: @accent;
+          color: @base !important;
+        }
+
+        a.item:focus,
+        a.item:active,
+        details.dropdown > summary:focus,
+        details.dropdown > summary:active,
+        details.dropdown[open] > summary,
+        button.item:focus,
+        button.item:active {
+          background-color: darken(@accent, 5%);
+          color: @base !important;
+        }
+
+        a.donation-pretty {
+          --donation-pretty-gradient-color-1: @accent;
+          --donation-pretty-gradient-color-2: darken(@accent, 5%);
+
+          color: @base !important;
+
+          &:hover {
+            --donation-pretty-gradient-color-1: darken(@accent, 5%);
+            --donation-pretty-gradient-color-2: darken(@accent, 10%);
+          }
+        }
+      }
+
       a#navbar-logo {
         img {
+          #codeberg-logo(@accent);
+        }
+
+        &:hover img {
           #codeberg-logo(@base);
         }
       }
 
-      .menu {
-        > a, button, details > summary {
-          color: @base;
-        }
-
-        .donation-pretty {
-          --color-secondary-alpha-60: fade(darken(@accent, 10%), 60%)
-            !important;
-
-          &:hover {
-            background: darken(@accent, 3%) !important;
-          }
-        }
+      img[src^="/assets/img/svg/forgejo-wordmark"] {
+        filter: @text-filter;
       }
+
+      a.item.active {
+        color: @base !important;
+      }
+    }
+
+    /* Otherwise we've got @blue on @green, which is impossible to see :] */
+    .repository .ui.attached.isSigned.isVerified.bottom a strong {
+      color: @crust;
     }
 
     footer {
@@ -104,6 +189,113 @@
       a:hover {
         color: @blue !important;
       }
+
+      .language.button {
+        &.active {
+          color: @base;
+          background-color: @accent;
+        }
+
+        &:hover {
+          color: @base;
+          background-color: darken(@accent, 5%);
+        }
+
+        &:active,
+        &:focus {
+          color: @base;
+          background-color: darken(@accent, 10%);
+        }
+      }
+    } // HOMEPAGE
+    main {
+      a.button {
+        svg {
+          filter: drop-shadow(-1px -2px 0 @yellow);
+        }
+
+        &:hover svg {
+          filter: drop-shadow(-1px -2px 0 darken(@yellow, 10%));
+        }
+      }
+
+      header {
+        color: @text;
+
+        .header-social-links a {
+          color: @accent;
+
+          &:hover {
+            color: darken(@accent, 5%);
+          }
+        }
+
+        .header-logo img {
+          filter: @text-filter;
+        }
+      }
+
+      section#home-section-about {
+        color: @text;
+
+        .home-section-about-box-container {
+          .home-section-about-box {
+            background-image: linear-gradient(
+              to top,
+              fade(@accent, 30%) 40%,
+              fade(@accent, 40%)
+            );
+          }
+
+          .home-section-about-register-button-container a {
+            color: @base;
+            text-shadow: -1px -2px 0 @yellow;
+            background-color: @yellow;
+
+            &:hover {
+              text-shadow: -1px -2px 0 darken(@yellow, 10%);
+              background-color: darken(@yellow, 5%);
+            }
+          }
+        }
+
+        .home-section-about-container div {
+          color: @accent;
+
+          p.powered-by-forgejo a {
+            color: @accent;
+          }
+        }
+      }
+
+      section#home-section-support {
+        color: @text; // Yellow buttons
+        div a {
+          color: @base;
+          text-shadow: -1px -2px 0 @yellow;
+          background-color: @yellow;
+
+          &:hover {
+            text-shadow: -1px -2px 0 darken(@yellow, 10%);
+            background-color: darken(@yellow, 5%);
+          }
+        } // Your support helps us grow! :hearts:
+        h3 svg.svg.codeberg-icon-hearts {
+          path:nth-child(1) {
+            fill: @peach !important;
+          }
+
+          path:nth-child(2) {
+            fill: @yellow !important;
+          }
+
+          path:nth-child(3) {
+            fill: @sapphire !important;
+          }
+        }
+      }
     }
   }
 }
+
+@-moz-document domain("donate.codeberg.org") {}

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -19,10 +19,10 @@
 @-moz-document domain("codeberg.org") {
   // GITEA
   @import (css)
-    url("http://localhost:8000/gitea/dist/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
+    url("https://catppuccin.github.io/gitea/theme-catppuccin-@{lightFlavor}-@{accentColor}.css")
     (prefers-color-scheme: light);
   @import (css)
-    url("http://localhost:8000/gitea/dist/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
+    url("https://catppuccin.github.io/gitea/theme-catppuccin-@{darkFlavor}-@{accentColor}.css")
     (prefers-color-scheme: dark);
   // We need CodeMirror lib too!
 }

--- a/styles/codeberg/catppuccin.user.less
+++ b/styles/codeberg/catppuccin.user.less
@@ -120,15 +120,15 @@
       > .menu,
       > .menu .menu {
         a,
-        button,
-        details > summary {
-          color: @text;
+        details > summary,
+        button {
+          color: @text !important;
         }
 
         a.item:hover,
         details.dropdown > summary:hover,
         button.item:hover {
-          background-color: @accent;
+          background-color: @accent !important;
           color: @base !important;
         }
 
@@ -139,7 +139,7 @@
         details.dropdown[open] > summary,
         button.item:focus,
         button.item:active {
-          background-color: darken(@accent, 5%);
+          background-color: darken(@accent, 5%) !important;
           color: @base !important;
         }
 


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.
  - NEVERRRRRRRRRRRRRRRRRRRRRRRRRRR [angry anti-ai noises]

## 🔧 What does this fix? 🔧

<!--
Give a short description of the fixes/updates implemented in this pull request, and add "Closes #<ISSUE-NUMBER>" below for any relevant issues.
E.g. Fixes unthemed buttons on the home page.
-->

- [x] Makes the navbar mantle, with hover buttons as accent, it's cleaner and more accessible to read imo (less violently bright on accents like rosewater).
- [x] Adds the codeberg landing page theming. [Codeberg | About](https://codeberg.org/about)
- [x] Adds isWarning class for isSigned shasums which aren't verified.

## Troubles with this PR?

> Yes, actually! Here's a list of pages I _haven't_ themed, and WHY:

- so, docs.codeberg.org, relies a ton on *halfmoon, which is a theme loaded through bootstrap*. that's honestly gonna be quite painful to theme, without a dedicated library, which is gonna require a lot of work, because there's about 500 variables here that are all bound and tangled, and a lot are just duplicates that navigate to other vars, etc. **See halfmoon.css on that site.** This is writable, but we'll have to write a lib, which will then define the 500 or so variables.
  - As a secondary, uses PrismJS for syntax-highlighting.
- blogs.codeberg.org uses...*scoped halfmoon, scoped to its own codeberg-design module*, which...umm, somehow defines a whole new 1500 variables. That's just not gonna be fun. **See codeberg.css on that site.** This just isn't feasible, so either we just sloppily define what we can see, and patch as we go along, or we just ignore the website entirely. It's not a major subdomain that people want afaik?
  - As a secondary, uses Pygments for syntax-highlighting.
- donate.codeberg.org is the lightest, and uses pico, which you can see, **lies in pico.min.css which you can see on the site**. It's not hard to theme, but the *correct* thing to do in accordance with our own userstyle/lib modularisations, is to write a lib for pico, then import it. This one does have a very light solution but not something we should care about until we get a pico library, because it's not worth doing yet, and not something major, just like blogs.