### PR TITLE
chore(renovate): enable pin github actions digests

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["local>catppuccin/renovate-config"],
+  extends: ["local>catppuccin/renovate-config", "helpers:pinGitHubActionDigests"],
   packageRules: [
     // Deno keep releasing minor/patch releases for doc updates so disabling updates to the standard lib
     {


### PR DESCRIPTION
This is a recommended security practice for GitHub Actions these days. I think after merging Renvoate will start opening pull requests pinning each action to its digest.

See https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating.