### PR TITLE
fix(chatgpt): update dark theme selector to include OLED support

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -24,7 +24,7 @@
     #catppuccin(@lightFlavor);
   }
 
-  .dark {
+  .dark, .dark[data-oled] {
     #catppuccin(@darkFlavor);
   }
 


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

Adds support for ChatGPT's OLED dark theme by including the `[data-oled]` attribute selector alongside the existing `.dark` class selector.

## 🔍 Reproduction Steps 🔍

To verify the fix works:

1. Visit https://chatgpt.com/
2. Ensure the theme is set to "Dark" 
3. *Add the `data-oled` attribute to the `html` tag if needed*
4. The theme should now properly style the interface with the dark color scheme
