### PR TITLE
fix(chatgpt): inline code and code block backgrounds

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -89,7 +89,8 @@
 
       /* Markdown */
 
-      code:not([class]) {
+      /* inline code */
+      code:not(pre > code) {
         background-color: @surface0;
       }
 

--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -89,7 +89,7 @@
 
       /* Markdown */
 
-      /* inline code */
+      /* Inline code */
       code:not(pre > code) {
         background-color: @surface0;
       }


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

Fixes ChatGPT Markdown rendering by narrowing inline code styling. The selector now targets only inline `code` elements, preventing `pre > code` blocks from receiving the inline background style.

## 🔍 Reproduction Steps 🔍

1. Visit https://chatgpt.com/
2. Create or view a message containing a code block
   _(example prompt: `Generate an inline and code block example`)_
3. The code blocks render without inline background while inline code remain the same.

## Screenshots

<details>
<summary>Before</summary>
<img width="996" height="655" alt="image" src="https://github.com/user-attachments/assets/05ddbec8-8b77-4aaa-815b-acfe7d8604cc" />
</details>

<details>
<summary>After</summary>
<img width="996" height="655" alt="image" src="https://github.com/user-attachments/assets/2b2ca552-bd86-4f32-964f-36d13d7bf329" />
</details>
