### PR TITLE
fix(nixos-search): align theme behavior with upstream manual toggle

### DIFF
--- a/styles/nixos-search/catppuccin.user.less
+++ b/styles/nixos-search/catppuccin.user.less
@@ -18,13 +18,21 @@
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
 @-moz-document domain("search.nixos.org") {
-  :root {
+  :root:not([data-theme]) {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);
     }
     @media (prefers-color-scheme: dark) {
       #catppuccin(@darkFlavor);
     }
+  }
+
+  :root[data-theme="dark"] {
+    #catppuccin(@darkFlavor);
+  }
+
+  :root[data-theme="light"] {
+    #catppuccin(@lightFlavor);
   }
 
   #catppuccin(@flavor) {


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [x] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

NixOS Search now uses a persisted 3-way theme toggle (Auto/Light/Dark) via `data-theme` on `:root`, replacing browser-only `prefers-color-scheme` handling. This update aligns the userstyle’s theme behavior with that upstream change so manual theme selection is respected consistently.
Upstream PR: https://github.com/NixOS/nixos-search/pull/1274

## 🔍 Reproduction Steps 🔍

Visit search.nixos.org and search for something.
