### PR TITLE
fix(chatgpt): fix background

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -48,6 +48,8 @@
 
       --bg-tooltip: @crust;
 
+      --black: @base;
+      
       --main-surface-primary: @base;
       --main-surface-secondary: @surface0;
       --main-surface-tertiary: @surface1;


### PR DESCRIPTION
(This is my first PR to this repo, hope everything is fine, let me know!)

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

<!--
Give a short description of the fixes/updates implemented in this pull request, and add "Closes #<ISSUE-NUMBER>" below for any relevant issues.
E.g. Fixes unthemed buttons on the home page.
-->

This fixes the background not being themed some times by overriding the `black` variable as well.

## 🔍 Reproduction Steps 🔍

<!--
Provide a series of instruction steps, relevant URLs, and/or screenshots to be able to reproduce or demonstrate the underlying issue.
E.g. Unthemed button can be found in the navigation bar on https://example.com/pages/foo, by hovering over the third link in the header.
-->

For me, going to chatgpt.com resulted in the background being `#000` instead of the correct color.

<!-- You may want to use the following before/after table template to show your changes. Paste/move an image into the textbox and use the resulting <img> in the appropriate cell of the table. -->


| Before | After |
| ------ | ----- |
| <img width="2483" height="1184" alt="image" src="https://github.com/user-attachments/assets/aa6b2c72-68f3-4213-8402-ddc11a2a681d" /> |
<img width="2483" height="1184" alt="image" src="https://github.com/user-attachments/assets/bda8eb5d-4a54-4ed7-b45f-0c6b498a012f" /> |


