### PR TITLE
fix(chatgpt): increase selector specificity to resist variable overrides

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -80,6 +80,10 @@
       // chat input prompt border
       --shadow-color-1: fade(@mantle, 50%);
       --shadow-color-2: fade(@text, 80%);
+      
+      .__menu-item[data-sidebar-item] {
+        --menu-item-highlighted: @surface0;
+      }
 
       .__menu-item[data-color="danger"] {
         --menu-item-highlighted: fade(@red, 20%);

--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -24,7 +24,7 @@
     #catppuccin(@lightFlavor);
   }
 
-  .dark, .dark[data-oled] {
+  .dark {
     #catppuccin(@darkFlavor);
   }
 
@@ -32,7 +32,7 @@
     #lib.palette();
     #lib.defaults();
 
-    &, .popover {
+    * {
       --text-primary: @text;
       --text-secondary: @subtext1;
       --text-tertiary: @subtext0;


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

Increases selector specificity in the userstyle so variables are not overridden.
This addresses the same issue as #2249, but fixes it by raising selector specificity rather than changing variables.
Both approaches are acceptable, but this should hopefully also withstand future ChatGPT changes.

## 🔍 Reproduction Steps 🔍

1. Visit https://chatgpt.com/
2. Confirm Catppuccin colors are consistently applied.

Just for reference, this is the selector/variable that broke the background color *(again)*.

```css
html.dark[data-oled], html.dark[data-oled]:not(:where(.light,.light *)) {
    --main-surface-primary: var(--black)
}
```