### PR TITLE
fix (gmail): Update unread emails to match background and hover of read emails

### DIFF
--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -420,6 +420,17 @@
     .aT5-aOt-I-JX-Jw, .aT5-aOt-I-JX-atM {
       background-color: @surface0;
     }
+    /* Search bar */
+    .FOBRw-I {
+      background-color: @accent;
+    }
+    .bas, .aJf {
+      background-color: @surface0;
+      color: @text;
+    }
+    .gb_0e > svg > path, .gb_We > svg > path:first-child, .gb_Ve > svg > path:first-child {
+      fill: @accent;
+    }
     /* Inbox categories */
     .aKx > .aKz {
       color: @text;

--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -438,6 +438,16 @@
     }
     .h0 {
       color: @subtext1;
+    } 
+    /* Inbox background */
+    .aeJ {
+      background-color: @surface0;
+    }
+      
+    /* Welcome to Gmail popup */
+    .O6 {
+      background-color: @surface2;    
+      border-color: @surface1;
     }
     /* Inbox footer */
     .md.mj,

--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -410,6 +410,16 @@
         filter: @text-filter;
       }
     }
+    /* Navigation for GSuite sidebar */
+    .aT5-aOt-I-JX-atM-Kv, .brC-bsf-aT5-aOt, .nH > .aUx > .bAw > .brC-aT5-aOt-Jw, .bcf, .tRcrsc {
+      background-color: @mantle;
+      border-color: @surface1;
+      color: @text;
+    }
+    /* Navigation icons for GSuite sidebar */
+    .aT5-aOt-I-JX-Jw, .aT5-aOt-I-JX-atM {
+      background-color: @surface0;
+    }
     /* Inbox categories */
     .aKx > .aKz {
       color: @text;

--- a/styles/gmail/catppuccin.user.less
+++ b/styles/gmail/catppuccin.user.less
@@ -477,9 +477,20 @@
           0 0 6px 2px @surface1;
       }
     }
-    /* Read email text */
+    /* Unread emails */
     .zE {
+      background-color: @base;
       color: @text;
+
+      box-shadow: inset 0 -1px 0 0 @surface0;
+
+      &:hover {
+        box-shadow:
+          inset 1px 0 0 @surface0,
+          inset -1px 0 0 @surface0,
+          0 0 4px 0 @surface1,
+          0 0 6px 2px @surface1;
+      }
     }
     // Select icon
     .xY > .T-Jo,


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

Added the hover effect and background colour to unread email class.

## 🔍 Reproduction Steps 🔍

<!--
Provide a series of instruction steps, relevant URLs, and/or screenshots to be able to reproduce or demonstrate the underlying issue.
E.g. Unthemed button can be found in the navigation bar on https://example.com/pages/foo, by hovering over the third link in the header.
-->

<!-- You may want to use the following before/after table template to show your changes. Paste/move an image into the textbox and use the resulting <img> in the appropriate cell of the table. -->

| Before | After |
| ------ | ----- |
|<img width="1330" height="459" alt="before" src="https://github.com/user-attachments/assets/3fd967a7-87a5-46c2-8c70-0edf86a55ed3" /> | <img width="1338" height="432" alt="after" src="https://github.com/user-attachments/assets/ec0f4509-216a-4acc-af30-3d301b3887f8" /> |
| Unread emails had a background matching the background of the page behind, not the same background as read emails. Unread emails missing hover effect. | Unread and read emails have the same background and hover effect. |


