### PR TITLE
fix(google): clean ai chat overlays and apply catppuccin gradient

### DIFF
--- a/styles/google/catppuccin.user.less
+++ b/styles/google/catppuccin.user.less
@@ -86,6 +86,56 @@
       --Nsm0ce: @blue;
     }
 
+    /* ai chat: remove gradient overlay */
+    .Zze5V {
+      background: none !important;
+    }
+
+    /* ai chat: remove container + wrapper gradients (except RDmXvc, handled below) */
+    .RdNMvc,
+    .LrrQLb,
+    .Jkzafd {
+      background: none !important;
+      background-image: none !important;
+    }
+
+    /* ai chat: normalize layered backgrounds to avoid seams */
+    .RdNMvc,
+    .inVh0e,
+    .oOpie,
+    .FR7ZSc {
+      background-color: @base !important;
+    }
+
+    /* ai chat: clean spacer overlay layer */
+    .zNsLfb {
+      background: none !important;
+    }
+
+    /* ai chat: layout improvements + catppuccin styling */
+    .in7vHe:not(.BgrTif) {
+      border: 1px solid @overlay0 !important;
+    }
+
+    /* ai chat: subtle hover effect */
+    .in7vHe:not(.BgrTif):hover {
+      background-color: lighten(@mantle, 3%) !important;
+    }
+
+    /* ai chat: subtle collapsed state tint (catppuccin version of google rgb) */
+    .in7vHe.BgrTif {
+      background-color: fade(@crust, 25%) !important;
+    }
+
+    /* ai chat: catppuccin gradient overlay (replaces google white fade) */
+    .RDmXvc {
+      background-image: linear-gradient(
+        transparent 0px,
+        fade(@base, 80%) 52px,
+        @base 80px
+      ) !important;
+    }
+
     /* header background */
     .CvDJxb {
       background-color: @base !important;


### PR DESCRIPTION
### description

improves google ai chat styling when using catppuccin theme.

### changes

- removed gradient overlay (`.Zze5V`)
- removed container and wrapper gradients
- normalized layered backgrounds to eliminate visible seams
- cleaned spacer overlay layer (`.zNsLfb`)
- replaced default white gradient (`.RDmXvc`) with catppuccin-based gradient
- added subtle border and hover styling for ai response container
- added catppuccin-based tint for collapsed state

### result

- removes visual artifacts and edge seams
- preserves original google fade behavior
- integrates ai chat more cleanly with catppuccin palette
- improves visual consistency and readability

### notes

- this implementation is primarily optimized for **latte (light flavor)**
- the gradient replacement uses `@base`, which matches the light theme background
- in **dark flavors (frappé, macchiato, mocha)** the gradient may require further adjustment