### PR TITLE
fix(google): refine AI chat styling and gradients

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -75,6 +75,7 @@ collaborators:
   - &koibtw koibtw
   - &TheAnonymousCrusher TheAnonymousCrusher
   - &42willow 42willow
+  - &AvielSkrypnyk AvielSkrypnyk
 
 userstyles:
   advent-of-code:
@@ -354,7 +355,7 @@ userstyles:
     categories: [search_engine]
     icon: google
     color: sapphire
-    current-maintainers: []
+    current-maintainers: [*AvielSkrypnyk]
   google-drive:
     name: Google Drive
     link: https://drive.google.com

--- a/styles/google/catppuccin.user.less
+++ b/styles/google/catppuccin.user.less
@@ -86,6 +86,56 @@
       --Nsm0ce: @blue;
     }
 
+    /* ai chat: remove gradient overlay */
+    .Zze5V {
+      background: none !important;
+    }
+
+    /* ai chat: remove container + wrapper gradients (except RDmXvc, handled below) */
+    .RdNMvc,
+    .LrrQLb,
+    .Jkzafd {
+      background: none !important;
+      background-image: none !important;
+    }
+
+    /* ai chat: normalize layered backgrounds to avoid seams */
+    .RdNMvc,
+    .inVh0e,
+    .oOpie,
+    .FR7ZSc {
+      background-color: @base !important;
+    }
+
+    /* ai chat: clean spacer overlay layer */
+    .zNsLfb {
+      background: none !important;
+    }
+
+    /* ai chat: layout improvements + catppuccin styling */
+    .in7vHe:not(.BgrTif) {
+      border: 1px solid @overlay0 !important;
+    }
+
+    /* ai chat: subtle hover effect */
+    .in7vHe:not(.BgrTif):hover {
+      background-color: lighten(@mantle, 3%) !important;
+    }
+
+    /* ai chat: subtle collapsed state tint (catppuccin version of google rgb) */
+    .in7vHe.BgrTif {
+      background-color: fade(@crust, 25%) !important;
+    }
+
+    /* ai chat: catppuccin gradient overlay (replaces google white fade) */
+    .RDmXvc {
+      background-image: linear-gradient(
+        transparent 0px,
+        fade(@base, 80%) 52px,
+        @base 80px
+      ) !important;
+    }
+
     /* header background */
     .CvDJxb {
       background-color: @base !important;

--- a/styles/google/catppuccin.user.less
+++ b/styles/google/catppuccin.user.less
@@ -86,20 +86,17 @@
       --Nsm0ce: @blue;
     }
 
-    /* ai chat: remove gradient overlay */
-    .Zze5V {
-      background: none !important;
-    }
-
-    /* ai chat: remove container + wrapper gradients (except RDmXvc, handled below) */
+    /* ai chat: remove gradients */
+    .Zze5V,
     .RdNMvc,
     .LrrQLb,
-    .Jkzafd {
+    .Jkzafd,
+    .zNsLfb {
       background: none !important;
       background-image: none !important;
     }
 
-    /* ai chat: normalize layered backgrounds to avoid seams */
+    /* ai chat: normalize backgrounds */
     .RdNMvc,
     .inVh0e,
     .oOpie,
@@ -107,31 +104,27 @@
       background-color: @base !important;
     }
 
-    /* ai chat: clean spacer overlay layer */
-    .zNsLfb {
-      background: none !important;
-    }
-
-    /* ai chat: layout improvements + catppuccin styling */
+    /* ai chat: response container */
     .in7vHe:not(.BgrTif) {
       border: 1px solid @overlay0 !important;
+      background-color: @mantle !important;
     }
 
-    /* ai chat: subtle hover effect */
+    /* ai chat: hover */
     .in7vHe:not(.BgrTif):hover {
-      background-color: lighten(@mantle, 3%) !important;
+      background-color: @surface0 !important;
     }
 
-    /* ai chat: subtle collapsed state tint (catppuccin version of google rgb) */
+    /* ai chat: collapsed state */
     .in7vHe.BgrTif {
-      background-color: fade(@crust, 25%) !important;
+      background-color: fade(@crust, 35%) !important;
     }
 
-    /* ai chat: catppuccin gradient overlay (replaces google white fade) */
+    /* ai chat: gradient overlay */
     .RDmXvc {
       background-image: linear-gradient(
         transparent 0px,
-        fade(@base, 80%) 52px,
+        fade(@base, 90%) 52px,
         @base 80px
       ) !important;
     }

--- a/styles/google/catppuccin.user.less
+++ b/styles/google/catppuccin.user.less
@@ -93,7 +93,6 @@
     .Jkzafd,
     .zNsLfb {
       background: none !important;
-      background-image: none !important;
     }
 
     /* ai chat: normalize backgrounds */
@@ -106,13 +105,14 @@
 
     /* ai chat: response container */
     .in7vHe:not(.BgrTif) {
-      border: 1px solid @overlay0 !important;
-      background-color: @mantle !important;
-    }
+      & {
+        border-color: @overlay0 !important;
+        background-color: @mantle !important;
+      }
 
-    /* ai chat: hover */
-    .in7vHe:not(.BgrTif):hover {
-      background-color: @surface0 !important;
+      &:hover {
+        background-color: @surface0 !important;
+      }
     }
 
     /* ai chat: collapsed state */


### PR DESCRIPTION
## 📝 Checklist

- [x] I have read and followed Catppuccin's userstyle contributing guidelines.
- [x] I used AI (or AI-assistance) to improve wording in this PR description.

---

## 🔧 What does this fix?

Improves Catppuccin styling for Google AI chat by refining gradients, overlays, and background consistency.

Fixes issues where default Google styles conflicted with Catppuccin colors, causing visual inconsistencies and reduced readability.

---

## 🔍 Reproduction Steps

1. Open Google Search with AI chat enabled  
2. Interact with the AI chat panel  
3. Compare collapsed and expanded states  

---

### Before

**Collapsed**  
<img width="2560" height="730" alt="image" src="https://github.com/user-attachments/assets/e4190827-b5e8-4bb9-8eeb-6422e987357b" />

**Expanded**  
<img width="2560" height="1316" alt="image" src="https://github.com/user-attachments/assets/7b48476d-1c1c-4117-b539-908e226fc948" />

---

### After

**Collapsed**  
<img width="2560" height="730" alt="image" src="https://github.com/user-attachments/assets/fafa020f-b511-43a8-b01b-ede24e076e7c" />

**Expanded**  
<img width="2560" height="1316" alt="image" src="https://github.com/user-attachments/assets/4eed51bf-cf72-42ca-8639-a65e2e9492b3" />