### PR TITLE
fix(whatsapp-web): #side background gaps

### DIFF
--- a/styles/whatsapp-web/catppuccin.user.less
+++ b/styles/whatsapp-web/catppuccin.user.less
@@ -115,6 +115,8 @@
     #WDS(modal-backdrop-solid, @crust);
 
     #WDS(surface-default, @mantle);
+    --background-default: var(--WDS-surface-default);
+    --search-container-background: var(--WDS-surface-default);
     #WDS(surface-emphasized, @base);
     #WDS(surface-elevated-default, @base);
     #WDS(surface-elevated-emphasized, mix(@text, @base, @emphasize));


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

<!--
Give a short description of the fixes/updates implemented in this pull request, and add "Closes #<ISSUE-NUMBER>" below for any relevant issues.
E.g. Fixes unthemed buttons on the home page.
-->

Fixes some gaps in the background inside the `#side` container

## 🔍 Reproduction Steps 🔍

<!--
Provide a series of instruction steps, relevant URLs, and/or screenshots to be able to reproduce or demonstrate the underlying issue.
E.g. Unthemed button can be found in the navigation bar on https://example.com/pages/foo, by hovering over the third link in the header.
-->

<!-- You may want to use the following before/after table template to show your changes. Paste/move an image into the textbox and use the resulting <img> in the appropriate cell of the table. -->

| Before | After |
| ------ | ----- |
| <img width="1524" height="1455" alt="WhatsApp Web (before)" src="https://github.com/user-attachments/assets/da0ee66d-fc87-42c5-999a-985360df8ea1" /> | <img width="1524" height="1455" alt="WhatsApp Web (after)" src="https://github.com/user-attachments/assets/87eafe27-5060-410f-ae58-b78c08d7fbd4" /> |
