### PR TITLE
fix(desmos): fix lots of unstyled text

### DIFF
--- a/styles/desmos/catppuccin.user.less
+++ b/styles/desmos/catppuccin.user.less
@@ -1258,7 +1258,7 @@
     }
     
     /* tutorial (internally called tour/trip) */
-    .dcg-trip-interior {
+    .dcg-trip-interior, .dcg-trip-content {
       background: @base !important;
       color: @text;
     }

--- a/styles/desmos/catppuccin.user.less
+++ b/styles/desmos/catppuccin.user.less
@@ -1256,11 +1256,6 @@
     .dcg-slider {
       --dcg-custom-secondary-text-color: @accent;
     }
-
-    /* desmodder: disable set primary color */
-    .dsm-category-container > div[key="set-primary-color"] {
-      display: none !important;
-    }
     
     /* tutorial (internally called tour/trip) */
     .dcg-trip-interior {

--- a/styles/desmos/catppuccin.user.less
+++ b/styles/desmos/catppuccin.user.less
@@ -1301,7 +1301,7 @@
 
     /* desmodder: intellisense current variable highlight */
     .pfc-param-selected {
-      background: @accent !important;
+      background: @surface0 !important;
       color: @text !important;
     }
 

--- a/styles/desmos/catppuccin.user.less
+++ b/styles/desmos/catppuccin.user.less
@@ -176,7 +176,7 @@
       background: @overlay1 !important;
     }
 
-    .dcg-keypad-btn.dcg-btn-light-on-gray, .dcg-ctrl-toggle-cover {
+    .dcg-keypad-btn.dcg-btn-light-on-gray, .dcg-keypad-btn.dcg-btn-light-gray, .dcg-ctrl-toggle-cover {
       background: @mantle !important;
       border-color: @surface0 !important;
     }
@@ -512,7 +512,7 @@
       text-shadow: none !important;
     }
 
-    .dcg-btn-light-gray {
+    .dcg-btn-light-gray, .dcg-btn-light-on-gray {
       background: @mantle !important;
       box-shadow: none !important;
       border-color: @text !important;
@@ -544,6 +544,7 @@
       border-bottom-color: @overlay2 !important;
     }
 
+    .dcg-checkbox__box,
     .dcg-axis-label,
     .dcg-clickable-menu-row:has(.dcg-input-label) > .dcg-mathquill-wrapper {
       --dcg-accent-color: @accent !important;
@@ -1240,6 +1241,78 @@
     /* "powered by" text above logo */
     .dcg-powered-by {
       color: @text !important;
+    }
+
+    /* saved graph titles */
+    .dcg-checkbox__content {
+      color: @accent;
+    }
+    /* saved folders */
+    .dcg-saved-graphs {
+      --dcg-folder-background-color: @mantle;
+    }
+
+    /* slider bounds */
+    .dcg-slider {
+      --dcg-custom-secondary-text-color: @accent;
+    }
+
+    /* desmodder: disable set primary color */
+    .dsm-category-container > div[key="set-primary-color"] {
+      display: none !important;
+    }
+    
+    /* tutorial (internally called tour/trip) */
+    .dcg-trip-interior {
+      background: @base !important;
+      color: @text;
+    }
+
+    /* folders */
+    .dcg-folder {
+      --dcg-folder-background-color: @mantle !important;
+    }
+    .dcg-folder-item-count {
+      color: @subtext1;
+    }
+    .dcg-my-graphs-modal__back-btn-text,
+    .dcg-folder__name,
+    .dcg-my-graphs-modal__folder-header > .dcg-my-graphs-modal-saved-graphs-header,
+    .dcg-example-gallery__heading,
+    .dcg-saved-graphs-tile__title {
+      color: @accent;
+    }
+
+    /* folders search (no items found) */
+    .dcg-my-graphs-modal-empty-state__heading {
+      color: @accent !important;
+    }
+    .dcg-my-graphs-modal-empty-state__no-search-results {
+      color: @subtext1;
+    }
+
+    /* new graph button */
+    .dcg-new-my-graphs-item__button {
+      color: @text !important;
+    }
+    .dropdown-option-container > .dcg-dropdown-choice[role="menuitem"] {
+      color: @text;
+    }
+
+    /* update to new behavior button (write f()=random() then enter/exit text mode) */
+    .dcg-update-behavior-btn {
+      border-color: @surface0 !important;
+    }
+
+    /* desmodder: intellisense current variable highlight */
+    .pfc-param-selected {
+      background: @accent !important;
+      color: @text !important;
+    }
+
+    /* line numbers */
+    .dcg-num {
+      color: @text;
     }
   }
 }


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

## 🔧 What does this fix? 🔧

<!--
Give a short description of the fixes/updates implemented in this pull request, and add "Closes #<ISSUE-NUMBER>" below for any relevant issues.
E.g. Fixes unthemed buttons on the home page.
-->

- Slider (#2228)
<img width="115" height="70" alt="image" src="https://github.com/user-attachments/assets/21bdd91c-3f63-4a24-a45e-2a9e3ea5e7dc" />

- Legacy Buttons
<img width="404" height="116" alt="image" src="https://github.com/user-attachments/assets/89436dea-66d2-4d9e-9b1a-457307b30d1f" />
This spacing is an issue in vanilla desmos too.

- Built-in functions
<img width="854" height="518" alt="image" src="https://github.com/user-attachments/assets/72e0c6f3-d3ec-49fd-b36a-7a1badb9f638" />

- Saved graph folders & titles
<img width="492" height="412" alt="image" src="https://github.com/user-attachments/assets/d25ed3e9-576a-421e-be12-b7cb80a9ed11" />

- Example graphs
(i forgot to take a screenshot of this one, but the titles are the same unreadable color as saved graphs)

- Line numbers (#2227)
<img width="47" height="119" alt="image" src="https://github.com/user-attachments/assets/358293f4-90c4-449b-a751-96f6111e1e6e" />

- Tutorial (#2234)
<img width="371" height="160" alt="image" src="https://github.com/user-attachments/assets/0a0c762b-3c16-4eaa-b887-35e463505ccb" />

- (desmodder) IntelliSense
<img width="125" height="87" alt="image" src="https://github.com/user-attachments/assets/054233a0-80ab-4539-a421-a5d075f657a4" />

- the new graph button
<img width="198" height="299" alt="image" src="https://github.com/user-attachments/assets/627f1f5d-917c-4307-89bf-20cca10e3d43" />

- graph type filters
<img width="153" height="240" alt="image" src="https://github.com/user-attachments/assets/f6a736b7-86b8-4b82-844d-e729c7e163b7" />

- Saved graph checkbox is not the accent color
<img width="38" height="49" alt="image" src="https://github.com/user-attachments/assets/1ae00268-0671-4698-a088-d5fcf50e278a" />


## 🔍 Reproduction Steps 🔍

<!--
Provide a series of instruction steps, relevant URLs, and/or screenshots to be able to reproduce or demonstrate the underlying issue.
E.g. Unthemed button can be found in the navigation bar on https://example.com/pages/foo, by hovering over the third link in the header.
-->

Most of these things you can find just by viewing them in Desmos. For the legacy randomization button, enable the Desmodder text mode plugin, type `f()=random()`, enter text mode, and finally exit text mode

<!-- You may want to use the following before/after table template to show your changes. Paste/move an image into the textbox and use the resulting <img> in the appropriate cell of the table. -->

## Fixes

| Fix | Image |
| ---: | ----- |
| Slider | <img width="85" height="66" alt="image" src="https://github.com/user-attachments/assets/5336bee5-afbf-49d1-b07c-1f9f7589e244" /> |
| Legacy Buttons | <img width="411" height="93" alt="image" src="https://github.com/user-attachments/assets/3f6f4060-220f-4498-bfdf-d7555dba56c9" /> |
| Built-in functions | <img width="299" height="341" alt="image" src="https://github.com/user-attachments/assets/812951cb-40da-4f78-a38b-de8f22252f2b" /> |
| Saved graph folders & titles | <img width="264" height="353" alt="image" src="https://github.com/user-attachments/assets/31aaf5ca-62be-4a99-8012-ff3b91a4d705" /> |
| Example graphs | <img width="493" height="385" alt="image" src="https://github.com/user-attachments/assets/8d60309e-64d7-447c-bd71-39b775b0e3b0" /> |
| Line numbers | <img width="54" height="99" alt="image" src="https://github.com/user-attachments/assets/933319b5-7142-4377-bd7a-64b4f87ebb61" /> |
| Tutorial | <img width="232" height="56" alt="image" src="https://github.com/user-attachments/assets/fc626126-06e9-47ae-8c68-812a5d7563ec" /> |
| IntelliSense | <img width="104" height="49" alt="image" src="https://github.com/user-attachments/assets/43a9bc0a-fc94-44c2-bf2f-0eda3f5b908b" /> |
| New graph | <img width="193" height="289" alt="image" src="https://github.com/user-attachments/assets/764243d6-de18-4c0f-8dfc-0a4ee1715af5" /> |
| graph type filters | <img width="125" height="204" alt="image" src="https://github.com/user-attachments/assets/1bc51bda-ea2d-4643-892a-e64d9c451983" /> |
| Checkboxes | <img width="29" height="33" alt="image" src="https://github.com/user-attachments/assets/c1583296-0731-422b-b959-70d5672f7993" />   I personally don't believe the border around the checkbox is needed, but vanilla Desmos has that too so I won't remove it. |

Closes #2227, closes #2228, closes #2234