### PR TITLE
feat(pydata-readthedocs): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -75,6 +75,7 @@ collaborators:
   - &koibtw koibtw
   - &TheAnonymousCrusher TheAnonymousCrusher
   - &42willow 42willow
+  - &jonathanbreitg jonathanbreitg
 
 userstyles:
   advent-of-code:
@@ -781,6 +782,12 @@ userstyles:
     color: mauve
     note: Set Proton Mail's built-in theme to 'Snow' if you're using Latte or 'Carbon' if you're using the others.
     current-maintainers: [*soya-daizu]
+  pydata-readthedocs:
+    name: PyData readthedocs
+    link: https://pydata-sphinx-theme.readthedocs.io
+    categories: [development]
+    color: teal
+    current-maintainers: [*jonathanbreitg]
   pypi:
     name: PyPI
     link: https://pypi.org

--- a/styles/pydata-readthedocs/catppuccin.user.less
+++ b/styles/pydata-readthedocs/catppuccin.user.less
@@ -1,0 +1,131 @@
+/* ==UserStyle==
+@name PyData readthedocs Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/pydata-readthedocs
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/pydata-readthedocs
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/pydata-readthedocs/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Apydata-readthedocs
+@description Soothing pastel theme for PyData readthedocs
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@import "https://userstyles.catppuccin.com/lib/lib.less";
+
+@-moz-document domain("readthedocs.io"), domain("numpy.org"), domain("scipy.org"), domain("pydata.org"),domain("matplotlib.org"),domain("scikit-learn.org"),domain("bokeh.org") {
+  @import url("https://python.catppuccin.com/pygments/catppuccin-variables.important.css"); //provides the syntax highlighting for pygment code blocks
+
+  //PyData has a native light/dark toggle button via html[data-theme]
+  html[data-theme="light"] {
+    #catppuccin(@lightFlavor);
+  }
+  html[data-theme="dark"] {
+    #catppuccin(@darkFlavor);
+  }
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+    #lib.defaults();
+    #lib.css-variables();
+    scrollbar-color: @overlay0 @mantle;
+
+    @fade_percentage: 15%;
+    @accent_percentage: 8%;
+    /* most variable names here are mostly self-explanatory, i used darken() for hover/pressed and fade() for tinting.
+     The percentages (15% and 8%) were chosen by trial and error, seeing what most closely matched the difference between the base
+     color and the darkened/tinted on the unthemed pydata sites and what looked good to me. */
+
+    --pst-color-primary: @accent; //mostly links
+    --pst-color-primary-bg: fade(@accent, @fade_percentage); 
+    --pst-color-primary-highlight: darken(@accent, @accent_percentage);
+    --pst-color-primary-text: @base; /* guide: On Accent -> Base */
+    --pst-color-primary-highlight-text: @base;
+    --pst-color-secondary: @mauve; //secondary accent, i haven't found a site where this is set and used, however it could potentially be somewhat problematic if the accent is mauve 
+    --pst-color-secondary-bg: fade(@mauve, @fade_percentage);
+    --pst-color-secondary-highlight: darken(@mauve, @accent_percentage);
+    --pst-color-secondary-text: @base;
+    --pst-color-secondary-highlight-text: @base;
+    --pst-color-accent: @lavender; //active borders, focus rings
+    --pst-color-accent-bg: fade(@lavender, @fade_percentage);
+    --pst-color-info: @teal; //info boxes, admonitions
+    --pst-color-info-bg: fade(@teal, @fade_percentage);
+    --pst-color-info-highlight: darken(@teal, @accent_percentage);
+    --pst-color-info-text: @base;
+    --pst-color-info-highlight-text: @base;
+    --pst-color-success: @green; //success boxes, admonitions
+    --pst-color-success-bg: fade(@green, @fade_percentage);
+    --pst-color-success-highlight: darken(@green, @accent_percentage);
+    --pst-color-success-text: @base;
+    --pst-color-success-highlight-text: @base;
+    --pst-color-warning: @yellow; //warning boxes, admonitions
+    --pst-color-warning-bg: fade(@yellow, @fade_percentage);
+    --pst-color-warning-highlight: darken(@yellow, @accent_percentage);
+    --pst-color-warning-text: @base;
+    --pst-color-warning-highlight-text: @base;
+    --pst-color-danger: @red; //error/danger boxes, admonitions
+    --pst-color-danger-bg: fade(@red, @fade_percentage);
+    --pst-color-danger-highlight: darken(@red, @accent_percentage);
+    --pst-color-danger-text: @base;
+    --pst-color-danger-highlight-text: @base;
+    --pst-color-attention: @yellow; //attention boxes, admonitions. peach also works
+    --pst-color-attention-bg: fade(@yellow, @fade_percentage);
+    --pst-color-attention-text: @base;
+    --pst-color-attention-highlight-text: @base;
+    
+    --pst-color-background: @base; //main background color
+    --pst-color-on-background: @mantle; //secondary panes
+    --pst-color-surface: @crust; //background of copy button in code blocks, and background of fields in function declerations in API reference, crust looks better than surface0 for both
+    --pst-color-on-surface: @text;
+    --pst-color-text-base: @text; //main body text
+    --pst-color-text-muted: @subtext0; //sub headlines, subtext
+    --pst-color-border: @surface1; //border color for code blocks
+    --pst-color-border-muted: @surface0; //not used anywhere as far as i saw
+    --pst-color-shadow: fade(@crust, 40%); //shadow the top navbar casts on the body, 40% looked good but arbitrary
+    --pst-color-blockquote-notch: @overlay0; 
+    --pst-color-inline-code: @red; //never actually used as far as i saw
+    --pst-color-link-hover: darken(@accent,@accent_percentage); 
+    --pst-color-link-higher-contrast: @sapphire;
+    --pst-color-target: fade(@accent,@fade_percentage); //background in API reference titles for functions
+    --pst-color-table: @text;
+    --pst-color-table-row-hover-bg: fade(@accent, @fade_percentage); 
+    --pst-color-table-inner-border: @surface0;
+    --pst-color-heading: @text; 
+    --pst-color-link: @accent; 
+    --pst-color-table-heading-bg: @surface0; //surface element
+    --pst-color-table-outer-border: @surface1;
+    --pst-color-table-row-zebra-high-bg: @mantle; 
+    --pst-color-table-row-zebra-low-bg: @base;
+
+    
+    //sphinx-gallery variables, which are sometimes used for dataframe tables, script outputs, download buttons etc. Although very rarely
+    --sg-text-color: @text; 
+    --sg-background-color: @base; 
+    --sg-code-background-color: @red; //code block background for SG only, never actually used
+    --sg-tr-odd-color: @mantle; //zebra step, mirrors pst zebra mapping 
+    --sg-tr-hover-color: fade(@accent, @fade_percentage);
+    --sg-tooltip-foreground: @accent;
+    --sg-tooltip-background: @surface0; 
+    --sg-tooltip-border: @surface1 transparent;
+    --sg-thumb-box-shadow-color: fade(@crust, @fade_percentage);
+    --sg-thumb-hover-border: @accent; 
+    --sg-script-out: @subtext0; 
+    --sg-script-pre: @mantle;
+    --sg-pytb-foreground: @text;
+    --sg-pytb-background: fade(@red, @fade_percentage); 
+    --sg-pytb-border-color: @red;
+
+    //these numbers are purely what looked good to me, i was unable to find any close enough examples to match 
+    --sg-download-a-background-color: fade(@green, @fade_percentage) !important; 
+    --sg-download-a-background-image: linear-gradient(to bottom, fade(@green, 18%), fade(@green, 10%)) !important;
+    --sg-download-a-border-color: 1px solid fade(@green, 40%) !important; 
+    --sg-download-a-color: @text !important;
+    --sg-download-a-hover-background-color: fade(@green, 25%) !important;
+    --sg-download-a-hover-box-shadow-1: fade(@crust, @fade_percentage) !important;
+    --sg-download-a-hover-box-shadow-2: fade(@text, 25%) !important;
+  }
+}


### PR DESCRIPTION
<!-- Fill in the details for your userstyle below (e.g. website is "FooBar" and the URL is "https://foobar.com"). -->

**Website**: sites themed with the PyData sphinx theme (numpy,scipy,pydata,matplotlib,scikit,bokeh) 

**URL**: readthedocs.io, numpy.org, scipy.org, pydata.org, matplotlib.org, scikit-learn.org, bokeh.org

**Description**:

<!--
Give a short description of the website that you have themed.
E.g. YouTube is a video sharing platform that allows users to upload, view, and share videos.

You should also attach some screenshots of the themed website, show it off!
-->
PyData is a common theme used for the documentation of many popular python projects, especially in scientific computing. It's based on the sphinx theme for readthedocs.

before and after examples: 
<img width="2539" height="1418" alt="Screenshot_20260718_161248" src="https://github.com/user-attachments/assets/d1803665-1de9-4356-93f4-4738e94cd885" />
<img width="2542" height="1416" alt="Screenshot_20260718_161231" src="https://github.com/user-attachments/assets/39c50f4a-76f9-44e2-bd24-3c2b4914154d" />
<img width="1072" height="200" alt="Screenshot_20260718_161715" src="https://github.com/user-attachments/assets/2e66ffea-b1c7-4ee2-bb00-6db29aef82aa" />
<img width="1061" height="198" alt="Screenshot_20260718_161702" src="https://github.com/user-attachments/assets/8a743974-6e9d-4aa9-b99c-005d49963bc5" />
<img width="1125" height="710" alt="image" src="https://github.com/user-attachments/assets/3aa833b4-4d62-4462-88ef-3f817859f465" />
<img width="1116" height="705" alt="image" src="https://github.com/user-attachments/assets/44581cd9-d7ab-477a-b1ce-b95df27c31dd" />






## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

<!-- Please let us know for reviewing purposes whether or not your pull request was created in whole or in part using AI/LLMs. -->

- [ ] I used AI (or AI-assistance) for this change.

---

- [x] I have read and followed Catppuccin's [userstyle submission guidelines](https://userstyles.catppuccin.com/contributing/creating-userstyles/).
- [x] I have made a new directory underneath `/styles/<name-of-website>`.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have named the userstyle `catppuccin.user.less` within the new directory.
  - [x] I have followed the [template](https://github.com/catppuccin/userstyles/blob/main/template/catppuccin.user.less) and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have updated the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.

## 💬 Comments 💬

<!--
Include any difficulties you had theming this port, or any general comments that would be useful for the reviewer to know.
Feel free to leave this section empty if you don't have anything more to say.
-->

The main problem I need help with and am unsure of how to solve is efficiently applying the theme on all the different PyData sites. There are a lot and many of them are hosted on domains which don't reference readthedocs or Pydata (such as `numpy.org`). It would be easiest to simply apply the theme on all domains, the CSS variables would only matter for sites which use the PyData theme, this is what I'm doing on my local version and I didn't notice any performance hit at least on my machine, but obviously this isn't a sustainable method for theming so for this PR I included any sites hosted on readthedocs.io and the most popular projects I found that used this theme. If there is a better solution please suggest it. 

Other than that I was unable to find any standardized values for darkening and fading elements (like hovering over a button, link, or background for elements that use part of the color palette), I tried to follow the [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md), but I don't think it specifies a standardized approach for that, and other styles are inconsistent from what I've seen, so I ended up picking those values by eye. If there is something i missed please tell me and I'll fix it.

Other arbitrary choices and what the CSS variables are used for are documented in the comments of the Userstyle.