### PR TITLE
feat: add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM denoland/deno:bin-2.9.3 AS deno
+FROM mcr.microsoft.com/devcontainers/typescript-node:24
+COPY --from=deno /deno /usr/local/bin/deno

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"name": "Deno",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// Install git-lfs as it is required to push to the repo
+	"postCreateCommand": "sudo apt update && sudo apt install -y git-lfs && git lfs install",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"justjavac.vscode-deno-extensionpack"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,13 +15,13 @@
 	"postCreateCommand": "sudo apt update && sudo apt install -y git-lfs && git lfs install",
 
 	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"justjavac.vscode-deno-extensionpack"
-			]
-		}
-	}
+	// "customizations": {
+	// 	"vscode": {
+	// 		"extensions": [
+	// 			"justjavac.vscode-deno-extensionpack"
+	// 		]
+	// 	}
+	// }
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"


### PR DESCRIPTION
Adds a .devcontainer configuration to be used in GitHub Codespaces and VSCode containers.

References:
- Development containers - https://containers.dev/
- [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers)
- [Introduction to dev containers - GitHub Docs](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers)