### PR TITLE
chore(pnpm): migrate to 11.15.1 and pin version in package.json

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,6 @@ jobs:
         uses: withastro/action@a4407e937037e68022f04ae1c068d3634f08bc8d # v4
         with:
           path: ./docs
-          package-manager: pnpm@10.14.0
 
   deploy:
     needs: build

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@11.15.1",
+  "engines": {
+    "pnpm": ">=11.8.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,12 @@
   "private": true,
   "type": "module",
   "version": "0.0.1",
-  "packageManager": "pnpm@11.15.1",
-  "engines": {
-    "pnpm": ">=11.8.0"
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=11.8.0 <12.0.0",
+      "onFail": "error"
+    }
   },
   "scripts": {
     "dev": "astro dev",

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
Migrates pnpm to 11.15.1 and pins the version in package.json.

The version mismatch between CI and local enviornments has been creating issues with working with the documentation project, as in [pnpm 11.x](https://pnpm.io/blog/releases/11.0) onlyBuiltDependencies and related parameters were dropped and replaced with allowBuilds.

In local enviornments, often times the latest version of pnpm would be installed on the local enviornment, which mismatched with the CI, which was locked to a 10.x version. By defining an engines and packageManager field, it avoids mismatch and enforces using a recent enough version of pnpm for the new configuration options.
