### PR TITLE
fix(chatgpt): correct user message text color

### DIFF
--- a/styles/chatgpt/catppuccin.user.less
+++ b/styles/chatgpt/catppuccin.user.less
@@ -62,6 +62,7 @@
       --interactive-border-focus: @overlay0;
 
       --theme-user-msg-bg: @surface0;
+      --theme-user-msg-text: @text;
       --theme-submit-btn-bg: @accent;
       --theme-submit-btn-text: @base;
 


### PR DESCRIPTION
## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).
- [x] I used AI (or AI-assistance) for this change.

5.6 sol ultra was used.

## 🔧 What does this fix? 🔧

Sets ChatGPT's `--theme-user-msg-text` custom property to Catppuccin's `@text` color beside the existing user-message background variable. This prevents ChatGPT's upstream default from rendering user messages with black text.

Closes #2298

## 🔍 Reproduction Steps 🔍

1. Enable the Catppuccin userstyle on `https://chatgpt.com`.
2. Open a conversation containing a user message.
3. Confirm that the user-message text uses the selected Catppuccin flavor's text color.

## ✅ Verification

- `deno fmt --check styles/chatgpt/catppuccin.user.less`
- `deno task lint styles/chatgpt`
- `deno task lint`
- `deno task test` — 7 passed
