### PR TITLE
feat(scripts): improve library module dev server

### DIFF
--- a/docs/src/content/docs/contributing/library-modules.md
+++ b/docs/src/content/docs/contributing/library-modules.md
@@ -3,4 +3,28 @@ title: Library Modules
 description: Reference for library modules.
 ---
 
-Coming soon.
+Library modules live in the repository's [`lib`](https://github.com/catppuccin/userstyles/tree/main/lib) directory and are hosted at `https://userstyles.catppuccin.com/lib/`. Userstyles should always import the hosted URL so that published styles work outside a local checkout.
+
+## Developing locally
+
+The development server lets a userstyle use your local library files without changing its checked-in imports. It serves a transformed copy of the selected userstyle on the loopback interface and adds a library checksum to each import so that Stylus notices library changes.
+
+1. [Install Deno](https://docs.deno.com/runtime/getting_started/installation/) and clone this repository.
+2. From the repository root, start the server with a userstyle slug or path:
+
+   ```sh
+   deno task serve github
+   # Equivalent: deno task serve styles/github
+   ```
+
+3. Open the URL printed by the command in your browser and install or update it with Stylus. Follow the [hot reloading guide](/contributing/tips-and-tricks/hot-reloading/) if live reloading is not already enabled.
+4. Edit the selected userstyle or files under `lib/`. The server rebuilds the served userstyle automatically.
+5. Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the server.
+
+The server listens only on `127.0.0.1` and uses port 8000 by default. If that port is occupied, select another one:
+
+```sh
+deno task serve --port 8123 github
+```
+
+Run `deno task serve --help` to see all supported arguments.

--- a/scripts/serve/main.test.ts
+++ b/scripts/serve/main.test.ts
@@ -1,0 +1,157 @@
+import { assertEquals, assertNotEquals, assertThrows } from "@std/assert";
+
+import {
+  calculateLibChecksum,
+  createRequestHandler,
+  main,
+  parseServeArgs,
+  rewriteLibraryImports,
+} from "@/serve/main.ts";
+
+Deno.test("parseServeArgs accepts userstyle slugs and paths", () => {
+  assertEquals(parseServeArgs(["github"]), {
+    help: false,
+    port: 8000,
+    userstyle: "github",
+  });
+  assertEquals(
+    parseServeArgs(["--port", "8123", "styles\\github\\catppuccin.user.less"]),
+    {
+      help: false,
+      port: 8123,
+      userstyle: "github",
+    },
+  );
+  assertEquals(parseServeArgs(["--help"]), { help: true });
+});
+
+Deno.test("parseServeArgs rejects ambiguous or unsafe arguments", () => {
+  assertThrows(
+    () => parseServeArgs([]),
+    Error,
+    "Expected exactly one userstyle argument",
+  );
+  assertThrows(
+    () => parseServeArgs(["github", "youtube"]),
+    Error,
+    "Expected exactly one userstyle argument",
+  );
+  assertThrows(
+    () => parseServeArgs(["../github"]),
+    Error,
+    "Invalid userstyle",
+  );
+  assertThrows(
+    () => parseServeArgs(["--port", "0", "github"]),
+    Error,
+    "Invalid port",
+  );
+  assertThrows(
+    () => parseServeArgs(["--unknown", "github"]),
+    Error,
+    "Unknown option",
+  );
+});
+
+Deno.test("rewriteLibraryImports localizes only library imports", () => {
+  const source = `@import "https://userstyles.catppuccin.com/lib/lib.less";
+@import (reference) 'https://userstyles.catppuccin.com/lib/module.less?old=1';
+/* https://userstyles.catppuccin.com/lib/comment.less */
+@source "https://userstyles.catppuccin.com/styles/example";`;
+
+  assertEquals(
+    rewriteLibraryImports(source, "http://127.0.0.1:8123", "abcdef123456"),
+    `@import "http://127.0.0.1:8123/lib/lib.less?v=abcdef";
+@import (reference) 'http://127.0.0.1:8123/lib/module.less?v=abcdef';
+/* https://userstyles.catppuccin.com/lib/comment.less */
+@source "https://userstyles.catppuccin.com/styles/example";`,
+  );
+});
+
+Deno.test("calculateLibChecksum is independent of directory iteration order", async () => {
+  const first = await Deno.makeTempDir();
+  const second = await Deno.makeTempDir();
+
+  try {
+    await Deno.writeTextFile(`${first}/a.less`, "alpha");
+    await Deno.writeTextFile(`${first}/b.less`, "beta");
+    await Deno.writeTextFile(`${second}/b.less`, "beta");
+    await Deno.writeTextFile(`${second}/a.less`, "alpha");
+
+    assertEquals(
+      await calculateLibChecksum(first),
+      await calculateLibChecksum(second),
+    );
+
+    await Deno.writeTextFile(`${second}/a.less`, "changed");
+    assertNotEquals(
+      await calculateLibChecksum(first),
+      await calculateLibChecksum(second),
+    );
+  } finally {
+    await Deno.remove(first, { recursive: true });
+    await Deno.remove(second, { recursive: true });
+  }
+});
+
+Deno.test("createRequestHandler serves the generated userstyle", async () => {
+  const handler = createRequestHandler({
+    getUserstyleContents: () => "generated contents",
+    libPath: "lib",
+    userstyleRoute: "/styles/github/catppuccin.user.less",
+  });
+
+  const response = await handler(
+    new Request("http://127.0.0.1/styles/github/catppuccin.user.less"),
+  );
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("cache-control"), "no-store");
+  assertEquals(response.headers.get("content-type"), "text/css; charset=utf-8");
+  assertEquals(await response.text(), "generated contents");
+
+  const notFound = await handler(new Request("http://127.0.0.1/unknown"));
+  assertEquals(notFound.status, 404);
+});
+
+Deno.test("main serves a localized userstyle and shuts down", async () => {
+  const portProbe = Deno.listen({ hostname: "127.0.0.1", port: 0 });
+  const port = (portProbe.addr as Deno.NetAddr).port;
+  portProbe.close();
+
+  const stop = new AbortController();
+  const running = main(["--port", port.toString(), "github"], stop.signal);
+  const userstyleUrl =
+    `http://127.0.0.1:${port}/styles/github/catppuccin.user.less`;
+
+  try {
+    let response: Response | undefined;
+    for (let attempt = 0; attempt < 40; attempt++) {
+      try {
+        response = await fetch(userstyleUrl);
+        break;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+
+    assertEquals(response?.status, 200);
+    const contents = await response!.text();
+    assertEquals(
+      contents.includes(`http://127.0.0.1:${port}/lib/lib.less?v=`),
+      true,
+    );
+    assertEquals(
+      contents.includes(
+        '@import "https://userstyles.catppuccin.com/lib/lib.less"',
+      ),
+      false,
+    );
+
+    const library = await fetch(`http://127.0.0.1:${port}/lib/lib.less`);
+    assertEquals(library.status, 200);
+    await library.text();
+  } finally {
+    stop.abort();
+    await running;
+  }
+});

--- a/scripts/serve/main.ts
+++ b/scripts/serve/main.ts
@@ -1,111 +1,264 @@
-import { parseArgs } from "@std/cli";
-import { serveDir } from "@std/http/file-server";
 import { debounce } from "@std/async/debounce";
-import { createHash } from "node:crypto";
-
+import { parseArgs } from "@std/cli/parse-args";
+import { serveDir } from "@std/http/file-server";
 import * as path from "@std/path";
+import { createHash } from "node:crypto";
 
 import { REPO_ROOT } from "@/constants.ts";
 
-const args = parseArgs(Deno.args, {});
-const userstyle = args._[0]
-  ?.toString()
-  .match(
-    /(?<base>styles\/)?(?<userstyle>[a-z0-9_\-.]+)(?<trailing>\/)?(?<file>catppuccin\.user\.less)?/,
-  )?.groups?.userstyle;
-if (!userstyle) throw new Error("Invalid userstyle argument");
+const DEFAULT_PORT = 8000;
+const HOSTNAME = "127.0.0.1";
+const USERSTYLE_FILENAME = "catppuccin.user.less";
+const REMOTE_ORIGIN = "https://userstyles.catppuccin.com";
+const LIB_IMPORT_PATTERN = new RegExp(
+  `(@import\\s+(?:\\([^)]*\\)\\s*)?["'])${
+    REMOTE_ORIGIN.replaceAll(
+      ".",
+      "\\.",
+    )
+  }(/lib/[^"'?#\\s]+\\.less)(?:\\?[^"'\\s]*)?(["'])`,
+  "gi",
+);
 
-const server = Deno.serve({
-  onListen() {
-    // Disable unnecessary post-startup log.
-  },
-}, (req: Request) => {
-  const pathname = new URL(req.url).pathname;
+export const HELP_TEXT = `Usage: deno task serve [options] <userstyle>
 
-  if (pathname.startsWith("/lib")) {
-    return serveDir(req, {
-      fsRoot: "lib",
-      urlRoot: "lib",
-    });
+Serve a userstyle and the local library modules for Stylus live reloading.
+
+Arguments:
+  <userstyle>            A slug or path such as github or styles/github
+
+Options:
+  -p, --port <port>      Loopback port to use (default: ${DEFAULT_PORT})
+  -h, --help             Show this help`;
+
+export type ServeCliOptions =
+  | { help: true }
+  | { help: false; port: number; userstyle: string };
+
+export function parseUserstyleName(input: string): string {
+  const normalized = input.replaceAll("\\", "/").replace(/\/+$/, "");
+  const match =
+    /^(?:styles\/)?(?<userstyle>[a-z0-9][a-z0-9._-]*)(?:\/catppuccin\.user\.less)?$/
+      .exec(normalized);
+
+  if (!match?.groups?.userstyle) {
+    throw new Error(
+      `Invalid userstyle '${input}'. Expected a slug or path such as github or styles/github.`,
+    );
   }
 
-  return new Response("404: Not Found", {
-    status: 404,
+  return match.groups.userstyle;
+}
+
+export function parseServeArgs(args: string[]): ServeCliOptions {
+  const parsed = parseArgs(args, {
+    alias: {
+      help: "h",
+      port: "p",
+    },
+    boolean: ["help"],
+    default: {
+      port: DEFAULT_PORT.toString(),
+    },
+    string: ["port"],
+    unknown(option, key) {
+      if (key !== undefined) throw new Error(`Unknown option '${option}'.`);
+      return true;
+    },
   });
-});
 
-const userstylePath = path.join(
-  REPO_ROOT,
-  "styles",
-  userstyle,
-  "catppuccin.user.less",
-);
+  if (parsed.help) return { help: true };
 
-const libPath = path.join(
-  REPO_ROOT,
-  "lib",
-);
-
-const tempUserstylePath = await Deno.makeTempFile({
-  prefix: "userstyle_",
-  suffix: ".user.less",
-});
-
-async function calculateLibChecksum(): Promise<string> {
-  const files = [];
-  for await (const entry of Deno.readDir(libPath)) {
-    if (entry.isFile) {
-      files.push(path.join(libPath, entry.name));
-    }
+  if (parsed._.length !== 1) {
+    throw new Error(
+      "Expected exactly one userstyle argument. Run 'deno task serve --help' for usage.",
+    );
   }
+
+  const port = Number(parsed.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(
+      `Invalid port '${parsed.port}'. Expected an integer from 1 to 65535.`,
+    );
+  }
+
+  return {
+    help: false,
+    port,
+    userstyle: parseUserstyleName(parsed._[0].toString()),
+  };
+}
+
+export async function calculateLibChecksum(libPath: string): Promise<string> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(libPath)) {
+    if (entry.isFile) files.push(entry.name);
+  }
+  files.sort();
 
   const hash = createHash("sha256");
   for (const file of files) {
-    const content = await Deno.readTextFile(file);
+    const content = await Deno.readTextFile(path.join(libPath, file));
+    hash.update(file);
+    hash.update("\0");
     hash.update(content);
+    hash.update("\0");
   }
 
   return hash.digest("hex");
 }
 
-let lastLibChecksum = await calculateLibChecksum();
-
-async function updateTempUserstyle() {
-  let contents = await Deno.readTextFile(userstylePath);
-  /* Appends a query parameter suffix to import URLs from userstyles.catppuccin.com, containing the library modules content checksum.  */
-  const importRegex =
-    /(@import\s+"https:\/\/userstyles\.catppuccin\.com\/lib\/[^\s]+\.less")/g;
-  contents = contents.replace(importRegex, (match) => {
-    return match.replace(
-      /(\.less)/,
-      `$1?v=${lastLibChecksum.slice(0, 6)}`,
-    );
-  });
-
-  /* Then replace the remote userstyles.catppuccin.com host with the local(host) server URL for these imports. */
-  contents = contents.replaceAll(
-    "https://userstyles.catppuccin.com",
-    `http://localhost:${server.addr.port}`,
+export function rewriteLibraryImports(
+  contents: string,
+  serverOrigin: string,
+  libChecksum: string,
+): string {
+  const checksum = libChecksum.slice(0, 6);
+  return contents.replace(
+    LIB_IMPORT_PATTERN,
+    (_match, prefix: string, libUrl: string, suffix: string) =>
+      `${prefix}${serverOrigin}${libUrl}?v=${checksum}${suffix}`,
   );
-
-  await Deno.writeTextFile(tempUserstylePath, contents);
 }
 
-updateTempUserstyle();
+interface RequestHandlerOptions {
+  getUserstyleContents: () => string;
+  libPath: string;
+  userstyleRoute: string;
+}
 
-console.log(`[serve] ${userstyle} userstyle served at '${tempUserstylePath}'`);
+export function createRequestHandler(
+  options: RequestHandlerOptions,
+): (request: Request) => Response | Promise<Response> {
+  return (request) => {
+    const pathname = new URL(request.url).pathname;
 
-const reload = debounce(() => {
-  console.log(
-    `[serve]: reloaded ${userstyle} userstyle`,
-  );
-  updateTempUserstyle();
-}, 200);
+    if (pathname === options.userstyleRoute) {
+      return new Response(
+        request.method === "HEAD" ? null : options.getUserstyleContents(),
+        {
+          headers: {
+            "cache-control": "no-store",
+            "content-type": "text/css; charset=utf-8",
+          },
+        },
+      );
+    }
 
-const watcher = Deno.watchFs([userstylePath, libPath]);
-for await (const event of watcher) {
-  if (event.paths.some((path) => path.startsWith(libPath))) {
-    lastLibChecksum = await calculateLibChecksum();
+    if (pathname === "/lib" || pathname.startsWith("/lib/")) {
+      return serveDir(request, {
+        fsRoot: options.libPath,
+        quiet: true,
+        urlRoot: "lib",
+      });
+    }
+
+    return new Response("404: Not Found", { status: 404 });
+  };
+}
+
+async function assertUserstyleExists(userstylePath: string): Promise<void> {
+  try {
+    const info = await Deno.stat(userstylePath);
+    if (!info.isFile) throw new Error();
+  } catch {
+    throw new Error(`Userstyle not found at '${userstylePath}'.`);
   }
-  reload();
+}
+
+export async function main(
+  args = Deno.args,
+  stopSignal?: AbortSignal,
+): Promise<void> {
+  const options = parseServeArgs(args);
+  if (options.help) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  const userstylePath = path.join(
+    REPO_ROOT,
+    "styles",
+    options.userstyle,
+    USERSTYLE_FILENAME,
+  );
+  const libPath = path.join(REPO_ROOT, "lib");
+  await assertUserstyleExists(userstylePath);
+
+  const serverOrigin = `http://${HOSTNAME}:${options.port}`;
+  const userstyleRoute = `/styles/${options.userstyle}/${USERSTYLE_FILENAME}`;
+  let servedUserstyle = "";
+
+  const rebuildUserstyle = async () => {
+    const [contents, checksum] = await Promise.all([
+      Deno.readTextFile(userstylePath),
+      calculateLibChecksum(libPath),
+    ]);
+    servedUserstyle = rewriteLibraryImports(contents, serverOrigin, checksum);
+  };
+  await rebuildUserstyle();
+
+  const server = Deno.serve(
+    {
+      hostname: HOSTNAME,
+      onListen() {
+        // The URL below is more useful than Deno's default startup log.
+      },
+      port: options.port,
+    },
+    createRequestHandler({
+      getUserstyleContents: () => servedUserstyle,
+      libPath,
+      userstyleRoute,
+    }),
+  );
+
+  console.log(
+    `[serve] ${options.userstyle} is available at ${serverOrigin}${userstyleRoute}`,
+  );
+  console.log("[serve] Press Ctrl+C to stop.");
+
+  let activeReload = Promise.resolve();
+  const reload = debounce(() => {
+    activeReload = rebuildUserstyle()
+      .then(() => console.log(`[serve] Reloaded ${options.userstyle}.`))
+      .catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[serve] Reload failed: ${message}`);
+      });
+  }, 200);
+
+  const watcher = Deno.watchFs([userstylePath, libPath]);
+  let stopping = false;
+  const stop = () => {
+    if (stopping) return;
+    stopping = true;
+    watcher.close();
+  };
+  const signals: Deno.Signal[] = ["SIGINT"];
+  if (Deno.build.os !== "windows") signals.push("SIGTERM");
+  for (const signal of signals) Deno.addSignalListener(signal, stop);
+  if (stopSignal?.aborted) stop();
+  else stopSignal?.addEventListener("abort", stop, { once: true });
+
+  try {
+    for await (const _event of watcher) reload();
+  } finally {
+    reload.clear();
+    stopSignal?.removeEventListener("abort", stop);
+    for (const signal of signals) Deno.removeSignalListener(signal, stop);
+    if (!stopping) watcher.close();
+    await activeReload;
+    await server.shutdown();
+  }
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[serve] ${message}`);
+    Deno.exitCode = 1;
+  }
 }


### PR DESCRIPTION
Closes #2293

## Summary

- serve the selected userstyle at a predictable loopback URL while rewriting hosted library imports to the local server
- add validated CLI arguments, a custom port option, helpful output, and clean shutdown without a temporary userstyle file
- document the library-module development workflow and add focused unit and integration coverage

## Validation

- `deno task test` — 13 passed
- `deno task lint`
- `deno check scripts/**/*.ts`
- `deno fmt --check scripts/serve/main.ts scripts/serve/main.test.ts docs/src/content/docs/contributing/library-modules.md`
- `pnpm build` in `docs` — 18 pages built and all internal links valid
- LSP diagnostics — no findings in the three changed files