### PR TITLE
feat(apple-music): init

### DIFF
--- a/scripts/userstyles.yml
+++ b/scripts/userstyles.yml
@@ -75,6 +75,7 @@ collaborators:
   - &koibtw koibtw
   - &TheAnonymousCrusher TheAnonymousCrusher
   - &42willow 42willow
+  - &scarcekoi scarcekoi
 
 userstyles:
   advent-of-code:
@@ -120,6 +121,12 @@ userstyles:
     color: green
     link: https://github.com/httpjamesm/AnonymousOverflow
     current-maintainers: [*ImenaOphelia]
+  apple-music:
+    name: Apple Music
+    categories: [music]
+    color: red
+    link: https://music.apple.com
+    current-maintainers: [*scarcekoi]
   arch-wiki:
     name: Arch Wiki
     link: https://wiki.archlinux.org

--- a/styles/apple-music/catppuccin.user.less
+++ b/styles/apple-music/catppuccin.user.less
@@ -77,13 +77,11 @@
     --systemHeaderMaterialSover: fade(@mantle, 80%) !important;
     --systemToolbarTitlebarMaterialSover: fade(@mantle, 80%) !important;
 
-    /* Scrollbars */
     * {
+      /* Scrollbars */
       scrollbar-color: @surface1 @mantle !important;
-    }
 
-    /* Accent variables, and variables Apple re-declares on the element */
-    * {
+      /* Accent variables, and variables Apple re-declares on the element */
       --keyColor: @accent !important;
       --keyColor-rgb: #lib.rgbify(@accent) [] !important;
       --keyColor-rollover: lighten(@accent, 5%) !important;

--- a/styles/apple-music/catppuccin.user.less
+++ b/styles/apple-music/catppuccin.user.less
@@ -1,0 +1,34 @@
+/* ==UserStyle==
+@name Apple Music Catppuccin
+@namespace github.com/catppuccin/userstyles/styles/apple-music
+@homepageURL https://github.com/catppuccin/userstyles/tree/main/styles/apple-music
+@version 2000.01.01
+@updateURL https://github.com/catppuccin/userstyles/raw/main/styles/apple-music/catppuccin.user.less
+@supportURL https://github.com/catppuccin/userstyles/issues?q=is%3Aopen+is%3Aissue+label%3Aapple-music
+@description Soothing pastel theme for Apple Music
+@author Catppuccin
+@license MIT
+
+@preprocessor less
+@var select lightFlavor "Light Flavor" ["latte:Latte*", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha"]
+@var select darkFlavor "Dark Flavor" ["latte:Latte", "frappe:Frappé", "macchiato:Macchiato", "mocha:Mocha*"]
+@var select accentColor "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve*", "red:Red", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Gray"]
+==/UserStyle== */
+
+@import "https://userstyles.catppuccin.com/lib/lib.less";
+
+@-moz-document domain("music.apple.com") {
+  :root {
+    @media (prefers-color-scheme: light) {
+      #catppuccin(@lightFlavor);
+    }
+    @media (prefers-color-scheme: dark) {
+      #catppuccin(@darkFlavor);
+    }
+  }
+
+  #catppuccin(@flavor) {
+    #lib.palette();
+    #lib.defaults();
+  }
+}

--- a/styles/apple-music/catppuccin.user.less
+++ b/styles/apple-music/catppuccin.user.less
@@ -17,7 +17,7 @@
 
 @import "https://userstyles.catppuccin.com/lib/lib.less";
 
-@-moz-document domain("music.apple.com") {
+@-moz-document url-prefix("https://music.apple.com") {
   :root {
     @media (prefers-color-scheme: light) {
       #catppuccin(@lightFlavor);
@@ -30,5 +30,219 @@
   #catppuccin(@flavor) {
     #lib.palette();
     #lib.defaults();
+
+    /* Background and structure */
+    --pageBG: @base !important;
+    --pageBG-rgb: #lib.rgbify(@base) [] !important;
+    --opaqueShelfBG: @mantle !important;
+    --fallbackMaterialBG: fade(@mantle, 97%) !important;
+    --shelfBG: fade(@surface0, 15%) !important;
+    --genericJoeColor: @surface1 !important;
+
+    /* Text */
+    --systemPrimary: fade(@text, 85%) !important;
+    --systemPrimary-vibrant: @text !important;
+    --systemSecondary: fade(@subtext1, 55%) !important;
+    --systemSecondary-vibrant: @subtext0 !important;
+    --systemTertiary: fade(@overlay0, 25%) !important;
+    --systemQuaternary: fade(@surface1, 15%) !important;
+    --systemQuinary: fade(@surface0, 8%) !important;
+
+    /* Borders and dividers */
+    --labelDivider: fade(@surface2, 20%) !important;
+    --vibrantDivider: fade(@surface2, 25%) !important;
+
+    /* Player */
+    --playerBackground: fade(@mantle, 88%) !important;
+    --playerBackgroundFallback: fade(@mantle, 97%) !important;
+    --playerLCDBGFill: @surface0 !important;
+    --playerMissingArtworkBg: @surface1 !important;
+    --playerMissingArtworkIcon: @surface2 !important;
+    --playerScrubberFill: @accent !important;
+    --playerScrubberTrack: fade(@surface1, 20%) !important;
+    --playerPlatterButtonBGFill: @accent !important;
+    --playerPlatterButtonIconFill: @base !important;
+    --playerDropShadow2: fade(@crust, 10%) !important;
+
+    /* Navigation */
+    --segmentedControlBG: fade(@surface0, 20%) !important;
+    --segmentedControlSelectedBG: @surface1 !important;
+
+    /* Tracklist */
+    --tracklistHoverColor: fade(@surface0, 8%) !important;
+    --tracklistAltRowColor: fade(@surface0, 3%) !important;
+
+    /* Materials */
+    --systemStandardThickMaterialSover: fade(@mantle, 72%) !important;
+    --systemHeaderMaterialSover: fade(@mantle, 80%) !important;
+    --systemToolbarTitlebarMaterialSover: fade(@mantle, 80%) !important;
+
+    /* Scrollbars */
+    * {
+      scrollbar-color: @surface1 @mantle !important;
+    }
+
+    /* Accent variables, and variables Apple re-declares on the element */
+    * {
+      --keyColor: @accent !important;
+      --keyColor-rgb: #lib.rgbify(@accent) [] !important;
+      --keyColor-rollover: lighten(@accent, 5%) !important;
+      --keyColor-pressed: lighten(@accent, 5%) !important;
+      --keyColor-deepPressed: lighten(@accent, 5%) !important;
+      --keyColor-disabled: fade(@accent, 35%) !important;
+      --keyColorBG: @accent !important;
+      --musicKeyColor: @accent !important;
+      --musicBrandBG: @accent !important;
+      --selectionColor: @accent !important;
+      --chromePlayerBGFill: fade(@mantle, 88%) !important;
+      --lcd-bg-color: @surface0 !important;
+    }
+
+    /* Sidebar */
+    .navigation {
+      background-color: fade(@mantle, 100%) !important;
+
+      &-item--selected {
+        background-color: fade(@accent, 4%) !important;
+      }
+    }
+
+    /* Try Apple Music banner */
+    .cwc-upsell-banner, .cwc-upsell-banner__subhead {
+      color: @base;
+    }
+    .cwc-upsell-banner__cta-button .cwc-button {
+      color: @text;
+      background-color: @base;
+
+      &:hover {
+        background-color: lighten(@base, 5%);
+      }
+    }
+    /* Try Apple Music page */
+    .cwc-upsell-personal {
+      color: @base;
+      background-image: linear-gradient(@red);
+
+      &__cta-button .cwc-button {
+        color: @text;
+        background-color: @base;
+      }
+    }
+
+    /* Sign in button */
+    .app-container .signin {
+      color: @base;
+
+      .auth-icon {
+        fill: @base;
+      }
+    }
+
+    /* More to Explore buttons */
+    .link-component .link-box {
+      background-color: fade(@accent, 8%);
+    }
+
+    /* Live radio */
+    .live-radio-lockup {
+      .play-button {
+        background-color: fade(@surface0, 5%) !important;
+
+        &--platter:hover {
+          --iconFillArrow: @base;
+        }
+      }
+
+      .more-button {
+        background-color: @base !important;
+
+        &:hover {
+          --iconEllipsisFill: @base !important;
+        }
+      }
+    }
+
+    /* Playlist/Album play button */
+    .primary-actions__button--play .click-action {
+      color: @base !important;
+      background-color: @text !important;
+    }
+
+    /* Tracklist */
+    .songs-list-row {
+      --tracklistHoverColor: fade(@accent, 8%);
+    }
+
+    div.is-selected {
+      color: @base;
+    }
+
+    /* Player bar */
+    .chrome-player::before {
+      background-color: fade(@mantle, 88%) !important;
+      background-image: none !important;
+    }
+
+    /* Side panels (lyrics and up Next) */
+    .side-panel {
+      background-color: fade(@mantle, 97%) !important;
+      backdrop-filter: blur(50px) saturate(100%) !important;
+    }
+    .side-panel.side-panel-header-wrapper,
+    .side-panel .side-panel-header-wrapper,
+    .side-panel-header-wrapper {
+      background-color: fade(@mantle, 97%) !important;
+    }
+
+    /* Footer */
+    :is(
+      footer,
+      .scrollable-page footer
+    ) {
+      background: @crust !important;
+      background-color: @crust !important;
+      border-color: fade(@surface2, 20%) !important;
+      color: fade(@text, 85%) !important;
+    }
+
+    :is(
+      footer,
+      .scrollable-page footer
+    ) :is(a, button, select, [role="button"], [class*="dropdown"]) {
+      border-color: fade(@surface2, 25%) !important;
+      color: fade(@text, 85%) !important;
+    }
+
+    /* Country/region picker modal background */
+    [class*="locale-switcher"] {
+      background: @mantle !important;
+      background-color: @mantle !important;
+    }
+
+    /* Country/region banner (bottom strip) */
+    [data-testid="banner-container"] {
+      background: @mantle !important;
+      background-color: @mantle !important;
+      color: fade(@text, 85%) !important;
+      border-color: fade(@surface2, 25%) !important;
+    }
+    [data-testid="banner-container"] [data-testid="close-button"] {
+      color: fade(@text, 85%) !important;
+      fill: fade(@text, 85%) !important;
+    }
+    [data-testid="banner-container"] [data-testid="close-button"] svg path {
+      fill: fade(@text, 85%) !important;
+    }
+    [data-testid="banner-container"] [data-testid="dropdown-button"] {
+      background-color: @surface0 !important;
+      border-color: fade(@surface2, 40%) !important;
+      color: fade(@text, 85%) !important;
+    }
+
+    /* Accent buttons */
+    .button.primary button.click-action {
+      background-color: @accent !important;
+    }
   }
 }


### PR DESCRIPTION
**Website**: Apple Music

**URL**: https://music.apple.com

**Description**: Apple Music is a music streaming service.

## 🗒 Checklist 🗒

- [x] I have read and followed Catppuccin's [userstyle contributing guidelines](https://userstyles.catppuccin.com/contributing/).

- [ ] I used AI (or AI-assistance) for this change.

---

- [x] I have read and followed Catppuccin's [userstyle submission guidelines](https://userstyles.catppuccin.com/contributing/creating-userstyles/).
- [x] I have made a new directory underneath `/styles/<name-of-website>`.
  - [x] I have ensured that the new directory is in **lower-kebab-case**.
  - [x] I have named the userstyle `catppuccin.user.less` within the new directory.
  - [x] I have followed the [template](https://github.com/catppuccin/userstyles/blob/main/template/catppuccin.user.less) and kept the preprocessor as [LESS](https://lesscss.org/#overview).
- [x] I have updated the [`userstyles.yml`](https://github.com/catppuccin/userstyles/blob/main/scripts/userstyles.yml) file with information about the new userstyle.

## 💬 Comments 💬

Used base CSS from [Sidra](https://github.com/wimpysworld/sidra).
Liquid glass is a bit annoying because most things have transparency.
Also incredibly difficult to find the element being themed due to the amount and complexity of their css.
