### PR TITLE
ci: fix deno setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,10 @@ jobs:
           token: ${{ secrets.USERSTYLES_TOKEN }}
 
       - name: Setup Deno
-        uses: nekowinston/setup-deno@a790e9ad1e6b1c727a4ea621a8a8219b1f2c373d # main
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.3.5
+          cache: true
 
       - name: Generate Stylus import
         run: deno task ci:stylus-import

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,10 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Deno
-        uses: nekowinston/setup-deno@a790e9ad1e6b1c727a4ea621a8a8219b1f2c373d # main
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.3.5
+          cache: true
 
       - name: Bump changed userstyles
         run: |

--- a/.github/workflows/deno-check.yml
+++ b/.github/workflows/deno-check.yml
@@ -17,9 +17,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Deno
-        uses: nekowinston/setup-deno@a790e9ad1e6b1c727a4ea621a8a8219b1f2c373d # main
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.3.5
+          cache: true
 
       - name: Check
         run: |

--- a/.github/workflows/deno-lock.yml
+++ b/.github/workflows/deno-lock.yml
@@ -16,9 +16,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Deno
-        uses: nekowinston/setup-deno@a790e9ad1e6b1c727a4ea621a8a8219b1f2c373d # main
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.3.5
+          cache: true
 
       - name: Regenerate Deno lock
         run: deno cache **/*.ts --lock=deno.lock

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Deno
-        uses: nekowinston/setup-deno@a790e9ad1e6b1c727a4ea621a8a8219b1f2c373d # main
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.3.5
+          cache: true
 
       - name: Lint
         run: deno task lint

--- a/.github/workflows/maintainers.yml
+++ b/.github/workflows/maintainers.yml
@@ -15,9 +15,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Deno
-        uses: nekowinston/setup-deno@a790e9ad1e6b1c727a4ea621a8a8219b1f2c373d # main
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.3.5
+          cache: true
 
       - name: Sync maintainers
         run: deno task ci:sync-maintainers


### PR DESCRIPTION
Switches from the custom fork https://github.com/nekowinston/setup-deno to the official https://github.com/denoland/setup-deno action. Looks like we can enable a similar kind of caching that the former enabled out of the box with `cache: true`.

I think Renovate should be able to open a pull request after this merges and pin the SHA for us.