### PR TITLE
docs: fix missing end of code block

### DIFF
--- a/docs/src/content/docs/contributing/reference/libraries/standard/index.mdx
+++ b/docs/src/content/docs/contributing/reference/libraries/standard/index.mdx
@@ -20,6 +20,7 @@ The standard library is a collection of mixins to deduplicate and simplify code 
 
 ```less
 @import "https://userstyles.catppuccin.com/lib/std/v1.less";
+```
 
 ## Changelog
 


### PR DESCRIPTION
Fixes a missing end of code fence for a code block which caused Markdown rendering issues (see https://userstyles.catppuccin.com/contributing/reference/libraries/standard/#importing).